### PR TITLE
Issue/1692 part 2: fix virtual fields when fields= is used in SQLFORM.grid

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -1922,7 +1922,6 @@ class SQLFORM(FORM):
         else:
             fields = []
             columns = []
-            virtual_fields = []
             virtual_columns = []
             for table in tables:
                 for k,f in table.iteritems():
@@ -1934,9 +1933,8 @@ class SQLFORM(FORM):
                         elif isinstance(f,Field.Virtual) and f.readable:
                             #f.tablename = table._tablename now set above
                             #keep virtual fields at end
-                            virtual_columns.append(f)
-                            virtual_fields.append(f)
-            fields = fields + virtual_fields
+                            virtual_columns.append(f) #add to fields as well
+            fields = fields + virtual_columns
             columns = columns + virtual_columns
                         
         if not field_id:


### PR DESCRIPTION
for some reason virtualfields do not get their tablename attribute set which was causing problems with the virtualfields changes to SQLFORM.grid. 
The first PR fixed this in cases where no fields argument was passed to the grid. 
This PR fixes it when fields is used. 

As well, I make sure that virtual fields appear after real fields in the order of columns in the case when the fields argument is not passed to SQLFORM.grid, which looks better; all sortable headings come earlier. 
