### PR TITLE
fix admin editor  (full-screen and theme selector)

### DIFF
--- a/applications/admin/static/codemirror/theme/web2py.css
+++ b/applications/admin/static/codemirror/theme/web2py.css
@@ -18,7 +18,9 @@
 .cm-s-web2py span.cm-tag {color: #170;}
 .cm-s-web2py span.cm-attribute {color: #00c;}
 .cm-s-web2py span.cm-link {color: #219;}
-
+.cm-s-web2py {
+	background: white;
+}
 .cm-s-web2py .CodeMirror-matchingbracket {
 	border:1px solid grey;
 	color:black !important;;
@@ -29,17 +31,6 @@
 .cm-s-web2py {
   line-height: 1.40em;
   font-family: Monaco, Menlo,"Andale Mono","lucida console","Courier New",monospace !important;
-}
-
-/* Fullscreen mode and active line highlight */
-
-.cm-s-web2py .CodeMirror-fullscreen {
-  display: block;
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  z-index: 9999;
 }
 
 .cm-s-web2py .activeline {background: #e8f2ff !important;}

--- a/applications/admin/views/default/edit.html
+++ b/applications/admin/views/default/edit.html
@@ -32,8 +32,18 @@
 <link rel="stylesheet" href="{{=cm}}/lib/util/dialog.css">
 <script src="{{=cm}}/emmet.min.js"></script>
 <script language="Javascript" type="text/javascript" src="{{=URL('static','js/ajax_editor.js')}}"></script>
+<style>
+.CodeMirror-fullscreen {
+	display: block;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100% !important;
+	z-index: 9999;
+}
+</style>
 <script language="Javascript" type="text/javascript">
-
+var current_theme = "web2py";	//Default theme
 jQuery(document).on('shown click', 'a[data-toggle="tab"]', function (e) {
 	var tab_id = jQuery(this).attr('href');
 	var editor = jQuery(tab_id + " textarea").data('editor');
@@ -91,6 +101,7 @@ jQuery(document).on('click', '#themes a', function (e) {
 		editor.setOption("theme", name);
 	});
 	jQuery('#themeName').html(name);
+	current_theme = name;
 //#TODO save on session
 });
 
@@ -141,8 +152,8 @@ jQuery(document).on('click', '#themes a', function (e) {
 
 
 <div class='row-fluid'>
-<div class="right controls pull-right">
-<div class="dropdown pull-left">
+<div class="right controls btn-toolbar pull-right">
+<div class="dropdown btn-group pull-left">
 	<a class="dropdown-toggle button btn" data-target="themes" data-toggle="dropdown" href="#" >Theme: <span id="themeName" style="color: #E8953C">Web2py</span> <span class="caret"></span></a>
 	<ul class="dropdown-menu" role="menu" id="themes">	
 		{{for f in listfiles('admin', "static/codemirror/theme", regexp='.*\.css$' ):}}
@@ -150,12 +161,13 @@ jQuery(document).on('click', '#themes a', function (e) {
 		{{pass}}
 	</ul>
 </div>
+<div class="btn-group">
   {{=button(URL('design',args=request.vars.app if request.vars.app else request.args[0], anchor=request.vars.id), T('back'))}}
   {{#if request.args[1]=='models':}}
   <a class="button btn" href="http://www.web2py.com/sqldesigner" target="_blank"><span>{{=T('online designer')}}</span></a>
   {{#pass}}
   <a class="button btn" href="http://www.web2py.com/examples/static/epydoc/index.html" target="_blank"><span>{{=T('docs')}}</span></a>
-
+</div>
 </div>
 </div>
 <div id="editor_area" class="row-fluid">

--- a/applications/admin/views/default/edit_js.html
+++ b/applications/admin/views/default/edit_js.html
@@ -49,7 +49,7 @@
 	{{pass}}
 		lineNumbers: true,
         indentUnit: 4,
-        theme: "web2py",
+        theme: current_theme,
         tabMode: "shift",
         lineWrapping: true,
         {{if TEXT_EDITOR_KEYBINDING == 'emacs':}}keyMap: "emacs",{{pass}}


### PR DESCRIPTION
fixed:
-  inconsistent spacing between the style dropdown and the rest of the buttons on the right above the editor
- theme selected is applied to the new tabs too
- full-screen fix

(tested on FF and Chrome on top ubuntu 12.04)
