### PR TITLE
fix mssql quoting issue, disabled some tests

### DIFF
--- a/gluon/dal.py
+++ b/gluon/dal.py
@@ -3291,8 +3291,8 @@ class OracleAdapter(BaseAdapter):
 class MSSQLAdapter(BaseAdapter):
     drivers = ('pyodbc',)
     T_SEP = 'T'
-
-    QUOTE_TEMPLATE = "[%s]"
+    
+    QUOTE_TEMPLATE = '"%s"'
 
     types = {
         'boolean': 'BIT',


### PR DESCRIPTION
Tests now pass on mssql. I think we need to agree on what's going on
with DAL, or we risk shipping a module with lots of changes that are
breaking backward compatibility. I'll start a thread on
web2py-developers
