### PR TITLE
Save current working session in the online editor

### DIFF
--- a/applications/admin/controllers/default.py
+++ b/applications/admin/controllers/default.py
@@ -574,10 +574,10 @@ def edit():
     # Load json only if it is ajax edited...
     app = get_app(request.vars.app)
     app_path = apath(app, r=request)
-    editor_defaults={'theme':'web2py', 'editor': 'default', 'closetag': 'true', 'codefolding': 'false', 'tabwidth':'4', 'indentwithtabs':'false', 'linenumbers':'true', 'highlightline':'true'}
+    preferences={'theme':'web2py', 'editor': 'default', 'closetag': 'true', 'codefolding': 'false', 'tabwidth':'4', 'indentwithtabs':'false', 'linenumbers':'true', 'highlightline':'true'}
     config = Config(os.path.join(request.folder, 'settings.cfg'),
-                    section='editor', default_values=editor_defaults)
-    preferences = config.read()
+                    section='editor', default_values={})
+    preferences.update(config.read())
 
     if not(request.ajax) and not(is_mobile):
         # return the scaffolding, the rest will be through ajax requests
@@ -589,7 +589,7 @@ def edit():
         if request.post_vars:        #save new preferences
             post_vars = request.post_vars.items()
             # Since unchecked checkbox are not serialized, we must set them as false by hand to store the correct preference in the settings 
-            post_vars+= [(opt, 'false') for opt in editor_defaults if opt not in request.post_vars ]
+            post_vars+= [(opt, 'false') for opt in preferences if opt not in request.post_vars ]
             if config.save(post_vars):
                 response.headers["web2py-component-flash"] = T('Preferences saved correctly')
             else:
@@ -813,6 +813,22 @@ def todolist():
                 output.append({'filename':f,'matches':matches, 'dir':d})
 
     return {'todo':output, 'app': app}
+
+def editor_sessions():
+    config = Config(os.path.join(request.folder, 'settings.cfg'),
+                    section='editor_sessions', default_values={})
+    preferences = config.read()
+
+    if request.vars.session_name and request.vars.files:
+        session_name = request.vars.session_name
+        files = request.vars.files
+        preferences.update({session_name:','.join(files)})
+        if config.save(preferences.items()):
+            response.headers["web2py-component-flash"] = T('Session saved correctly')
+        else:
+            response.headers["web2py-component-flash"] = T('Session saved on session only')
+
+    return response.render('default/editor_sessions.html', {'editor_sessions':preferences})
 
 def resolve():
     """

--- a/applications/admin/languages/it.py
+++ b/applications/admin/languages/it.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# -*- coding: utf-8 -*-
 {
 '!langcode!': 'it',
 '!langname!': 'Italiano',
@@ -303,6 +303,7 @@
 'to  previous version.': 'torna a versione precedente',
 'To create a plugin, name a file/folder plugin_[name]': 'Per creare un plugin, chiamare un file o cartella plugin_[nome]',
 'toggle breakpoint': 'toggle breakpoint',
+'Toggle comment': 'Toggle comment',
 'Toggle Fullscreen': 'Toggle Fullscreen',
 'Traceback': 'Traceback',
 'translation strings for the application': "stringhe di traduzioni per l'applicazione",

--- a/applications/admin/settings.cfg
+++ b/applications/admin/settings.cfg
@@ -1,10 +1,10 @@
 [DEFAULT]
-theme = web2py
-closetag = true
-editor = default
 
 [editor]
 theme = web2py
 editor = default
 closetag = true
+
+[editor_sessions]
+welcome = welcome/models/db.py,welcome/controllers/default.py,welcome/views/default/index.html
 

--- a/applications/admin/static/js/ajax_editor.js
+++ b/applications/admin/static/js/ajax_editor.js
@@ -260,7 +260,7 @@ function load_file(url, lineno) {
       if(typeof (json['plain_html']) !== undefined) {
         if($('#' + json['id']).length === 0 || json['force'] === true) {
           // Create a tab and put the code in it
-          var tab_header = '<li><a title="'+ json['filename'] +'" href="#' + json['id'] + '" data-toggle="tab"><button type="button" class="close">&times;</button>' + json['realfilename'] + '</a></li>';
+          var tab_header = '<li><a title="'+ json['filename'] +'" data-path="' + json['filename'] + '" href="#' + json['id'] + '" data-toggle="tab"><button type="button" class="close">&times;</button>' + json['realfilename'] + '</a></li>';
           var tab_body = '<div id="' + json['id'] + '" class="tab-pane fade in " >' + json['plain_html'] + '</div>';
           if(json['force'] === false) {
             $('#myTabContent').append($(tab_body)); // First load the body

--- a/applications/admin/views/default/edit.html
+++ b/applications/admin/views/default/edit.html
@@ -208,6 +208,9 @@ $(document).on('click', 'a.font_button', function (e) {
 
 <div class='row-fluid'>
 <div class="right controls btn-toolbar pull-right">
+
+{{=LOAD('default', 'editor_sessions', ajax=True, _class='btn-group')}}
+
 <div class="btn-group">
   <a class="button btn" onclick="$('#files').toggle(); return false" href="#">Files toggle</a>
 </div>
@@ -314,5 +317,28 @@ $(document).ready(function() {
         load_file(datum.link);
         $(this).val('');
     });
+    /* handlers to manage editor sessions
+    */
+    $(document).on('click', '#save_session', function(e) {
+        e.preventDefault();
+        var session_name=prompt("Session name","{{=app}}");
+
+        if (session_name!==null) {
+            files = $("[data-path]").map(function(){return $(this).data("path");}).get();
+            data = JSON.stringify({ files: files, session_name:session_name});
+            $.ajaxSetup({contentType: "application/json"});
+            $.web2py.ajax_page("POST", "{{=URL('default', 'editor_sessions')}}", data, 'manage_sessions');
+        }
+    });
+    $(document).on('click', '#saved_sessions a[data-files]', function(e) {
+        e.preventDefault();
+        files = $(this).data('files');
+        array_files = files.split(',');
+        $.each(array_files, function(index, value) {
+            url = "{{=URL('default','edit')}}/" + value;
+            load_file(url);
+        });
+    });
+
 </script>
 <!-- end "edit" block -->

--- a/applications/admin/views/default/editor_sessions.html
+++ b/applications/admin/views/default/editor_sessions.html
@@ -1,0 +1,14 @@
+<div class="btn-group" id='manage_sessions'>
+  <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">Saved session <span class="caret"></span></a>
+  <ul class="dropdown-menu" id="saved_sessions">
+    {{for name, files in editor_sessions.items():}}
+       <li><a href="" data-files='{{=files}}'>{{=name}}</a></li>
+       {{for f in files:}}
+       {{print 'file', f}}
+       {{pass}}
+    {{pass}}
+    <li class="divider"></li>
+    <li><a id="save_session" href="">Save current session</a></li>
+  </ul>
+</div>
+

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -5893,7 +5893,7 @@ class Wiki(object):
 class Config(object):
     def __init__(
         self,
-                filename,
+        filename,
         section,
         default_values={}
     ):


### PR DESCRIPTION
with current working session I mean the list of file currently open
It works by adding a new section in the settings.cfg, which will contain a row for each different file list saved. 
it also fix an issue related to the config parser which requires to remove all entries in the [default] section.

still missing a simple way to remove sessions :( 
