### PR TITLE
fixed line not found issues in set breakpoint (linecache patch, used by the debugger)

### DIFF
--- a/gluon/widget.py
+++ b/gluon/widget.py
@@ -1263,6 +1263,25 @@ end tell
         print '\t', url
         print 'use "kill -SIGTERM %i" to shutdown the web2py server' % os.getpid()
 
+    # enhance linecache.getline (used by debugger) to look at the source file
+    # if the line was not found (under py2exe & when file was modified)
+    import linecache
+    py2exe_getline = linecache.getline
+    def getline(filename, lineno, *args, **kwargs):
+        line = py2exe_getline(filename, lineno, *args, **kwargs)
+        if not line:                
+            f = open(filename, "r")
+            try:
+                for i, line in enumerate(f):
+                    if lineno == i + 1:
+                        break
+                else:
+                    line = None
+            finally:
+                f.close()
+        return line
+    linecache.getline = getline
+
     server = main.HttpServer(ip=ip,
                              port=port,
                              password=options.password,


### PR DESCRIPTION
It seems that the python debugger framework (bdb, used by the online debugger) uses linecache.getline that is not working under py2exe for user applications (maybe because py2exe monkey patch it)

Also, that function stores a internal line cache, so it doesn't work very well with web2py "eval" execution model, and may not find new lines added to a controller after a breakpoint was set (it doesn't refresh the file source code if modified).

This PR fixes both.

Please note that the debug interact view reads the full source code using readlines, so linecache is not used there and is not affected by this issue.
