### PR TITLE
jsonrpc2 requests need mandatory key/pair jsonrpc:'2.0'

### DIFF
--- a/gluon/contrib/simplejsonrpc.py
+++ b/gluon/contrib/simplejsonrpc.py
@@ -81,12 +81,13 @@ class JSONSafeTransport(JSONTransportMixin, SafeTransport):
 class ServerProxy(object):
     "JSON RPC Simple Client Service Proxy"
 
-    def __init__(self, uri, transport=None, encoding=None, verbose=0):
+    def __init__(self, uri, transport=None, encoding=None, verbose=0,version=None):
         self.location = uri             # server location (url)
         self.trace = verbose            # show debug messages
         self.exceptions = True          # raise errors? (JSONRPCError)
         self.timeout = None
         self.json_request = self.json_response = ''
+        self.version = version          # '2.0' for jsonrpc2
 
         type, uri = urllib.splittype(uri)
         if type not in ("http", "https"):
@@ -112,6 +113,8 @@ class ServerProxy(object):
         # build data sent to the service
         request_id = random.randint(0, sys.maxint)
         data = {'id': request_id, 'method': method, 'params': args, }
+        if self.version:
+            data['jsonrpc'] = self.version #mandatory key/value for jsonrpc2 validation else err -32600
         request = json.dumps(data)
 
         # make HTTP request (retry if connection is lost)


### PR DESCRIPTION
closes 1898
jsonrpc2 errors out with error number -32600 if the request dict does not have a key 'jsonrpc' with value '2.0'
There was no mechanism for the ServerProxy class to know if it was sending a request to jsonrpc2 or jsonrpc so I added a keyword argument version=None
If defined, it adds the missing key to data. Only a value of version='2.0' will work with jsonrpc2.
None falls back to current jsonrpc behaviour.
