### PR TITLE
enable custom attributes for the generated crud forms

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -3343,6 +3343,7 @@ class Crud(object):
         message=DEFAULT,
         deletable=DEFAULT,
         formname=DEFAULT,
+        **attributes
         ):
         """
         method: Crud.update(table, record, [next=DEFAULT
@@ -3395,7 +3396,8 @@ class Crud(object):
             deletable=deletable,
             upload=self.settings.download_url,
             formstyle=self.settings.formstyle,
-            separator=self.settings.label_separator
+            separator=self.settings.label_separator,
+            **attributes
             )
         self.accepted = False
         self.deleted = False
@@ -3453,6 +3455,7 @@ class Crud(object):
         log=DEFAULT,
         message=DEFAULT,
         formname=DEFAULT,
+        **attributes
         ):
         """
         method: Crud.create(table, [next=DEFAULT [, onvalidation=DEFAULT
@@ -3479,6 +3482,7 @@ class Crud(object):
             message=message,
             deletable=False,
             formname=formname,
+            **attributes
             )
 
     def read(self, table, record):


### PR DESCRIPTION
just wanted to add a class to a crud generated form... which is not possible at the moment. The patch adds an **attributes parameter to crud.create and crud.update to pass it on to SQLFORM.

(BTW: I'm not sure if that also makes sense for crud.read)
