### PR TITLE
oauth strip encoding part in content-type response from server.

### DIFF
--- a/gluon/contrib/login_methods/oauth20_account.py
+++ b/gluon/contrib/login_methods/oauth20_account.py
@@ -172,7 +172,7 @@ server for requests.  It can be used for the optional"scope" parameters for Face
             if open_url:
                 try:
                     data = open_url.read()
-                    resp_type = open_url.info().get('Content-Type')
+                    resp_type = open_url.info().gettype()
                     # try json style first
                     if not resp_type or resp_type[:16] == 'application/json':
                         try:


### PR DESCRIPTION
Thanx to Jayadevan M.
