### PR TITLE
Add _return_record to update_or_insert

### DIFF
--- a/gluon/dal.py
+++ b/gluon/dal.py
@@ -8786,7 +8786,7 @@ class Table(object):
             response.id = None
         return response
 
-    def update_or_insert(self, _key=DEFAULT, **values):
+    def update_or_insert(self, _key=DEFAULT, _return_record=False, **values):
         if _key is DEFAULT:
             record = self(**values)
         elif isinstance(_key,dict):
@@ -8795,7 +8795,10 @@ class Table(object):
             record = self(_key)
         if record:
             record.update_record(**values)
-            newid = None
+            if _return_record:
+                newid = record
+            else:
+                newid = None
         else:
             newid = self.insert(**values)
         return newid


### PR DESCRIPTION
From the web2py discussion @
https://groups.google.com/forum/#!topic/web2py/vjU9sYCoxU0 this
implements Anthony's suggestion to return the full record after a
successful update with update_or_insert.

To use pass '_return_record=True' before arguments.

The default action of returning None is retained.

In [3]: db.auth_user.update_or_insert(email='user')
Out[3]: 1L

In [4]: db.auth_user.update_or_insert(email='user')

In [5]: db.auth_user.update_or_insert(_return_record=True, email='user')
Out[5]: <Row {'first_name': '', 'last_name': '', 'registration_id': '',
'id': 1L, 'reset_password_key': '', 'password': None,
'registration_key': '', 'email': 'user'}>
