### PR TITLE
Changed a condition in order to not show `None` if there is no errors

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -2442,7 +2442,7 @@ class SQLFORM(FORM):
                 message = T('at least %(nrows)s records found') % dict(nrows=nrows)
             else:
                 message = T('%(nrows)s records found') % dict(nrows=nrows)
-        console.append(DIV(message or T('None'), _class='web2py_counter'))
+        console.append(DIV(message or '', _class='web2py_counter'))
 
         paginator = UL()
         if paginate and dbset._db._adapter.dbengine == 'google:datastore':


### PR DESCRIPTION
Changed a condition in order to not show `None` if there is not error. When we don't get errors "None" is printed: `message or T('None')`.

I guess is better not to print anything: `message or ''` because we don't have errors.  `message` has the same effect as `message or T('None')`
