### PR TITLE
Fix config to save checkboxes values when they are unchecked (false)

### DIFF
--- a/applications/admin/controllers/default.py
+++ b/applications/admin/controllers/default.py
@@ -576,7 +576,10 @@ def edit():
     # show settings tab and save prefernces
     if 'settings' in request.vars:
         if request.post_vars:        #save new preferences
-            if config.save(request.post_vars.items()):
+            post_vars = request.post_vars.items()
+            # Since unchecked checkbox are not serialized, we must set them as false by hand to store the correct preference in the settings 
+            post_vars+= [(opt, 'false') for opt in editor_defaults if opt not in request.post_vars ]
+            if config.save(post_vars):
                 response.headers["web2py-component-flash"] = T('Preferences saved correctly')
             else:
                 response.headers["web2py-component-flash"] = T('Preferences saved on session only')


### PR DESCRIPTION
In settings.cfg we must store if a preference is enabled(true) or disabled(false).
Given the fact that checkbox are not serialized when unchecked, this trick allows us to set them as 'false'.

We can think about the possibility to move that piece of code directly in the config class but we must know which language (javascript/python) to use to save the value. Currently for the editor section I use javascript, namely the unchecked value is set as 'false' instead of 'False'.
