### PR TITLE
Update gluon.validators.py to process a string of values submitted through a multiselect form field

### DIFF
--- a/applications/welcome/static/js/web2py.js
+++ b/applications/welcome/static/js/web2py.js
@@ -12,7 +12,7 @@
   }
 
 
-  String.prototype.reverse = function (this) {
+  String.prototype.reverse = function () {
     return this.split('').reverse().join('');
   };
   var web2py;


### PR DESCRIPTION
This update would allow a string of values to be used to update a list:reference field through a form (e.g., '1,2,3,4' would be parsed by the validator into the ['1','2','3','4'] list format expected by web2py's DAL when updating a list:reference field). This update would require import and use of ast.literal_eval to transform the string into a list of values. 
