### PR TITLE
Fixed #1810: DAL.select(left=...) causes "Unknown column 't1.i1' in 'on ...

### DIFF
--- a/gluon/dal.py
+++ b/gluon/dal.py
@@ -1767,12 +1767,17 @@ class BaseAdapter(ConnectionPool):
         sql_w = ' WHERE ' + self.expand(query) if query else ''
 
         if inner_join and not left:
-            sql_t = ', '.join([self.table_alias(t)
+            # Wrap table references with parenthesis (approach 1)
+            # sql_t = ', '.join([self.table_alias(t)
+            #                    for t in iexcluded + itables_to_merge.keys()])
+            # sql_t = '(%s)' % sql_t
+            # or approach 2: Use 'JOIN' instead comma:
+            sql_t = ' JOIN '.join([self.table_alias(t)
                                for t in iexcluded + itables_to_merge.keys()])
             for t in ijoinon:
                 sql_t += ' %s %s' % (icommand, t)
         elif not inner_join and left:
-            sql_t = ', '.join([self.table_alias(t)
+            sql_t = ' JOIN '.join([self.table_alias(t)
                                for t in excluded + tables_to_merge.keys()])
             if joint:
                 sql_t += ' %s %s' % (command,
@@ -1785,7 +1790,7 @@ class BaseAdapter(ConnectionPool):
             tables_in_joinon = set(joinont + ijoinont)
             tables_not_in_joinon = \
                 all_tables_in_query.difference(tables_in_joinon)
-            sql_t = ','.join([self.table_alias(t) for t in tables_not_in_joinon])
+            sql_t = ' JOIN '.join([self.table_alias(t) for t in tables_not_in_joinon])
             for t in ijoinon:
                 sql_t += ' %s %s' % (icommand, t)
             if joint:


### PR DESCRIPTION
...clause'"

According to the MySQL 5.5 manual [1], comma-separated table references in joins
should be wrapped in parenthesis or JOIN should be used instead of comma.

Further explanation from the manual: The ON clause takes precedence since
a couple of versions so the operands for the ON clause change:

SELECT \* FROM t1, t2 JOIN t3 ON (t1.i1 = t3.i3);

The operands for the ON are t2 and t3. t1.i1 is not known at this point.

[1] https://dev.mysql.com/doc/refman/5.5/en/join.html
