### PR TITLE
Add migrate control to Auth.wiki()

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -3368,7 +3368,8 @@ class Auth(object):
              resolve=True,
              extra=None,
              menu_groups=None,
-             templates=None):
+             templates=None,
+             migrate=True):
 
         if not hasattr(self, '_wiki'):
             self._wiki = Wiki(self, render=render,
@@ -3377,7 +3378,8 @@ class Auth(object):
                               restrict_search=restrict_search,
                               env=env, extra=extra or {},
                               menu_groups=menu_groups,
-                              templates=templates)
+                              templates=templates,
+                              migrate=migrate)
         else:
             self._wiki.env.update(env or {})
         # if resolve is set to True, process request as wiki call
@@ -4950,7 +4952,7 @@ class Wiki(object):
     def __init__(self, auth, env=None, render='markmin',
                  manage_permissions=False, force_prefix='',
                  restrict_search=False, extra=None,
-                 menu_groups=None, templates=None):
+                 menu_groups=None, templates=None, migrate=True):
 
         settings = self.settings = Settings()
 
@@ -4998,20 +5000,20 @@ class Wiki(object):
                               compute=self.get_render(),
                               readable=False, writable=False),
                         auth.signature],
-              'vars':{'format':'%(title)s'}}),
+                    'vars':{'format':'%(title)s', 'migrate':migrate}}),
             ('wiki_tag', {
                     'args':[
                         Field('name'),
                         Field('wiki_page', 'reference wiki_page'),
                         auth.signature],
-                    'vars':{'format':'%(name)s'}}),
+                    'vars':{'format':'%(title)s', 'migrate':migrate}}),
             ('wiki_media', {
                     'args':[
                         Field('wiki_page', 'reference wiki_page'),
                         Field('title', required=True),
                         Field('filename', 'upload', required=True),
                         auth.signature],
-                    'vars':{'format':'%(title)s'}})
+                    'vars':{'format':'%(title)s', 'migrate':migrate}}),
             ]
 
         # define only non-existent tables


### PR DESCRIPTION
The Auth.wiki() function does not allow for control of the migration
settings, always defaulting to migrate=True. In some instances the
developer may want to not force migration. This change adds the
ability to set the migrate option. Fake_migrate was not added but
can be if desired.
