### PR TITLE
Short syntax to fetch a record for GAE keys (id or name)

### DIFF
--- a/gluon/dal.py
+++ b/gluon/dal.py
@@ -3938,10 +3938,10 @@ class GoogleDatastoreAdapter(NoSQLAdapter):
     def select(self,query,fields,attributes):
         (items, tablename, fields) = self.select_raw(query,fields,attributes)
         # self.db['_lastsql'] = self._select(query,fields,attributes)
-        rows = [
-            [t=='id' and (int(item.key().id()) if item.key().id() else
-                          item.key().name()) or getattr(item, t) for t in fields]
-            for item in items]
+        rows = []
+        for item in items:
+            row = [t=='id' and item.key().id_or_name() or getattr(item, t) for t in fields]
+            rows.append(row)
         colnames = ['%s.%s' % (tablename, t) for t in fields]
         processor = attributes.get('processor',self.parse)
         return processor(rows,fields,colnames,False)
@@ -6906,7 +6906,7 @@ class Table(dict):
             if rows:
                 return rows[0]
             return None
-        elif str(key).isdigit():
+        elif str(key).isdigit() or isinstance(key, Key):
             return self._db(self._id == key).select(limitby=(0,1)).first()
         elif key:
             return dict.__getitem__(self, str(key))


### PR DESCRIPTION
With this patch, the following short syntax to get a single record will work on GAE for both id and named keys:

``` python
db.table_name[key]
```

The patch also simplifies the already working code for getting the record by key the long way:

``` python
db(db.table_name.id == key).select().first()
db.table_name(db.table_name.id == key)
```
