### PR TITLE
Check whether memdb record is None before trying to read its keys

### DIFF
--- a/gluon/contrib/memdb.py
+++ b/gluon/contrib/memdb.py
@@ -294,6 +294,8 @@ class Table(DALStorage):
 
     def __call__(self, id, **kwargs):
         record = self.get(id)
+        if record is None:
+          return None
         if kwargs and any(record[key]!=kwargs[key] for key in kwargs):
             return None
         return record


### PR DESCRIPTION
In memdb table.**call**(), check whether record is None before trying to read its keys otherwise app crashes.
