### PR TITLE
updating jQueryUI version

### DIFF
--- a/applications/welcome/views/layout.html
+++ b/applications/welcome/views/layout.html
@@ -58,8 +58,8 @@
   }}
 
   <!-- uncomment here to load jquery-ui
-       <link rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/themes/base/jquery-ui.css" type="text/css" media="all" />
-       <script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js" type="text/javascript"></script>
+       <link rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/themes/base/jquery-ui.css" type="text/css" media="all" />
+       <script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js" type="text/javascript"></script>
        uncomment to load jquery-ui //-->
   <noscript><link href="{{=URL('static', 'css/web2py_bootstrap_nojs.css')}}" rel="stylesheet" type="text/css" /></noscript>
   {{block head}}{{end}}


### PR DESCRIPTION
jQuery 1.9/1.10 breaks older versions of jQuery UI.
1.8 is not working with jQuery 1.10.

Updating UI to 1.10 to match jQuery version.
