### PR TITLE
fix issue 1840, CAS failing due to redirect loop

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -2112,7 +2112,7 @@ class Auth(object):
         success = False
         if row:
             userfield = self.settings.login_userfield or 'username' \
-                if 'username' in table_user.fields else 'email'
+                if 'username' in table.fields else 'email'
             # If ticket is a service Ticket and RENEW flag respected
             if ticket[0:3] == 'ST-' and \
                     not ((row.renew and renew) ^ renew):


### PR DESCRIPTION
there seems to be a minor bug with commit c87bf5, and therefore it solves the redirect loop preventing CAS authentication from working.
In my testing this patch fixes it. Note that this reverts to prior behaviour of checking the CAS provider to see if username is used to identify users. I'm not sure how this would work if the CAS provider was not web2py, I know nothing about CAS. But it was the old behaviour. 
