### PR TITLE
apply same rules as DAL's to find tables and fields in column names

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -2913,13 +2913,14 @@ class SQLTABLE(TABLE):
         (components, row) = (self.components, [])
         if not sqlrows:
             return
+        REGEX_TABLE_DOT_FIELD = sqlrows.db._adapter.REGEX_TABLE_DOT_FIELD
         if not columns:
-            REGEX_TABLE_DOT_FIELD = sqlrows.db._adapter.REGEX_TABLE_DOT_FIELD
             columns = [c for c in sqlrows.colnames if REGEX_TABLE_DOT_FIELD.match(c)]
         if headers == 'fieldname:capitalize':
             headers = {}
             for c in columns:
-                headers[c] = c.split('.')[-1].replace('_', ' ').title()
+                (t,f) = REGEX_TABLE_DOT_FIELD.match(c).groups()
+                headers[t + '.' + f] = f.replace('_', ' ').title()
         elif headers == 'labels':
             headers = {}
             for c in columns:
@@ -2938,6 +2939,7 @@ class SQLTABLE(TABLE):
             headers = {}
         else:
             for c in columns:  # new implement dict
+                c = '.'.join(REGEX_TABLE_DOT_FIELD.match(c).groups())
                 if isinstance(headers.get(c, c), dict):
                     coldict = headers.get(c, c)
                     attrcol = dict()
@@ -2987,6 +2989,7 @@ class SQLTABLE(TABLE):
                         raise KeyError(
                             "Column %s not found (SQLTABLE)" % colname)
                 (tablename, fieldname) = matched_column_field.groups()
+                colname = tablename + '.' + fieldname
                 try:
                     field = sqlrows.db[tablename][fieldname]
                 except (KeyError, AttributeError):


### PR DESCRIPTION
This should fix SQLTABLE when using case sensitive field names (DAL option "quoted_entities")
