### PR TITLE
related to issue 1708 - bugfix to allow no expiration for gae_memcache

### DIFF
--- a/gluon/contrib/gae_memcache.py
+++ b/gluon/contrib/gae_memcache.py
@@ -27,15 +27,11 @@ class MemcacheClient(object):
         time_expire=300,
     ):
         key = '%s/%s' % (self.request.application, key)
-        dt = time_expire
         value = None
         obj = self.client.get(key)
-        if obj and (dt is None or obj[0] > time.time() - dt):
+        if obj:
             value = obj[1]
-        elif f is None:
-            if obj:
-                self.client.delete(key)
-        else:
+        elif f is not None:
             value = f()
             self.client.set(key, (time.time(), value), time=time_expire)
         return value


### PR DESCRIPTION
When gae_memcache passed expiration time to memcache Client
(see commit 59290534bc2faad501ba13c495aeb051d619314),
logic is no longer needed to calculate time delta, since memcache
handles that for us.  Also, time_expire=0 was expiring values
immediately, instead of the documented behavior where 0 signified
no expiration.

Kept timestamp in value for backwards compatibility (is this
necessary since cached data is transient?)
