### PR TITLE
Optimized script for nginx and uwsgi on ubuntu 12.04

### DIFF
--- a/scripts/setup-web2py-nginx-uwsgi-ubuntu.sh
+++ b/scripts/setup-web2py-nginx-uwsgi-ubuntu.sh
@@ -22,7 +22,8 @@ echo 'server {
            root /home/www-data/web2py/applications/;
         }
          location / {
-                uwsgi_pass      127.0.0.1:9001;
+                #uwsgi_pass      127.0.0.1:9001;
+                uwsgi_pass      unix:///run/uwsgi/app/web2py/web2py.socket;
                 include         uwsgi_params;
                 uwsgi_param     UWSGI_SCHEME $scheme;
                 uwsgi_param     SERVER_SOFTWARE    nginx/$nginx_version;
@@ -36,7 +37,8 @@ server {
         ssl_certificate         /etc/nginx/ssl/web2py.crt;
         ssl_certificate_key     /etc/nginx/ssl/web2py.key;
         location / {
-                uwsgi_pass      127.0.0.1:9001;
+                #uwsgi_pass      127.0.0.1:9001;
+                uwsgi_pass      unix:///run/uwsgi/app/web2py/web2py.socket;
                 include         uwsgi_params;
                 uwsgi_param     UWSGI_SCHEME $scheme;
                 uwsgi_param     SERVER_SOFTWARE    nginx/$nginx_version;
@@ -55,11 +57,23 @@ openssl x509 -req -days 1780 -in web2py.csr -signkey web2py.key -out web2py.crt
 # Create configuration file /etc/uwsgi/apps-available/web2py.xml
 echo '<uwsgi>
     <plugin>python</plugin>
-    <socket>127.0.0.1:9001</socket>
+    <socket>/run/uwsgi/app/web2py/web2py.socket</socket>
     <pythonpath>/home/www-data/web2py/</pythonpath>
     <app mountpoint="/">
         <script>wsgihandler</script>
     </app>
+    <master/>
+    <processes>4</processes>
+    <harakiri>60</harakiri> 
+    <reload-mercy>8</reload-mercy>
+    <cpu-affinity>1</cpu-affinity>
+    <stats>/tmp/stats.socket</stats>
+    <max-requests>2000</max-requests>
+    <limit-as>512</limit-as>
+    <reload-on-as>256</reload-on-as>
+    <reload-on-rss>192</reload-on-rss>
+    <no-orphans/>
+    <vacuum/>    
 </uwsgi>' >/etc/uwsgi/apps-available/web2py.xml
 ln -s /etc/uwsgi/apps-available/web2py.xml /etc/uwsgi/apps-enabled/web2py.xml
 


### PR DESCRIPTION
I installed this script on several machines and after a month of testing I figured out the basic configuration for a performatic uwsgi.

Without this settings uwsgi can be a memory eater. (see the thread about wsgi by Bruce Wade on the list, this script was based on Bruce tips)

Explanations:
1. Use unix socket instead of tcp
2. set the app to start the **master** process - it is useful for monitoring with uwsgitop and also for **no-orphans**
3. set the **processes** to 4 (but this depends on the installed machine, for web2py 4 is the minimum)
4. **harakiri** 60 - Every request that will take longer than the seconds specified in the harakiri timeout will be dropped and the corresponding worker recycled.
5. set the maximum amount of seconds to wait for a worker death during a graceful reload
6. **cpu-affinity** - http://lists.unbit.it/pipermail/uwsgi/2011-March/001594.html
7. **Stats** - output the stats on tmp so you can use $uwsgitop /tmp/stats.socket to monitoring the workers
## THE MOST IMPORTANT FOR WEB2PY
1. **reload-mercy** - set the maximum amount of seconds to wait for a worker death during a graceful reload
2. **limit-as** limit the address space usage of each uWSGI process using POSIX/UNIX setrlimit()
3. **max-requests** 2000 - set the maximum number of requests for each worker. When a worker reaches this number it will get recycled. You can use this option to dumb fight memory leaks (even if reload-on-as and reload-on-rss are more useful for this kind of problem)
4.  **reload-on-as** recycle a workers when its address space usage is over the limit specified
5. **reload-on-rss** Works as reload-on-as but it control the physical unshared memory. You can enable both
6. **no-orphans** automatically kill workers without a master process
7. **vacuum** - automatically remove unix socket and pidfiles on server exit

I did a lot of tests and on a Linode 1024 machine with Ubuntu 12.04 that is the best setup. 
If running a Linode 2048 (or any machine with 2GB RAM)  the config can be doubled to:

**max-requests** - 4000, **reload-on-as** 512, **reload-on-rss** 192, **limit-as** 1024 , **processes** 8, **cpu-affinity** 3

It is important: http://lists.unbit.it/pipermail/uwsgi/2011-March/001594.html

Also on nginx.conf it is usefull to set the number of processes/workers - I am using 12

``` javascript
user www-data;
worker_processes 12;
pid /var/run/nginx.pid;

events {
    worker_connections 768;
    # multi_accept on;
}

http {
....
}
```

Code

``` xml
<uwsgi>
    <plugin>python</plugin>
    <socket>/run/uwsgi/app/web2py/web2py.socket</socket>
    <pythonpath>/home/www-data/web2py/</pythonpath>
    <app mountpoint="/">
        <script>wsgihandler</script>
    </app>
    <master/>
    <processes>4</processes>
    <harakiri>60</harakiri> 
    <reload-mercy>8</reload-mercy>
    <cpu-affinity>1</cpu-affinity>
    <stats>/tmp/stats.socket</stats>
    <max-requests>2000</max-requests>
    <limit-as>512</limit-as>
    <reload-on-as>256</reload-on-as>
    <reload-on-rss>192</reload-on-rss>
    <no-orphans/>
    <vacuum/>    
</uwsgi>
```

and

``` javascript
location / {
                uwsgi_pass      unix:///run/uwsgi/app/web2py/web2py.socket;
                include         uwsgi_params;
                uwsgi_param     UWSGI_SCHEME $scheme;
                uwsgi_param     SERVER_SOFTWARE    nginx/$nginx_version;
        }
```
