### PR TITLE
Switching style class for auto-generated form help to "help-block"

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -774,7 +774,7 @@ def formstyle_bootstrap(form, fields):
     parent = FIELDSET()
     for id, label, controls, help in fields:
         # wrappers
-        _help = SPAN(help, _class='help-inline')
+        _help = SPAN(help, _class='help-block')
         # embed _help into _controls
         _controls = DIV(controls, _help, _class='controls')
         # submit unflag by default


### PR DESCRIPTION
Due to the organization of the generation of the bootstrap forms, if using the "help-inline" style, help messages end up misaligned and harder to read. This changes the behavior to always put the help text in the "help-block" style, which aligns it to the left of the form field.
