### PR TITLE
Issue #1772: let the user choose uploads_in_blob with mongodb

### DIFF
--- a/gluon/dal.py
+++ b/gluon/dal.py
@@ -5508,6 +5508,8 @@ class MongoDBAdapter(NoSQLAdapter):
         # synchronous, except when overruled by either this default or
         # function parameter
         self.safe = adapter_args.get('safe',True)
+        # load user setting for uploads in blob storage
+        self.uploads_in_blob = adapter_args.get('uploads_in_blob', False)
 
         if isinstance(m,tuple):
             m = {"database" : m[1]}


### PR DESCRIPTION
About this issue:
https://code.google.com/p/web2py/issues/detail?id=1772

and because of @mdipierro commit https://github.com/web2py/web2py/commit/97739e9e8a9cac642c47f1d7e0adbc9cc5ec4cc8

this give users the possibility to choose, also doesn't break compatibility to apps using blob storage in web2py 2.7.4 and above.
