### PR TITLE
Added support for stdlib's pbkdf2

### DIFF
--- a/gluon/utils.py
+++ b/gluon/utils.py
@@ -42,18 +42,21 @@ except ImportError:
 
 import hmac
 
-try:
+import hashlib
+
+if hasattr(hashlib, "pbkdf2_hmac"):
+    def pbkdf2_hex(data, salt, iterations=1000, keylen=24, hashfunc=None):
+        hashfunc = hashfunc or sha1
+        return hashlib.pbkdf2_hmac(hashfunc().name,
+                           data, salt, iterations,
+                           keylen).encode("hex")
+
+else:
     try:
         from gluon.contrib.pbkdf2_ctypes import pbkdf2_hex
     except (ImportError, AttributeError):
         from gluon.contrib.pbkdf2 import pbkdf2_hex
-    HAVE_PBKDF2 = True
-except ImportError:
-    try:
-        from .pbkdf2 import pbkdf2_hex
-        HAVE_PBKDF2 = True
-    except (ImportError, ValueError):
-        HAVE_PBKDF2 = False
+
 
 logger = logging.getLogger("web2py")
 


### PR DESCRIPTION
This change should default the pbkdf2 implementation to the stdlib's whenever it is available. This is currently only Python 3.4 but should be available for Python [2.7.8](https://docs.python.org/2.7/library/hashlib.html#hashlib.pbkdf2_hmac) whenever it is released.

Nothing _should_ break although I am not 100% confident of this because this bit of code doesn't appear to be covered by tests.
