### PR TITLE
PEP8 improvements white space here and there

### DIFF
--- a/gluon/dal.py
+++ b/gluon/dal.py
@@ -8284,7 +8284,7 @@ class DAL(object):
                                     'error': 'invalid path', 'response': None})
                     return Row({'status': 200, 'response': response,
                                 'pattern': pattern, 'count': count})
-        return Row({'status':4 00, 'error': 'no matching pattern', 'response': None})
+        return Row({'status': 400, 'error': 'no matching pattern', 'response': None})
 
     def define_table(self,
                      tablename,


### PR DESCRIPTION
I search with regexp ",[^\s-]" to spot missing space after comma. I also, add double break line in front of function or class. I change a couple of comparator in order to add space in front and after " == " for instance.
