### PR TITLE
Fix LOAD on action @request.restful()

### DIFF
--- a/gluon/compileapp.py
+++ b/gluon/compileapp.py
@@ -38,6 +38,7 @@ import marshal
 import shutil
 import imp
 import logging
+import types
 logger = logging.getLogger("web2py")
 from gluon import rewrite
 from custom_import import custom_import_install
@@ -211,7 +212,7 @@ def LOAD(c=None, f='index', args=None, vars=None,
             request.env.path_info
         other_request.cid = target
         other_request.env.http_web2py_component_element = target
-        other_request.restful = request.restful  # Needed when you call LOAD() on a controller who has some actions decorates with @request.restful()
+        other_request.restful = types.MethodType(request.restful.im_func, other_request) # A bit nasty but needed to use LOAD on action decorates with @request.restful()
         other_response.view = '%s/%s.%s' % (c, f, other_request.extension)
 
         other_environment = copy.copy(current.globalenv)  # NASTY


### PR DESCRIPTION
LOAD didn't work on action decorated with @request.restful() when args and/or vars are passed because the restful method is called with the main "request" object (browser url action) instead of the "other_request" object used by LOAD.
So I have injected the restful method with the good object context.
It's a bit nasty, so if someone knows how to do it better, I'm happy.
