### PR TITLE
Fix references with GAE in NDB mode

### DIFF
--- a/gluon/dal.py
+++ b/gluon/dal.py
@@ -4839,12 +4839,10 @@ class GoogleDatastoreAdapter(NoSQLAdapter):
             elif field_type.startswith('reference'):
                 if field.notnull:
                     attr = dict(required=True)
-                referenced = field_type[10:].strip()
-                ftype = self.types[field_type[:9]](referenced, **attr)
+                ftype = self.types[field_type[:9]](**attr)
             elif field_type.startswith('list:reference'):
                 if field.notnull:
                     attr['required'] = True
-                referenced = field_type[15:].strip()
                 ftype = self.types[field_type[:14]](**attr)
             elif field_type.startswith('list:'):
                 ftype = self.types[field_type](**attr)


### PR DESCRIPTION
For reference types the IntegerProperty class (no matter if NDB or
not) constructor is passed the referenced table name as the first
parameter.

For non-NDB, the first parameter is 'verbose_name'. For NDB, the first
parameter is 'name'.

In NDB mode this causes the property to have a wrong identity and
therefore references fail to work properly.

The verbose_name set in non-NDB mode is relatively harmless in
comparison, but seems to be wrong as well as it does not really make
sense.

Do not pass referenced table name to the IntegerProperty constructor in
either case.
