### PR TITLE
dal.py: Table class: validate_and_update_or_insert method created, validate_and_update minor changes

### DIFF
--- a/gluon/dal.py
+++ b/gluon/dal.py
@@ -9205,7 +9205,6 @@ class Table(object):
 
         if record:
             response = self.validate_and_update(_key, **fields)
-            # Now primary key must be returned
             primary_keys = {}
             for key in self._primarykey:
                 primary_keys[key] = getattr(record, key)


### PR DESCRIPTION
dal.py: Table class: validate_and_update_or_insert method created, and minor changes in validate_and_update

· these methods should be working even in case of tables with multiple primary keys
· the validate_and_update_or_insert method assumes that in case that no primary keys are provided, all table fields marked as "required" will be used for searching the record to update (or to insert, in case that the record doesn't yet exist)
