### PR TITLE
Better HTTP code for method not supported

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -348,7 +348,7 @@ class Request(Storage):
                 rest_action = _action().get(method, None)
                 if not (rest_action and method == method.upper()
                         and callable(rest_action)):
-                    raise HTTP(400, "method not supported")
+                    raise HTTP(405, "method not allowed")
                 try:
                     return rest_action(*_self.args, **getattr(_self, 'vars', {}))
                 except TypeError, e:


### PR DESCRIPTION
Change HTTP code to raise from 400 to 405 (Method Not Allowed).
