### PR TITLE
fix grid groupby with more than 2 Fields in the expression

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -2111,6 +2111,8 @@ class SQLFORM(FORM):
                 field_id = groupby #take the field passed as groupby
             elif groupby and isinstance(groupby, Expression):
                 field_id = groupby.first #take the first groupby field
+                while not(isinstance(field_id, Field)): # Navigate to the first Field of the expression
+                    field_id = field_id.first
         table = field_id.table
         tablename = table._tablename
         if not any(str(f) == str(field_id) for f in fields):


### PR DESCRIPTION
There is an issue with SQLFORM.grid when we pass a groupby composed of more than 2 fields.
This PR is a way to fix it, I suppose there are other approaches to fix it
Test case

``` python
db = DAL('sqlite://test_grid')
db.define_table('person',
    Field('name'), Field('city'), Field('age', 'integer')
)
def test_grid():
    grid=SQLFORM.grid(db.person, user_signature=False, formname='grid')
    return {'grid':grid, 'grid_js':LOAD('test', 'grid_js', ajax=True)}

def grid_js():
    groupby = db.person.name|db.person.age|db.person.city
    grid=SQLFORM.grid(db.person, fields=[db.person.name], groupby=groupby, user_signature=False, formname='gridjs')
    return grid
```

A workaround is

``` python
    groupby = db.person.name|(db.person.age|db.person.city)
```
