### PR TITLE
Fixing mongodb binary repr

### DIFF
--- a/gluon/dal.py
+++ b/gluon/dal.py
@@ -5449,6 +5449,8 @@ class MongoDBAdapter(NoSQLAdapter):
         elif fieldtype == "blob":
             from bson import Binary
             if not isinstance(value, Binary):
+                if not isinstance(value, basestring):
+                    return Binary(str(value))
                 return Binary(value)
             return value
         elif (isinstance(fieldtype, basestring) and


### PR DESCRIPTION
If value is not a basestring we got type Exception in converting to Binary. This commit solve the issue.

For more details please take a look at https://groups.google.com/forum/#!topic/web2py-developers/6MKjeIzYhxI
