### PR TITLE
Issues/1859 export from grid fails when virtual fields are present

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -2192,7 +2192,7 @@ class SQLFORM(FORM):
                                 expcolumns.append(str(field))
                             if not(isinstance(field,Field.Virtual)):
                                 selectable_columns.append(str(field))
-                    #look for virtual fields not displayed (and computed fields to be added here)
+                    #look for virtual fields not displayed (and virtual method fields to be added here?)
                     for (field_name,field) in table.iteritems():
                         if isinstance(field,Field.Virtual) and not str(field) in expcolumns:
                              expcolumns.append(str(field))


### PR DESCRIPTION
This fix assumes there are either real fields or virtual fields in a grid. It works in my test cases and is a big improvement over current functionality (tickets are no longer generated and export behaves as expected). But more work may be needed.
