### PR TITLE
Clear passwords on failed registration

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -2780,6 +2780,8 @@ class Auth(object):
             else:
                 next = replace_id(next, form)
             redirect(next, client_side=self.settings.client_side)
+        else:
+        	[input.update(_value='') for input in form.elements('[type=password]')]
         return form
 
     def is_logged_in(self):


### PR DESCRIPTION
For security, when the register form fails validation, do not return the plain text passwords in the HTML.
