### PR TITLE
Fix IS_STRONG used with validate_and_update

### DIFF
--- a/gluon/dal.py
+++ b/gluon/dal.py
@@ -10692,7 +10692,7 @@ class Set(object):
         for key, value in update_fields.iteritems():
             value, error = self.db[tablename][key].validate(value)
             if error:
-                response.errors[key] = error
+                response.errors[key] = '%s' % error
             else:
                 new_fields[key] = value
         table = self.db[tablename]


### PR DESCRIPTION
Fix no error return with IS_STRONG validator because it returns a gluon.html.XML instead of str, so when pushed to response.errors that is a Row, it isn't display because Row object filters his output and doesn't support XML objects.
