### PR TITLE
Enable admin app for GAE (experimental)

### DIFF
--- a/examples/app.example.yaml
+++ b/examples/app.example.yaml
@@ -65,8 +65,8 @@ skip_files: |
  (.*\.py[co])|
  (.*/RCS/.*)|
  (\..*)|
- (applications/(admin|examples)/.*)|
- ((admin|examples|welcome)\.(w2p|tar))|
+ (applications/examples/.*)|
+ ((examples|welcome)\.(w2p|tar))|
  (applications/.*?/(cron|databases|errors|cache|sessions)/.*)|
  ((logs|scripts)/.*)|
  (anyserver\.py)|


### PR DESCRIPTION
Allows to browse for installed app files, check db error ticket, (probably) issuing commands trough the shell. For now, any feature within the design page writing to the filesystem is ignored (returns a not supported flash message)
