### PR TITLE
Update location of handlers so that make_min_web2py.py works again

### DIFF
--- a/scripts/make_min_web2py.py
+++ b/scripts/make_min_web2py.py
@@ -13,12 +13,12 @@ it will mkdir minweb2py and build a minimal web2py installation
 REQUIRED = """
 VERSION
 web2py.py
-fcgihandler.py
-gaehandler.py
-wsgihandler.py
 anyserver.py
 applications/__init__.py
 applications/welcome/controllers/default.py
+handlers/fcgihandler.py
+handlers/gaehandler.py
+handlers/wsgihandler.py
 """
 
 # files and folders to exclude from gluon folder (comment with # if needed)


### PR DESCRIPTION
The location of the handlers changed in 07f74c63621 and since then
this error blocked the creation of a minizimed web2py instance:

IOError: [Errno 2] No such file or directory: 'fcgihandler.py'
