### PR TITLE
Updated jquery-ui css resource to fix 404 error

### DIFF
--- a/applications/welcome/views/layout.html
+++ b/applications/welcome/views/layout.html
@@ -58,7 +58,7 @@
   }}
 
   <!-- uncomment here to load jquery-ui
-       <link rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/themes/base/jquery-ui.css" type="text/css" media="all" />
+       <link rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/themes/ui-lightness/jquery-ui.css" type="text/css" media="all" />
        <script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js" type="text/javascript"></script>
        uncomment to load jquery-ui //-->
   <noscript><link href="{{=URL('static', 'css/web2py_bootstrap_nojs.css')}}" rel="stylesheet" type="text/css" /></noscript>


### PR DESCRIPTION
As per issue 1695, the css for the jquery-ui enabling code is out of date. By default this code section is commented out. I have replaced the now-missing base theme with the theme ui-lightness. 
