### PR TITLE
fix for Issue 1692 virtual fields in SQLFORM.grid

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -2273,7 +2273,8 @@ class SQLFORM(FORM):
             limitby = None
 
         try:
-            table_fields = filter(lambda f: f.tablename in tablenames, fields)
+    #        table_fields = filter(lambda f: f.tablename in tablenames, fields)
+            table_fields = filter(lambda f: (f.tablename in tablenames) and (not(isinstance(f,Field.Virtual))),fields)
             if dbset._db._adapter.dbengine=='google:datastore':
                 rows = dbset.select(left=left,orderby=orderby,
                                     groupby=groupby,limitby=limitby,


### PR DESCRIPTION
fix for Issue 1692 virtual fields in SQLFORM.grid: this gets rid of the virtual field names from the SQL and at least in a simple test case shows the virtual field on the grid.
