### PR TITLE
mssql4 adapter enhancements

### DIFF
--- a/gluon/dal.py
+++ b/gluon/dal.py
@@ -3575,6 +3575,35 @@ class MSSQL4Adapter(MSSQLAdapter):
 
     Requires MSSQL >= 2012, uses `OFFSET ... ROWS ... FETCH NEXT ... ROWS ONLY`
     """
+    
+    types = {
+    'boolean': 'BIT',
+    'string': 'VARCHAR(%(length)s)',
+    'text': 'VARCHAR(MAX)',
+    'json': 'VARCHAR(MAX)',
+    'password': 'VARCHAR(%(length)s)',
+    'blob': 'IMAGE',
+    'upload': 'VARCHAR(%(length)s)',
+    'integer': 'INT',
+    'bigint': 'BIGINT',
+    'float': 'FLOAT',
+    'double': 'FLOAT',
+    'decimal': 'NUMERIC(%(precision)s,%(scale)s)',
+    'date': 'DATETIME',
+    'time': 'TIME(7)',
+    'datetime': 'DATETIME',
+    'id': 'INT IDENTITY PRIMARY KEY',
+    'reference': 'INT NULL, CONSTRAINT %(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
+    'list:integer': 'VARCHAR(MAX)',
+    'list:string': 'VARCHAR(MAX)',
+    'list:reference': 'VARCHAR(MAX)',
+    'geometry': 'geometry',
+    'geography': 'geography',
+    'big-id': 'BIGINT IDENTITY PRIMARY KEY',
+    'big-reference': 'BIGINT NULL, CONSTRAINT %(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
+    'reference FK': ', CONSTRAINT FK_%(constraint_name)s FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_key)s ON DELETE %(on_delete_action)s',
+    'reference TFK': ' CONSTRAINT FK_%(foreign_table)s_PK FOREIGN KEY (%(field_name)s) REFERENCES %(foreign_table)s (%(foreign_key)s) ON DELETE %(on_delete_action)s',
+     }
 
     def select_limitby(self, sql_s, sql_f, sql_t, sql_w, sql_o, limitby):
         if limitby:


### PR DESCRIPTION
Given that mssql4 requires MSSQL2012, we can use newer types for data
without worrying about compatibility with older MSSQL versions
