### PR TITLE
Fix in redis_session.py select: prevent errors when value is integer/long

### DIFF
--- a/gluon/contrib/redis_session.py
+++ b/gluon/contrib/redis_session.py
@@ -168,7 +168,7 @@ class MockQuery(object):
     def select(self):
         if self.op == 'eq' and self.field == 'id' and self.value:
             #means that someone wants to retrieve the key self.value
-            key = self.keyprefix + ':' + self.value
+            key = self.keyprefix + ':' + str(self.value)
             if self.with_lock:
                 acquire_lock(self.db, key + ':lock', self.value)
             rtn = self.db.hgetall(key)


### PR DESCRIPTION
See discussion on google groups: https://groups.google.com/forum/#!topic/web2py-developers/JvbFzXFXNWY
