### PR TITLE
Added _insert for App Engine

### DIFF
--- a/gluon/dal.py
+++ b/gluon/dal.py
@@ -5297,10 +5297,12 @@ class GoogleDatastoreAdapter(NoSQLAdapter):
         LOGGER.info(str(counter))
         return counter
 
+    def _insert(self, table, fields):
+        return dict((f.name,self.represent(v,f.type)) for f,v in fields)
+
     def insert(self,table,fields):
-        dfields=dict((f.name,self.represent(v,f.type)) for f,v in fields)
         # table._db['_lastsql'] = self._insert(table,fields)
-        tmp = table._tableobj(**dfields)
+        tmp = table._tableobj(**self._insert(table, fields))
         tmp.put()
         key = tmp.key if self.use_ndb else tmp.key()
         rid = Reference(key.id())


### PR DESCRIPTION
Returns a dictionary with processed values without applying the changes to datastore.
Now .insert uses _insert for data representation
Usage: this can be used for pre-processing data before lower level I/O (i.e. using google api for storing entities)

Discussion: https://groups.google.com/d/msg/web2py/lFKiIGary0c/h5jxr1gxiVoJ
