### PR TITLE
fix cache.increment, added tests

### DIFF
--- a/gluon/cache.py
+++ b/gluon/cache.py
@@ -357,7 +357,7 @@ class CacheOnDisk(CacheAbstract):
             os.mkdir(folder)
 
         self.storage = CacheOnDisk.PersistentStorage(folder)
-        
+
         if not CacheAbstract.cache_stats_name in self.storage:
             self.storage[CacheAbstract.cache_stats_name] = {'hit_total': 0, 'misses': 0}
 
@@ -402,7 +402,13 @@ class CacheOnDisk(CacheAbstract):
 
     def increment(self, key, value=1):
         self.initialize()
-        self.storage[key] += value
+        storage = self.storage
+        try:
+            if key in storage:
+                value = storage[key][1] + value
+            storage[key] = (time.time(), value)
+        except:
+            pass
         return value
 
 
@@ -445,7 +451,7 @@ class Cache(object):
 
     def __init__(self, request):
         """
-        Args: 
+        Args:
             request: the global request object
         """
         # GAE will have a special caching

--- a/gluon/tests/test_cache.py
+++ b/gluon/tests/test_cache.py
@@ -40,7 +40,7 @@ fix_sys_path()
 
 
 from storage import Storage
-from cache import CacheInRam, CacheOnDisk
+from cache import CacheInRam, CacheOnDisk, Cache
 
 oldcwd = None
 
@@ -76,6 +76,20 @@ class TestCache(unittest.TestCase):
         cache.clear()
         self.assertEqual(cache('a', lambda: 3, 100), 3)
         self.assertEqual(cache('a', lambda: 4, 0), 4)
+        #test singleton behaviour
+        cache = CacheInRam()
+        cache.clear()
+        self.assertEqual(cache('a', lambda: 3, 100), 3)
+        self.assertEqual(cache('a', lambda: 4, 0), 4)
+        #test key deletion
+        cache('a', None)
+        self.assertEqual(cache('a', lambda: 5, 100), 5)
+        #test increment
+        self.assertEqual(cache.increment('a'), 6)
+        self.assertEqual(cache('a', lambda: 1, 100), 6)
+        cache.increment('b')
+        self.assertEqual(cache('b', lambda: 'x', 100), 1)
+
 
     def testCacheOnDisk(self):
 
@@ -93,6 +107,30 @@ class TestCache(unittest.TestCase):
         cache.clear()
         self.assertEqual(cache('a', lambda: 3, 100), 3)
         self.assertEqual(cache('a', lambda: 4, 0), 4)
+        #test singleton behaviour
+        cache = CacheOnDisk(s)
+        cache.clear()
+        self.assertEqual(cache('a', lambda: 3, 100), 3)
+        self.assertEqual(cache('a', lambda: 4, 0), 4)
+        #test key deletion
+        cache('a', None)
+        self.assertEqual(cache('a', lambda: 5, 100), 5)
+        #test increment
+        self.assertEqual(cache.increment('a'), 6)
+        self.assertEqual(cache('a', lambda: 1, 100), 6)
+        cache.increment('b')
+        self.assertEqual(cache('b', lambda: 'x', 100), 1)
+
+    def testCacheWithPrefix(self):
+        s = Storage({'application': 'admin',
+                     'folder': 'applications/admin'})
+        cache = Cache(s)
+        prefix = cache.with_prefix(cache.ram,'prefix')
+        self.assertEqual(prefix('a', lambda: 1, 0), 1)
+        self.assertEqual(prefix('a', lambda: 2, 100), 1)
+        self.assertEqual(cache.ram('prefixa', lambda: 2, 100), 1)
+
+
 
 
 if __name__ == '__main__':

--- a/gluon/tests/test_dal.py
+++ b/gluon/tests/test_dal.py
@@ -564,7 +564,7 @@ class TestMinMaxSumAvg(unittest.TestCase):
         db.tt.drop()
 
 
-class TestCache(unittest.TestCase):
+class TestSelectCache(unittest.TestCase):
     def testRun(self):
         from cache import CacheInRam
         cache = CacheInRam()

--- a/gluon/tests/test_languages.py
+++ b/gluon/tests/test_languages.py
@@ -63,6 +63,10 @@ try:
     #due to http://bugs.python.org/issue10845, testing multiprocessing in python is impossible
     if sys.platform.startswith('win'):
         MP_WORKING = 0
+    #multiprocessing is also not available on GAE. Since tests randomly
+    #fail, let's not make them on it too
+    if 'datastore' in os.getenv('DB', ''):
+        MP_WORKING = 0
 except ImportError:
     pass
 


### PR DESCRIPTION
in addition to that, weird things happen with coverage when test cases have the same name..... go figure. Anyway, the coverage for cache.py is now up to 61% vs 29%.
