### PR TITLE
allow to process post vars in DELETE requests

### DIFF
--- a/gluon/main.py
+++ b/gluon/main.py
@@ -344,7 +344,7 @@ def parse_get_post_vars(request, environ):
 
 
     # parse POST variables on POST, PUT, BOTH only in post_vars
-    if (body and env.request_method in ('POST', 'PUT', 'BOTH')):
+    if (body and env.request_method in ('POST', 'PUT', 'DELETE', 'BOTH')):
         dpost = cgi.FieldStorage(fp=body, environ=environ, keep_blank_values=1)
         # The same detection used by FieldStorage to detect multipart POSTs
         is_multipart = dpost.type[:10] == 'multipart/'


### PR DESCRIPTION
Our use case for requiring post_vars variables in a DELETE is that we wanted
our interface to support a bulk deleting method so as to reduce the number of
requests needed to be made.

As part of our miration path of getting our app to speak JSON from end-to-end,
we also wanted to ensure it was able to take a message body similar to a web
form submission.

e.g.
[form data]
    DELETE /app/rest/categoryofobjects HTTP/1.1
    ...
    Content-Type: application/x-www-form-urlencoded
    Content-Length: ...

```
ids=1&ids=2ids=3...
```

[JSON]
    DELETE /app/rest/categoryofobjects HTTP/1.1
    ...
    Content-Type: application/json
    Content-Length: ...

```
{
    "ids": [1, 2, 3, ...]
}
```

NOTE: the spec is fuzzy on this point, but we feel that this change doesn't actually hurt anything so is worthy of inclusion for flexibility-sake 
