### PR TITLE
add Recaptcha(...ajax=True) to use ajax api, fix Recaptcha in LOAD issue/1888

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -757,7 +757,8 @@ class Recaptcha(DIV):
         error_message='invalid',
         label='Verify:',
         options='',
-        comment = ''
+        comment = '',
+        ajax=False
     ):
         self.request_vars = request and request.vars or current.request.vars
         self.remote_addr = request.env.remote_addr
@@ -772,6 +773,7 @@ class Recaptcha(DIV):
         self.label = label
         self.options = options
         self.comment = comment
+        self.ajax = ajax
 
     def _validate(self):
 
@@ -825,18 +827,43 @@ class Recaptcha(DIV):
             server = self.API_SSL_SERVER
         else:
             server = self.API_SERVER
-        captcha = DIV(
-            SCRIPT("var RecaptchaOptions = {%s};" % self.options),
-            SCRIPT(_type="text/javascript",
-                   _src="%s/challenge?k=%s%s" % (server, public_key, error_param)),
-            TAG.noscript(
-                IFRAME(
-                    _src="%s/noscript?k=%s%s" % (
-                        server, public_key, error_param),
-                    _height="300", _width="500", _frameborder="0"), BR(),
-                INPUT(
-                    _type='hidden', _name='recaptcha_response_field',
-                    _value='manual_challenge')), _id='recaptcha')
+        if not self.ajax:
+            captcha = DIV(
+                SCRIPT("var RecaptchaOptions = {%s};" % self.options),
+                SCRIPT(_type="text/javascript",
+                       _src="%s/challenge?k=%s%s" % (server, public_key, error_param)),
+                TAG.noscript(
+                    IFRAME(
+                        _src="%s/noscript?k=%s%s" % (
+                            server, public_key, error_param),
+                        _height="300", _width="500", _frameborder="0"), BR(),
+                    INPUT(
+                        _type='hidden', _name='recaptcha_response_field',
+                        _value='manual_challenge')), _id='recaptcha')
+
+        else: #use Google's ajax interface, needed for LOADed components
+
+            url_recaptcha_js = "%s/js/recaptcha_ajax.js" % server
+            RecaptchaOptions = "var RecaptchaOptions = {%s}" % self.options
+            script = """%(options)s;
+            jQuery.getScript('%(url)s',function() {
+                Recaptcha.create('%(public_key)s',
+                    'recaptcha',jQuery.extend(RecaptchaOptions,{'callback':Recaptcha.focus_response_field}))
+                }) """ % ({'options':RecaptchaOptions,'url':url_recaptcha_js,'public_key':public_key})
+            captcha = DIV(
+                SCRIPT(
+                    script,
+                    _type="text/javascript",
+                ),
+                TAG.noscript(
+                    IFRAME(
+                        _src="%s/noscript?k=%s%s" % (
+                            server, public_key, error_param),
+                        _height="300", _width="500", _frameborder="0"), BR(),
+                    INPUT(
+                        _type='hidden', _name='recaptcha_response_field',
+                        _value='manual_challenge')), _id='recaptcha')
+
         if not self.errors.captcha:
             return XML(captcha).xml()
         else:


### PR DESCRIPTION
the current implementation of recaptcha doesn't work in LOAD(...ajax=True). 
the new argument to the Recaptcha constructor, ajax= True | False, uses the ajax API to recaptcha.
The new argument defaults to False to keep existing behaviour.
