### PR TITLE
added tests and refactored incorrect docstrings

### DIFF
--- a/gluon/languages.py
+++ b/gluon/languages.py
@@ -324,8 +324,8 @@ def write_dict(filename, contents):
     try:
         fp = LockedFile(filename, 'w')
         fp.write('# -*- coding: utf-8 -*-\n{\n')
-        for key in sorted(contents, sort_function):                          
-            fp.write('%s: %s,\n' % (repr(Utf8(key)), 
+        for key in sorted(contents, sort_function):
+            fp.write('%s: %s,\n' % (repr(Utf8(key)),
                                     repr(Utf8(contents[key]))))
         fp.write('}\n')
     except (IOError, OSError):
@@ -558,18 +558,19 @@ class translator(object):
         self.force(self.http_accept_language)
 
     def plural(self, word, n):
-        """ Gets plural form of word for number *n*
-            invoked from T()/T.M() in `%%{}` tag
+        """
+        Gets plural form of word for number *n*
+        invoked from T()/T.M() in `%%{}` tag
 
-            Args:
-                word (str): word in singular
-                n (numeric): number plural form created for
+        Note:
+            "word" MUST be defined in current language (T.accepted_language)
 
-            Returns:
-                word (str): word in appropriate singular/plural form
+        Args:
+            word (str): word in singular
+            n (numeric): number plural form created for
 
-            Note:
-                "word" MUST be defined in current language (T.accepted_language)
+        Returns:
+            word (str): word in appropriate singular/plural form
 
         """
         if int(n) == 1:

--- a/gluon/restricted.py
+++ b/gluon/restricted.py
@@ -197,8 +197,9 @@ class RestrictedError(Exception):
 
 def compile2(code, layer):
     """
-    The +'\n' is necessary else compile fails when code ends in a comment.
+    The ``+'\\n'`` is necessary else compile fails when code ends in a comment.
     """
+
     return compile(code.rstrip().replace('\r\n', '\n') + '\n', layer, 'exec')
 
 

--- a/gluon/tests/test_html.py
+++ b/gluon/tests/test_html.py
@@ -38,6 +38,7 @@ def fix_sys_path():
 fix_sys_path()
 
 from html import *
+from storage import Storage
 
 
 class TestBareHelpers(unittest.TestCase):
@@ -275,6 +276,45 @@ class TestBareHelpers(unittest.TestCase):
     def testUL(self):
         self.assertEqual(UL('<>', _a='1', _b='2').xml(),
                          '<ul a="1" b="2"><li>&lt;&gt;</li></ul>')
+
+    def testStaticURL(self):
+        # test response.static_version coupled with response.static_version_urls
+        self.assertEqual(URL('a', 'c', 'f'), '/a/c/f')
+        self.assertEqual(URL('a', 'static', 'design.css'), '/a/static/design.css')
+        response = Storage()
+        response.static_version = '1.2.3'
+        from globals import current
+        current.response = response
+        self.assertEqual(URL('a', 'static', 'design.css'), '/a/static/design.css')
+        response.static_version_urls = True
+        self.assertEqual(URL('a', 'static', 'design.css'), '/a/static/_1.2.3/design.css')
+
+    def testURL(self):
+        self.assertEqual(URL('a', 'c', 'f', args='1'), '/a/c/f/1')
+        self.assertEqual(URL('a', 'c', 'f', args=('1', '2')), '/a/c/f/1/2')
+        self.assertEqual(URL('a', 'c', 'f', args=['1', '2']), '/a/c/f/1/2')
+        self.assertEqual(URL('a', 'c', '/f'), '/a/c/f')
+        self.assertEqual(URL('a', 'c', 'f.json'), '/a/c/f.json')
+        self.assertRaises(SyntaxError, URL, *['a'])
+        request = Storage()
+        request.application = 'a'
+        request.controller = 'c'
+        request.function = 'f'
+        request.env = {}
+        from globals import current
+        current.request = request
+        must_return = '/a/c/f'
+        self.assertEqual(URL('f'), must_return)
+        self.assertEqual(URL('c', 'f'), must_return)
+        self.assertEqual(URL('a', 'c', 'f'), must_return)
+        self.assertEqual(URL('a', 'c', 'f', extension='json'), '/a/c/f.json')
+        def weird():
+            pass
+        self.assertEqual(URL('a', 'c', weird), '/a/c/weird')
+        self.assertRaises(SyntaxError, URL, *['a','c', 1])
+
+
+
 
 class TestData(unittest.TestCase):
 

--- a/gluon/tests/test_web.py
+++ b/gluon/tests/test_web.py
@@ -63,6 +63,12 @@ def startwebserver():
     for a in range(1,11):
         time.sleep(1)
         print a, '...'
+        try:
+            c = WebClient('http://127.0.0.1:8000')
+            c.get('/')
+            break
+        except:
+            continue
     print ''
 
 def terminate_process(pid):
@@ -176,7 +182,7 @@ class TestWeb(LiveTest):
         # check internal server error returned (issue 153)
         assert(s.status == 500)
         assert(s.text == xml_response)
-        
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
as a nice bonus, we don't need to wait a fixed number of seconds to see if the server started, we have webclient for it (launch ./web2py.py --run_system_tests and enjoy ~10 seconds less of wait time ^_^)
