### PR TITLE
Gluon app_cleanup() doesn't appear to clear cache

### DIFF
--- a/gluon/admin.py
+++ b/gluon/admin.py
@@ -126,7 +126,7 @@ def app_cleanup(app, request):
                 r = False
 
     # Remove cache files
-    path = apath('%s/sessions/' % app, request)
+    path = apath('%s/cache/' % app, request)
     if os.path.exists(path):
         for f in os.listdir(path):
             try:


### PR DESCRIPTION
While ambling through the Admin app I noticed app_cleanup() tries to clear the cache by removing things from <application>/sessions instead of <application>/cache. Looks like a copy/paste error to me, so here's a patch for it.
