### PR TITLE
Pointless to set session.flash before session.renew

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -2411,8 +2411,8 @@ class Auth(object):
                 next = cas.logout_url(next)
 
         current.session.auth = None
-        current.session.flash = self.messages.logged_out
         current.session.renew(clear_session=not self.settings.keep_session_onlogout)
+        current.session.flash = self.messages.logged_out
         if not next is None:
             redirect(next)
 


### PR DESCRIPTION
The logout message would be removed by session.renew => this commit switches the order of action
