### PR TITLE
replace write to stderr with LOGGER in failed database connection attemp...

### DIFF
--- a/gluon/dal.py
+++ b/gluon/dal.py
@@ -7768,7 +7768,7 @@ class DAL(object):
                         raise
                     except Exception:
                         tb = traceback.format_exc()
-                        sys.stderr.write('DEBUG: connect attempt %i, connection error:\n%s' % (k, tb))
+                        LOGGER.debug('DEBUG: connect attempt %i, connection error:\n%s' % (k, tb))
                 if connected:
                     break
                 else:


### PR DESCRIPTION
...t
( see https://code.google.com/p/web2py/issues/detail?id=1773 where I explain that the write to stderr causes an exception when running rocket as a windows service)
