### PR TITLE
time_expire=0 should clear memcache entry

### DIFF
--- a/gluon/contrib/gae_memcache.py
+++ b/gluon/contrib/gae_memcache.py
@@ -32,7 +32,7 @@ class MemcacheClient(object):
 
         key = '%s/%s' % (self.request.application, key)
         value = None
-        obj = self.client.get(key)
+        obj = self.client.get(key) if time_expire != 0 else None
         if obj:
             value = obj[1]
         elif f is not None:


### PR DESCRIPTION
If time_expire=0, then the cache should be cleared and reset with the
latest value to stay compatible with documented web2py functionality of
how caching works. Previous change broke this compatibility while adding
efficiency in other cases.
