### PR TITLE
Prevent error in restful decorator from swallowing up stacktrace

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -356,7 +356,7 @@ class Request(Storage):
                     if len(traceback.extract_tb(exc_traceback)) == 1:
                         raise HTTP(400, "invalid arguments")
                     else:
-                        raise e
+                        raise
             f.__doc__ = action.__doc__
             f.__name__ = action.__name__
             return f


### PR DESCRIPTION
by passing the exception to the raise in the restful decorator, all previous stacktrace is lost, making debugging quite difficult.  Removing the exception just raises the current exception, preserving the stacktrace.
