### PR TITLE
Fixes and improvements in admin editor

### DIFF
--- a/applications/admin/controllers/default.py
+++ b/applications/admin/controllers/default.py
@@ -562,7 +562,7 @@ def edit():
     # Load json only if it is ajax edited...
     app = get_app(request.vars.app)
     app_path = apath(app, r=request)
-    editor_defaults={'theme':'web2py'}
+    editor_defaults={'theme':'web2py', 'editor': 'default'}
     config = Config(os.path.join(request.folder, 'settings.cfg'),
                     section='editor', default_values=editor_defaults)
     preferences = config.read()
@@ -588,7 +588,7 @@ def edit():
                 response.headers["web2py-component-flash"] = T('Preferences saved correctly')
             else:
                 response.headers["web2py-component-flash"] = T('Preferences saved on session only')
-            response.headers["web2py-component-command"] = "update_theme('%s'); jQuery('a[href=#editor_settings] button.close').click();" % config.read()['theme']
+            response.headers["web2py-component-command"] = "update_theme('%s');update_editor('%s');jQuery('a[href=#editor_settings] button.close').click();" % (config.read()['theme'], config.read()['editor'])
             return
         else:
             details = {'filename':'settings', 'id':'editor_settings', 'force': False}
@@ -604,7 +604,7 @@ def edit():
         path = abspath(filename)
     else:
         path = apath(filename, r=request)
-     # Try to discover the file type
+    # Try to discover the file type
     if filename[-3:] == '.py':
         filetype = 'python'
     elif filename[-5:] == '.html':
@@ -700,7 +700,6 @@ def edit():
                                  offset and ' ' +
                                  T('at char %s', offset) or '',
                                  PRE(str(e)))
-
     if data_or_revert and request.args[1] == 'modules':
         # Lets try to reload the modules
         try:

--- a/applications/admin/static/js/ajax_editor.js
+++ b/applications/admin/static/js/ajax_editor.js
@@ -73,6 +73,12 @@ function doClickSave() {
       var t = jQuery("input[name='save']");
       t.attr('class', '');
       t.attr('disabled', '');
+	  var flash = xhr.getResponseHeader('web2py-component-flash');
+      if(flash) {
+        jQuery('.flash').html(decodeURIComponent(flash))
+          .append('<a href="#" class="close">&times;</a>')
+          .slideDown();
+      } else jQuery('.flash').hide();
       try {
         if(json.error) {
           window.location.href = json.redirect;

--- a/applications/admin/views/default/edit.html
+++ b/applications/admin/views/default/edit.html
@@ -16,13 +16,12 @@
 }}
 {{cm=URL('static','codemirror')}}
 <link rel="stylesheet" href="{{=cm}}/lib/codemirror.css">
-<link rel="stylesheet" href="{{="%s/theme/%s.css" % (cm, editor_settings['theme'])}}">
+<link rel="stylesheet" href="{{='%s/theme/%s.css' % (cm, editor_settings['theme'])}}">
 <script src="{{=cm}}/lib/codemirror.js"></script>
 <script src="{{=cm}}/mode/clike/clike.js"></script>
 <script src="{{=cm}}/addon/edit/matchbrackets.js"></script>
 <script src="{{=cm}}/addon/edit/closetag.js"></script>
-{{if TEXT_EDITOR_KEYBINDING == 'emacs':}}<script src="{{=cm}}/keymap/emacs.js"></script>{{pass}}
-{{if TEXT_EDITOR_KEYBINDING == 'vi':}}<script src="{{=cm}}/keymap/vim.js"></script>{{pass}}
+{{if editor_settings['editor'] != 'default':}}<script src="{{='%s/keymap/%s.js' % (cm, editor_settings['editor'])}}"></script>{{pass}}
 <script src="{{=cm}}/mode/python/python.js"></script>
 <script src="{{=cm}}/mode/xml/xml.js"></script>
 <script src="{{=cm}}/mode/css/css.js"></script>
@@ -43,6 +42,7 @@
 <link rel="stylesheet" href="{{=URL('static/css','web2py-codemirror.css')}}">
 <script type="text/javascript">
 var current_theme = "{{=editor_settings['theme']}}";  //Default theme
+var current_editor = "{{=editor_settings['editor']}}";  //Default editor
 var current_font_incr = 0; // Default font-size, 0 means don't set
 jQuery(document).on('shown click', 'a[data-toggle="tab"]', function (e) {
     var tab_id = jQuery(this).attr('href');
@@ -109,6 +109,24 @@ function update_theme(name) {
 		editor.setOption("theme", name);
 	});
 	current_theme = name;
+}
+
+function update_editor(editor_name) {
+	if (editor_name !='default'){
+		var src = "{{='%s/keymap/' % cm}}" + editor_name + ".js"; 
+		//var src = "/admin/static/codemirror/keymap/" + editor_name + ".js"; 
+		var script = jQuery("<script>");
+		script.attr({
+			src: src
+		});
+		jQuery("head").append( script ); 
+	}
+	jQuery('textarea[name="data"]') .each(function(id, ta) {
+		editor = jQuery(ta).data('editor');
+		editor.setOption("keyMap", editor_name);
+	});
+	current_editor = editor_name;
+
 }
 
 // incr/decr editor font-size

--- a/applications/admin/views/default/edit_js.html
+++ b/applications/admin/views/default/edit_js.html
@@ -55,8 +55,7 @@
         tabMode: "shift",
         lineWrapping: true,
         gutters: ["CodeMirror-linenumbers", "breakpoints"],
-        {{if TEXT_EDITOR_KEYBINDING == 'emacs':}}keyMap: "emacs",{{pass}}
-        {{if TEXT_EDITOR_KEYBINDING == 'vi':}}keyMap: "vim",{{pass}}
+        keyMap: current_editor,
         matchBrackets: true,
         autofocus: false,
         height: "350px",
@@ -88,7 +87,7 @@
             function(instance) {
                 setFullScreen(instance, !isFullScreen(instance));};
         CodeMirror.defaults.extraKeys["Tab"] = "indentMore";
-        CodeMirror.defaults.extraKeys["Esc"]=
+        CodeMirror.defaults.extraKeys["Shift-Esc"]=
             function(instance) {
                 if (isFullScreen(instance)) {
                     setFullScreen(instance, false);};}
@@ -104,7 +103,7 @@
                 function(instance) {
                     setFullScreen(instance, !isFullScreen(instance));};
             CodeMirror.defaults.extraKeys["Tab"] = "indentMore";
-            CodeMirror.defaults.extraKeys["Esc"]=
+            CodeMirror.defaults.extraKeys["Shift-Esc"]=
                 function(instance) {
                     if (isFullScreen(instance)) {
                         setFullScreen(instance, false);};}
@@ -145,6 +144,7 @@
         <ul class="keybindings unstyled">
             {{=shortcut('Ctrl+S', T('Save via Ajax'))}}
             {{=shortcut('Ctrl+F11', T('Toggle Fullscreen'))}}
+			{{=shortcut('Shift+Esc', T('Exit Fullscreen'))}}
             {{=shortcut('Ctrl-F / Cmd-F', T('Start searching'))}}
             {{=shortcut('Ctrl-G / Cmd-G', T('Find Next'))}}
             {{=shortcut('Shift-Ctrl-G / Shift-Cmd-G', T('Find Previous'))}}
@@ -157,6 +157,7 @@
         <ul class="keybindings unstyled">
             {{=shortcut('Ctrl+S', T('Save via Ajax'))}}
             {{=shortcut('Ctrl+F11', T('Toggle Fullscreen'))}}
+			{{=shortcut('Shift+Esc', T('Exit Fullscreen'))}}
             {{if filetype=='python':}}
             {{=shortcut('Ctrl-Space', T('Autocomplete Python Code'))}}
            {{pass}}

--- a/applications/admin/views/default/editor_settings.html
+++ b/applications/admin/views/default/editor_settings.html
@@ -6,10 +6,13 @@
       return files
 }}
 {{themes = [f[:-4] for f in listfiles('admin', "static/codemirror/theme", regexp='.*\.css$' )]}}
+{{editors = ['default', 'vim', 'emacs']}}
 <form id="editor_settings_form" class="form-horizontal">
 <div class="control-group">
     <label class="control-label" for="selectTheme">{{=T('Theme')}}</label>
 	<div class="controls">{{=SELECT(themes, value=editor_settings['theme'], _name="theme" )}}</div>
+	<label class="control-label" for="selectEditor">{{=T('Editor')}}</label>
+	<div class="controls">{{=SELECT(editors, value=editor_settings['editor'], _name="editor" )}}</div>
 </div>
 <div class="control-group">
 	<div class="controls"><button type="submit" class="disabled btn btn-primary">{{=T('Save')}}</button></div>


### PR DESCRIPTION
Fix lost flash message in case of error when save editor (crtl-s). Change Esc to Shift-Esc to exit from Fullscreen mode, because this cause collision with the Vim mode (Esc key). Add a select into the config button to select 'default', 'vim' or 'emacs' editor
