### PR TITLE
Mail - Added hostname to settings before locking

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -248,6 +248,7 @@ class Mail(object):
         settings.sender = sender
         settings.login = login
         settings.tls = tls
+        settings.hostname = None
         settings.ssl = False
         settings.cipher_type = None
         settings.gpg_home = None


### PR DESCRIPTION
Added settings.hostname before locking settings, the class may need a comment explaining when is settings.hostname needed
