### PR TITLE
fix issue-1789

### DIFF
--- a/gluon/dal.py
+++ b/gluon/dal.py
@@ -1659,7 +1659,7 @@ class BaseAdapter(ConnectionPool):
             return self.expand(field, colnames=True)
         self._colnames = map(colexpand, fields)
         def geoexpand(field):
-            if isinstance(field.type,str) and field.type.startswith('geometry'):
+            if isinstance(field.type,str) and field.type.startswith('geometry') and isinstance(field, Field):
                 field = field.st_astext()
             return self.expand(field)
         sql_f = ', '.join(map(geoexpand, fields))


### PR DESCRIPTION
this PR fix issue 1789 and it allows to make expression against geometry fields, however imho it is more a workaround. It doesn't brake the backward compatibility, on the other hand I think that adding .st_astext() to all geometry fields by default is not the best way we can follow. 
The st_astext() converts the binary content of the database in a more readable form. However, the st_astext is not the only function we can use to convert the binary content (es in postgis we can use st_asewkt).
My view is to fix the issue with this PR, and review the whole code in a future release ex: by removing the explicit call to .st_astext, user can still add the .st_astext when needed.
