### PR TITLE
static_version setup enabled by default

### DIFF
--- a/scripts/nginx_scgi.conf
+++ b/scripts/nginx_scgi.conf
@@ -80,9 +80,9 @@ http {
                          root /var/www/localhost/html;
                 }
 
-
-                location ^/(.*)/static/(.*) {
-                          alias $web2pyroot/applications/$1/static/$2;
+                location ~* ^/(\w+)/static(?:/_[\d]+\.[\d]+\.[\d]+)?/(.*)$ {
+                    alias $web2pyroot/applications/$1/static/$2;
+                    expires max;
                 }
 
                 location / {

--- a/scripts/setup-ubuntu-12-04-redmine-unicorn-web2py-uwsgi-nginx.sh
+++ b/scripts/setup-ubuntu-12-04-redmine-unicorn-web2py-uwsgi-nginx.sh
@@ -326,14 +326,9 @@ server {
         access_log  /var/log/nginx/yoursite.access.log;
         error_log  /var/log/nginx/yoursite.error.log;
         #to enable correct use of response.static_version
-        #location ~* /(\w+)/static(?:/_[\d]+\.[\d]+\.[\d]+)?/(.*)$ {
-        #    alias /home/www-data/web2py/applications/$1/static/$2;
-        #    expires max;
-        #}
-        location ~* /(\w+)/static/ {
-            root /home/www-data/web2py/applications/;
-            #remove next comment on production
-            #expires max;
+        location ~* /(\w+)/static(?:/_[\d]+\.[\d]+\.[\d]+)?/(.*)$ {
+            alias /home/www-data/web2py/applications/$1/static/$2;
+            expires max;
         }
         location ~^\/(?!redmine(.*)) {
             #uwsgi_pass      127.0.0.1:9001;
@@ -366,6 +361,10 @@ server {
                 ssl_ciphers ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA;
                 ssl_protocols SSLv3 TLSv1;
                 keepalive_timeout    70;
+        location ~* /(\w+)/static(?:/_[\d]+\.[\d]+\.[\d]+)?/(.*)$ {
+            alias /home/www-data/web2py/applications/$1/static/$2;
+            expires max;
+        }
         location ~^\/(?!redmine(.*)) {
             #uwsgi_pass      127.0.0.1:9001;
             uwsgi_pass      unix:///tmp/web2py.socket;

--- a/scripts/setup-web2py-debian-sid.sh
+++ b/scripts/setup-web2py-debian-sid.sh
@@ -102,11 +102,11 @@ echo '
   </Directory>
 
   <Location /admin>
-	Require all denied
+    Require all denied
   </Location>
 
   <LocationMatch ^/([^/]+)/appadmin>
-	Require all denied
+    Require all denied
   </LocationMatch>
 
   CustomLog /var/log/apache2/access.log common

--- a/scripts/setup-web2py-fedora-ami.sh
+++ b/scripts/setup-web2py-fedora-ami.sh
@@ -311,8 +311,8 @@ NameVirtualHost *:443
       Allow from all
     </Files>
   </Directory>
-
-  AliasMatch ^/([^/]+)/static/(.*) /opt/web-apps/web2py/applications/\$1/static/\$2
+  AliasMatch ^/([^/]+)/static/(?:_[\d]+.[\d]+.[\d]+/)?(.*) \
+        /opt/web-apps/web2py/applications/\$1/static/\$2
 
   <Directory /opt/web-apps/web2py/applications/*/static>
     Options -Indexes
@@ -350,7 +350,8 @@ NameVirtualHost *:443
     </Files>
   </Directory>
 
-  AliasMatch ^/([^/]+)/static/(.*) /opt/web-apps/web2py/applications/\$1/static/\$2
+  AliasMatch ^/([^/]+)/static/(?:_[\d]+.[\d]+.[\d]+/)?(.*) \
+        /opt/web-apps/web2py/applications/\$1/static/\$2
 
   <Directory /opt/web-apps/web2py/applications/*/static>
     Options -Indexes

--- a/scripts/setup-web2py-nginx-uwsgi-centos64.sh
+++ b/scripts/setup-web2py-nginx-uwsgi-centos64.sh
@@ -54,14 +54,9 @@ echo 'server {
         listen          YOUR_SERVER_IP:80;
         server_name     YOUR_SERVER_FQDN;
         #to enable correct use of response.static_version
-        #location ~* /(\w+)/static(?:/_[\d]+\.[\d]+\.[\d]+)?/(.*)$ {
-        #    alias /var/www/web2py/applications/$1/static/$2;
-        #    expires max;
-        #}
-        location ~* /(\w+)/static/ {
-            root /var/www/web2py/applications/;
-            #remove next comment on production
-            #expires max;
+        location ~* /(\w+)/static(?:/_[\d]+\.[\d]+\.[\d]+)?/(.*)$ {
+            alias /var/www/web2py/applications/$1/static/$2;
+            expires max;
         }
         location / {
             #uwsgi_pass      127.0.0.1:9001;
@@ -86,6 +81,10 @@ server {
         ssl_ciphers ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA;
         ssl_protocols SSLv3 TLSv1;
         keepalive_timeout    70;
+        location ~* /(\w+)/static(?:/_[\d]+\.[\d]+\.[\d]+)?/(.*)$ {
+            alias /var/www/web2py/applications/$1/static/$2;
+            expires max;
+        }
         location / {
             #uwsgi_pass      127.0.0.1:9001;
             uwsgi_pass      unix:///var/www/web2py/logs/web2py.socket;

--- a/scripts/setup-web2py-nginx-uwsgi-on-centos.sh
+++ b/scripts/setup-web2py-nginx-uwsgi-on-centos.sh
@@ -181,8 +181,9 @@ echo '
 server {
   listen 80;
   server_name $hostname;
-  location ~* /(\w+)/static/ {
-    root /opt/web-apps/web2py/applications/;
+  location ~* /(\w+)/static(?:/_[\d]+\.[\d]+\.[\d]+)?/(.*)$ {
+            alias /opt/web-apps/web2py/applications/$1/static/$2;
+            expires max;
   }
   location / {
     uwsgi_pass 127.0.0.1:9001;
@@ -200,6 +201,10 @@ server {
     uwsgi_pass 127.0.0.1:9001;
     include uwsgi_params;
     uwsgi_param UWSGI_SCHEME $scheme;
+  }
+  location ~* /(\w+)/static(?:/_[\d]+\.[\d]+\.[\d]+)?/(.*)$ {
+            alias /opt/web-apps/web2py/applications/$1/static/$2;
+            expires max;
   }
 }
 ' > /etc/nginx/conf.d/web2py.conf

--- a/scripts/setup-web2py-nginx-uwsgi-opensuse.sh
+++ b/scripts/setup-web2py-nginx-uwsgi-opensuse.sh
@@ -36,14 +36,9 @@ echo 'server {
         listen          80;
         server_name     $hostname;
         #to enable correct use of response.static_version
-        #location ~* /(\w+)/static(?:/_[\d]+\.[\d]+\.[\d]+)?/(.*)$ {
-        #    alias /srv/www/web2py/applications/$1/static/$2;
-        #    expires max;
-        #}
-        location ~* /(\w+)/static/ {
-            root /srv/www/web2py/applications/;
-            #remove next comment on production
-            #expires max;
+        location ~* /(\w+)/static(?:/_[\d]+\.[\d]+\.[\d]+)?/(.*)$ {
+            alias /srv/www/web2py/applications/$1/static/$2;
+            expires max;
         }
         location / {
             #uwsgi_pass      127.0.0.1:9001;
@@ -64,6 +59,10 @@ server {
         ssl_ciphers ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA;
         ssl_protocols SSLv3 TLSv1;
         keepalive_timeout    70;
+        location ~* /(\w+)/static(?:/_[\d]+\.[\d]+\.[\d]+)?/(.*)$ {
+            alias /srv/www/web2py/applications/$1/static/$2;
+            expires max;
+        }
         location / {
             #uwsgi_pass      127.0.0.1:9001;
             uwsgi_pass      unix:///tmp/web2py.socket;

--- a/scripts/setup-web2py-nginx-uwsgi-ubuntu.sh
+++ b/scripts/setup-web2py-nginx-uwsgi-ubuntu.sh
@@ -43,10 +43,13 @@ echo 'server {
         listen          80;
         server_name     $hostname;
         ###to enable correct use of response.static_version
-        #location ~* ^/(\w+)/static(?:/_[\d]+\.[\d]+\.[\d]+)?/(.*)$ {
-        #    alias /home/www-data/web2py/applications/$1/static/$2;
-        #    expires max;
-        #}
+        location ~* ^/(\w+)/static(?:/_[\d]+\.[\d]+\.[\d]+)?/(.*)$ {
+            alias /home/www-data/web2py/applications/$1/static/$2;
+            expires max;
+            ### if you want to use pre-gzipped static files (recommended)
+            ### check scripts/zip_static_files.py and remove the comments
+            # include /etc/nginx/conf.d/web2py/gzip_static.conf;
+        }
         ###
 
         ###if you use something like myapp = dict(languages=['en', 'it', 'jp'], default_language='en') in your routes.py
@@ -55,15 +58,7 @@ echo 'server {
         #    try_files static/$2/$3 static/$3 =404;
         #}
         ###
-        location ~* ^/(\w+)/static/ {
-            root /home/www-data/web2py/applications/;
-            #remove next comment on production
-            #expires max;
-            ### if you want to use pre-gzipped static files (recommended)
-            ### check scripts/zip_static_files.py and remove the comments
-            # include /etc/nginx/conf.d/web2py/gzip_static.conf;
-            ###
-        }
+        
         location / {
             #uwsgi_pass      127.0.0.1:9001;
             uwsgi_pass      unix:///tmp/web2py.socket;
@@ -104,8 +99,15 @@ server {
             #client_max_body_size 10m;
             ###
         }
-        ## if you serve static files through https, copy here the section
-        ## from the previous server instance to manage static files
+        ###to enable correct use of response.static_version
+        location ~* ^/(\w+)/static(?:/_[\d]+\.[\d]+\.[\d]+)?/(.*)$ {
+            alias /home/www-data/web2py/applications/$1/static/$2;
+            expires max;
+            ### if you want to use pre-gzipped static files (recommended)
+            ### check scripts/zip_static_files.py and remove the comments
+            # include /etc/nginx/conf.d/web2py/gzip_static.conf;
+        }
+        ###
 
 }' >/etc/nginx/sites-available/web2py
 


### PR DESCRIPTION
There was a time where scripts/\* were intended as blueprints. More and more users are instead intending them as one-click solutions. Now that static_version is tested and used, it may be the right time to add that feature by default also in scripts.
