### PR TITLE
bootstrap3 formstyle improvements

### DIFF
--- a/applications/welcome/models/db.py
+++ b/applications/welcome/models/db.py
@@ -25,7 +25,11 @@ else:
 ## by default give a view/generic.extension to all actions from localhost
 ## none otherwise. a pattern can be 'controller/function.extension'
 response.generic_patterns = ['*'] if request.is_local else []
-response.formstyle = 'bootstrap3'
+if request.vars.h:
+    from gluon.sqlhtml import formstyle_bootstrap3_horizontal
+    response.formstyle = formstyle_bootstrap3_horizontal(3)
+else:
+    response.formstyle = 'bootstrap3'
 ## (optional) optimize handling of static files
 # response.optimize_css = 'concat,minify,inline'
 # response.optimize_js = 'concat,minify,inline'


### PR DESCRIPTION
Better bootstrap3 formstyles (I hope).

I modified the formstyle_bootstrap3 and added a formstyle_bootstrap3_horizontal to gluon/sqlhtml.py.

They can be tested with welcome application. You can append in the browser ?h=1 to see the
horizontal formstyle.

Do not blindly merge this pull request. Probably it will need to be discussed first.

Does make sense to ship 2 formstyles?
if not, which one?
