### PR TITLE
fixed value -> text in simple_hash

### DIFF
--- a/gluon/utils.py
+++ b/gluon/utils.py
@@ -50,7 +50,7 @@ def simple_hash(text, key='', salt = '', digest_alg = 'md5'):
                           int(keylen),get_digest(alg))    
     elif key: # use hmac
         digest_alg = get_digest(digest_alg)
-        h = hmac.new(key+salt,value,digest_alg)
+        h = hmac.new(key+salt,text,digest_alg)
     else: # compatible with third party systems
         h = hashlib.new(digest_alg)
         h.update(text+salt)


### PR DESCRIPTION
e27321a22ad8831d0d0641a8c076efe79fad5613 introduced a bug as value is not defined in the simple_hash function
