### PR TITLE
Fix list types in GAE NDB after entity write

### DIFF
--- a/gluon/dal.py
+++ b/gluon/dal.py
@@ -5166,6 +5166,12 @@ class GoogleDatastoreAdapter(NoSQLAdapter):
         processor = attributes.get('processor',self.parse)
         return processor(rows,fields,colnames,False)
 
+    def parse_list_integers(self, value, field_type):
+        return value[:] if self.use_ndb else value
+
+    def parse_list_strings(self, value, field_type):
+        return value[:] if self.use_ndb else value
+
     def count(self,query,distinct=None,limit=None):
         if distinct:
             raise RuntimeError("COUNT DISTINCT not supported")


### PR DESCRIPTION
As per
http://code.google.com/p/appengine-ndb-experiment/issues/detail?id=208
("List items from repeated StringProperty get mutated to _BaseValue on
put") it seems to be expected behavior that lists in NDB models get
mutated to _BaseValue lists after .put() is called.

In web2py this corresponds to:

```
db.define_table('listintegertest',
    Field('dummy', 'boolean'),
    Field('integerlist', 'list:integer'),
    Field('stringlist', 'list:string'),
)

iidee = db.listintegertest.insert(
    integerlist=[1,2,3,4],
    stringlist=["1","2","3","4"]
)
row = db.listintegertest(iidee)
db.listintegertest[row.id] = dict(dummy=True)

print "type is %s" % (type(row.integerlist[0]))
print "type is %s" % (type(row.stringlist[0]))
```

The output of the above is currently:

```
type is <class 'google.appengine.ext.ndb.model._BaseValue'>
type is <class 'google.appengine.ext.ndb.model._BaseValue'>
```

while this is expected:

```
type is <type 'int'>
type is <type 'unicode'>
```

The workaround is to copy the list from the NDB model instead of
relying on it not being changed afterwards.

list:reference is not affected since parse_list_references() already
recreates the list in NoSQLAdapter case.
