### PR TITLE
Fixing bson binary TypeOf exception after fixing issue 1612

### DIFF
--- a/gluon/dal.py
+++ b/gluon/dal.py
@@ -5349,6 +5349,8 @@ class MongoDBAdapter(NoSQLAdapter):
             return datetime.datetime.combine(d, value)
         elif fieldtype == "blob":
             from bson import Binary
+            if not isinstance(value, str):
+                return Binary(str(value))
             return Binary(value)
         elif (isinstance(fieldtype, basestring) and
               fieldtype.startswith('list:')):


### PR DESCRIPTION
After fixing issue 1612, sometimes (encountered with auth) we have values that are not strings, so we had to convert them. See topic on developers group: https://groups.google.com/forum/#!topic/web2py-developers/6MKjeIzYhxI
