### PR TITLE
Popen objects leak fixed

### DIFF
--- a/gluon/newcron.py
+++ b/gluon/newcron.py
@@ -246,6 +246,7 @@ class cronlauncher(threading.Thread):
                                 shell=self.shell)
         _cron_subprocs.append(proc)
         (stdoutdata, stderrdata) = proc.communicate()
+        _cron_subprocs.remove(proc)
         if proc.returncode != 0:
             logger.warning(
                 'WEB2PY CRON Call returned code %s:\n%s' %


### PR DESCRIPTION
In windows web2py cron is not delete Popen object after task ends.
