### PR TITLE
fixed bug in defition of decimal types

### DIFF
--- a/scripts/extract_pgsql_models.py
+++ b/scripts/extract_pgsql_models.py
@@ -121,9 +121,9 @@ def define_field(conn, table, field, pks):
     elif field['data_type'] in ('time', 'time without time zone'):
         f['type'] = "'time'"
     elif field['data_type'] in ('numeric', 'currency'):
-        f['type'] = "'decimal'"
         f['precision'] = field['numeric_precision']
         f['scale'] = field['numeric_scale'] or 0
+        f['type'] = "'decimal({},{})'".format(f['precision'],f['scale'])
     elif field['data_type'] in ('bytea', ):
         f['type'] = "'blob'"
     elif field['data_type'] in ('point', 'lseg', 'polygon', 'unknown', 'USER-DEFINED'):


### PR DESCRIPTION
A postgresql column of type numeric(10,4) was mapped as just decimal, so the parse_decimal of dal.py will fail. The correct mapping is decimal(10,4) in the web2py model.
