### PR TITLE
lock in redis session

### DIFF
--- a/gluon/contrib/redis_session.py
+++ b/gluon/contrib/redis_session.py
@@ -242,4 +242,5 @@ end
 
 
 def release_lock(conn, lockname, identifier):
-    return RedisClient._release_script(keys=[lockname], args=[identifier])
+    return RedisClient._release_script(keys=[lockname], args=[identifier],
+            client=conn)


### PR DESCRIPTION
Optional lock in redis sessions

RedisClient accepts one more optional parameter, with_lock, that defaults to False

Also a minor optimization, mainly to minimize network round trips when executing a set of redis commands.
