### PR TITLE
quoting of tablenames and field names

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -21,7 +21,7 @@ from gluon.html import FORM, INPUT, LABEL, OPTION, SELECT, COL, COLGROUP
 from gluon.html import TABLE, THEAD, TBODY, TR, TD, TH, STYLE
 from gluon.html import URL, truncate_string, FIELDSET
 from gluon.dal import DAL, Field, Table, Row, CALLABLETYPES, smart_query, \
-    bar_encode, Reference, REGEX_TABLE_DOT_FIELD, Expression, SQLCustomType
+    bar_encode, Reference, Expression, SQLCustomType
 from gluon.storage import Storage
 from gluon.utils import md5_hash
 from gluon.validators import IS_EMPTY_OR, IS_NOT_EMPTY, IS_LIST_OF, IS_DATE, \
@@ -2893,7 +2893,7 @@ class SQLTABLE(TABLE):
         if not sqlrows:
             return
         if not columns:
-            columns = sqlrows.colnames
+            columns = ['.'.join(sqlrows.db._adapter.REGEX_TABLE_DOT_FIELD.match(c).groups()) for c in sqlrows.colnames]
         if headers == 'fieldname:capitalize':
             headers = {}
             for c in columns:
@@ -3116,7 +3116,7 @@ class ExportClass(object):
         for record in self.rows:
             row = []
             for col in self.rows.colnames:
-                if not REGEX_TABLE_DOT_FIELD.match(col):
+                if not self.rows.db._adapter.REGEX_TABLE_DOT_FIELD.match(col):
                     row.append(record._extra[col])
                 else:
                     (t, f) = col.split('.')


### PR DESCRIPTION
fix for wrong sequence name quoting

fix for wrong sequence name quoting 2

reverted test to quoted rname

rname passed asis. freedom in table names and field names. Case sensitivity in field and table names

removed test of allowed char sequence in table and field names, there is no limit anymore

fixed some troubles with postgresql drop(). Better Row.**getitem**(): should not be much slower.  Added a ignore_field_case parameter to allow Field('F')!=Field('f') on databases supporting case sesitivity.

different mysql drivers handled in quoting test.

improved handling of foreing keys

fix with quoted names in SQLTABLE.  fix for ORDER BY

handle references on non "id" fields

check reference expression against table list first
