### PR TITLE
Modify Table class so that uploadfs is respected when uploads_in_blob is set to True

### DIFF
--- a/gluon/dal.py
+++ b/gluon/dal.py
@@ -8735,9 +8735,9 @@ class Table(object):
             for field in fields:
                 fn = field.uploadfield
                 if isinstance(field, Field) and field.type == 'upload'\
-                        and fn is True:
+                        and fn is True and not field.uploadfs:
                     fn = field.uploadfield = '%s_blob' % field.name
-                if isinstance(fn, str) and not fn in uploadfields:
+                if isinstance(fn, str) and not fn in uploadfields and not field.uploadfs:
                     fields.append(Field(fn, 'blob', default='',
                                         writable=False, readable=False))
 


### PR DESCRIPTION
This patch addresses an issue where a database adapter has `uploads_in_blob = True` (e.g. `HerokuPostgresAdapter`) and an upload field has `uploadfs` specified.  Currently, the specified `uploadfs` is not used, and the data is stored as a blob in the database.  The solution presented here checks whether `uploadfs` is set before setting the file to be stored as a blob. 
