### PR TITLE
gluon.globals.py->Response.download(): contenttype already imported

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -322,7 +322,6 @@ class Response(Storage):
         downloads from http://..../download/filename
         """
 
-        import contenttype as c
         if not request.args:
             raise HTTP(404)
         name = request.args[-1]
@@ -336,7 +335,7 @@ class Response(Storage):
             (filename, stream) = field.retrieve(name)
         except IOError:
             raise HTTP(404)
-        self.headers['Content-Type'] = c.contenttype(name)
+        self.headers['Content-Type'] = contenttype(name)
         if attachment:
             self.headers['Content-Disposition'] = \
                 "attachment; filename=%s" % filename


### PR DESCRIPTION
Maybe think about adding a 'Last-Modified' header to make use of the browser cache?
