### PR TITLE
Forces scheduler_worker.worker_stats to be JSON string

### DIFF
--- a/gluon/scheduler.py
+++ b/gluon/scheduler.py
@@ -960,7 +960,7 @@ class Scheduler(MetaScheduler):
                 sw.insert(status=ACTIVE, worker_name=self.worker_name,
                           first_heartbeat=now, last_heartbeat=now,
                           group_names=self.group_names,
-                          worker_stats=self.w_stats)
+                          worker_stats=dumps(self.w_stats))
                 self.w_stats.status = ACTIVE
                 self.w_stats.sleep = self.heartbeat
                 mybackedstatus = ACTIVE
@@ -973,7 +973,7 @@ class Scheduler(MetaScheduler):
                         self.w_stats.status)
                     db(sw.worker_name == self.worker_name).update(
                         last_heartbeat=now,
-                        worker_stats=self.w_stats)
+                        worker_stats=dumps(self.w_stats))
                 elif mybackedstatus == TERMINATE:
                     self.w_stats.status = TERMINATE
                     logger.debug("Waiting to terminate the current task")
@@ -990,7 +990,7 @@ class Scheduler(MetaScheduler):
                         self.w_stats.status)
                     db(sw.worker_name == self.worker_name).update(
                         last_heartbeat=now, status=ACTIVE,
-                        worker_stats=self.w_stats)
+                        worker_stats=dumps(self.w_stats))
                     self.w_stats.sleep = self.heartbeat  # re-activating the process
                     if self.w_stats.status != RUNNING:
                         self.w_stats.status = ACTIVE
@@ -1406,7 +1406,7 @@ class Scheduler(MetaScheduler):
                 last_heartbeat=row.last_heartbeat,
                 group_names=row.group_names,
                 is_ticker=row.is_ticker,
-                worker_stats=row.worker_stats
+                worker_stats=Storage(loads(row.worker_stats))
             )
         return all_workers
 


### PR DESCRIPTION
In gluon/scheduler we attempt to send a Storage() variable to the worker_stats field, which gets converted to a string during the INSERT.

For (at least) PostgreSQL JSON fields, this isn't valid:

```
2014-09-12 05:28:26,421 - web2py.scheduler.bastille-9.local#29597 - send_heartbeat scheduler ERROR - Error retrieving status: invalid input syntax for type json
LINE 1: ...heartbeat) VALUES ('ACTIVE','2014-09-12 05:28:26','<Storage ...
                                                             ^
DETAIL:  Token "<" is invalid.
CONTEXT:  JSON data, line 1: <...
```

This PR uses the simplejson dumps/loads functions to convert between Storage() and JSON field content. It needs further review to see if it will break other things down the line.
