### PR TITLE
Added required=True argument to IS_IN_DB

### DIFF
--- a/gluon/validators.py
+++ b/gluon/validators.py
@@ -415,7 +415,7 @@ class IS_IN_DB(Validator):
         cache=None,
         multiple=False,
         zero='',
-	optional=False,
+	required=True,
         sort=False,
         _and=None,
     ):
@@ -453,7 +453,7 @@ class IS_IN_DB(Validator):
         self.cache = cache
         self.multiple = multiple
         self.zero = zero
-	self.optional = optional
+	self.required = required
         self.sort = sort
         self._and = _and
 
@@ -499,7 +499,7 @@ class IS_IN_DB(Validator):
     def __call__(self, value):
         table = self.dbset.db[self.ktable]
         field = table[self.kfield]
-	if self.optional and (value == None or value == ''):
+	if (not self.required) and (value == None or value == ''):
             return (None, None)
         if self.multiple:
             if self._and:


### PR DESCRIPTION
Added an optional argument

required=

(default: True)

to the IS_IN_DB validator.   If set to False, then the validator return value None (and no error) in case no value has been selected. 

Rationale:

Some fields in databases are not required.  Thus, it makes sense to have an option so that the IS_IN_DB validator checks that either the value is in the specified DB set (as now), _or_, the selection has been left empty. 

For instance, assume that I have a field as follows:

Field('teaching_assistant', db.person),

The database accepts a None value (because db....teaching_assistant.required has not been set to True).  So if I have a set of possible TAs q (as defined by a query), and I want the teaching assistant to be either selected from q, or left blank, I can now use:

IS_IN_DB(q, required=False)

to allow leaving the TA choice empty.
