### PR TITLE
Fix LOAD() in restful context

### DIFF
--- a/gluon/compileapp.py
+++ b/gluon/compileapp.py
@@ -211,7 +211,7 @@ def LOAD(c=None, f='index', args=None, vars=None,
             request.env.path_info
         other_request.cid = target
         other_request.env.http_web2py_component_element = target
-        other_request.restful = lambda: lambda function: lambda *args, **kwargs: function(*args, **kwargs)  # Needed when you call LOAD() on a controller who has some actions decorates with @request.restful()
+        other_request.restful = request.restful  # Needed when you call LOAD() on a controller who has some actions decorates with @request.restful()
         other_response.view = '%s/%s.%s' % (c, f, other_request.extension)
 
         other_environment = copy.copy(current.globalenv)  # NASTY


### PR DESCRIPTION
When you call LOAD() on a controller who has some actions decorates with @request.restful(), it fail with:

```
@request.restful()
TypeError: 'NoneType' object is not callable
```

Because LOAD use other_request variable who are a Request but without all methods and therefore without restful method.
I've just inject the restful method.
You can also use LOAD() to call an action decorates with @request.restful().
