### PR TITLE
Add 'set' to serializable types in Query.as_dict

### DIFF
--- a/gluon/dal.py
+++ b/gluon/dal.py
@@ -9804,7 +9804,7 @@ class Query(object):
                      "second":0}
         """
 
-        SERIALIZABLE_TYPES = (tuple, dict, list, int, long, float,
+        SERIALIZABLE_TYPES = (tuple, dict, set, list, int, long, float,
                               basestring, type(None), bool)
         def loop(d):
             newd = dict()


### PR DESCRIPTION
Sets were missing from serializable types - added by this commit.
