### PR TITLE
Fixed problem with Rows.render

### DIFF
--- a/gluon/dal.py
+++ b/gluon/dal.py
@@ -10501,7 +10501,7 @@ class Rows(object):
 
 
         if i is None:
-            return (self.repr(i, fields=fields) for i in range(len(self)))
+            return (self.render(i, fields=fields) for i in range(len(self)))
         import sqlhtml
         row = copy.deepcopy(self.records[i])
         keys = row.keys()


### PR DESCRIPTION
When calling Rows.render() without a record index, the recursive call mistakenly used the old method name (self.repr) instead of the current name (self.render).
