### PR TITLE
update vars only if FieldStorage holds actually something

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -215,7 +215,8 @@ class Request(Storage):
             and env.request_method in ('POST', 'PUT', 'DELETE', 'BOTH')):
             query_string = env.pop('QUERY_STRING',None)
             dpost = cgi.FieldStorage(fp=body, environ=env, keep_blank_values=1)
-            post_vars.update(dpost)
+            if dpost:
+                post_vars.update(dpost)
             if query_string is not None:
                 env['QUERY_STRING'] = query_string
             # The same detection used by FieldStorage to detect multipart POSTs


### PR DESCRIPTION
Groans with the upper "G" to FieldStorage. If it's empty, it's not an empty dict, so the following post_vars.update() goes into exception. 
