### PR TITLE
typo in contrib/gateways/fcgi.py

### DIFF
--- a/gluon/contrib/gateways/fcgi.py
+++ b/gluon/contrib/gateways/fcgi.py
@@ -815,7 +815,7 @@ class Connection(object):
         outrec = Record(FCGI_UNKNOWN_TYPE)
         outrec.contentData = struct.pack(FCGI_UnknownTypeBody, inrec.type)
         outrec.contentLength = FCGI_UnknownTypeBody_LEN
-        self.writeRecord(rec)
+        self.writeRecord(outrec)
 
 class MultiplexedConnection(Connection):
     """


### PR DESCRIPTION
Don't know if there are people using this file, but should be fixed just in case.
