### PR TITLE
fix for StorageList and tests added

### DIFF
--- a/gluon/storage.py
+++ b/gluon/storage.py
@@ -151,10 +151,10 @@ class StorageList(Storage):
 
     def __getattr__(self, key):
         if key in self:
-            return getattr(self, key)
+            return self.get(key)
         else:
             r = []
-            setattr(self, key, r)
+            self[key] = r
             return r
 
 

--- a/gluon/tests/__init__.py
+++ b/gluon/tests/__init__.py
@@ -2,14 +2,8 @@ import os, sys
 
 from test_http import *
 from test_cache import *
-
-NOSQL = any([name in (os.getenv("DB") or "")
-             for name in ("datastore", "mongodb", "imap")])
-if NOSQL:
-    from test_dal_nosql import *
-else:
-    from test_dal import *
-
+from test_contenttype import *
+from test_fileutils import *
 from test_html import *
 from test_is_url import *
 from test_languages import *
@@ -25,3 +19,12 @@ from test_web import *
 
 if sys.version[:3] == '2.7':
     from test_old_doctests import *
+
+
+NOSQL = any([name in (os.getenv("DB") or "")
+        	for name in ("datastore", "mongodb", "imap")])
+
+if NOSQL:
+    from test_dal_nosql import *
+else:
+    from test_dal import *

--- a/gluon/tests/fix_path.py
+++ b/gluon/tests/fix_path.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+import sys
+
+def fix_sys_path(current_path):
+    """
+    logic to have always the correct sys.path
+     '', web2py/gluon, web2py/site-packages, web2py/ ...
+    """
+
+    def add_path_first(path):
+        sys.path = [path] + [p for p in sys.path if (
+            not p == path and not p == (path + '/'))]
+
+    path = os.path.dirname(os.path.abspath(current_path))
+
+    if not os.path.isfile(os.path.join(path,'web2py.py')):
+        i = 0
+        while i<10:
+            i += 1
+            if os.path.exists(os.path.join(path,'web2py.py')):
+                break
+            path = os.path.abspath(os.path.join(path, '..'))
+
+    paths = [path,
+             os.path.abspath(os.path.join(path, 'site-packages')),
+             os.path.abspath(os.path.join(path, 'gluon')),
+             '']
+    [add_path_first(path) for path in paths]

--- a/gluon/tests/test_cache.py
+++ b/gluon/tests/test_cache.py
@@ -4,39 +4,11 @@
 """
     Unit tests for gluon.cache
 """
-
-import sys
 import os
 import unittest
+from fix_path import fix_sys_path
 
-
-def fix_sys_path():
-    """
-    logic to have always the correct sys.path
-     '', web2py/gluon, web2py/site-packages, web2py/ ...
-    """
-
-    def add_path_first(path):
-        sys.path = [path] + [p for p in sys.path if (
-            not p == path and not p == (path + '/'))]
-
-    path = os.path.dirname(os.path.abspath(__file__))
-
-    if not os.path.isfile(os.path.join(path,'web2py.py')):
-        i = 0
-        while i<10:
-            i += 1
-            if os.path.exists(os.path.join(path,'web2py.py')):
-                break
-            path = os.path.abspath(os.path.join(path, '..'))
-
-    paths = [path,
-             os.path.abspath(os.path.join(path, 'site-packages')),
-             os.path.abspath(os.path.join(path, 'gluon')),
-             '']
-    [add_path_first(path) for path in paths]
-
-fix_sys_path()
+fix_sys_path(__file__)
 
 
 from storage import Storage

--- a/gluon/tests/test_contenttype.py
+++ b/gluon/tests/test_contenttype.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+    Unit tests for gluon.contenttype
+"""
+
+import unittest
+from fix_path import fix_sys_path
+
+fix_sys_path(__file__)
+
+from contenttype import contenttype
+
+
+class TestContentType(unittest.TestCase):
+
+    def testTypeRecognition(self):
+        rtn = contenttype('.png')
+        self.assertEqual(rtn, 'image/png')
+        rtn = contenttype('.gif')
+        self.assertEqual(rtn, 'image/gif')
+        rtn = contenttype('.tar.bz2')
+        self.assertEqual(rtn, 'application/x-bzip-compressed-tar')
+        # test overrides and additions
+        mapping = {
+            '.load': 'text/html; charset=utf-8',
+            '.json': 'application/json',
+            '.jsonp': 'application/jsonp',
+            '.pickle': 'application/python-pickle',
+            '.w2p': 'application/w2p',
+            '.md': 'text/x-markdown; charset=utf-8'
+        }
+        for k, v in mapping.iteritems():
+            self.assertEqual(contenttype(k), v)
+
+        # test without dot extension
+        rtn = contenttype('png')
+        self.assertEqual(rtn, 'text/plain; charset=utf-8')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gluon/tests/test_contribs.py
+++ b/gluon/tests/test_contribs.py
@@ -3,37 +3,10 @@
 
 """ Unit tests for contribs """
 
-import sys
-import os
 import unittest
+from fix_path import fix_sys_path
 
-def fix_sys_path():
-    """
-    logic to have always the correct sys.path
-     '', web2py/gluon, web2py/site-packages, web2py/ ...
-    """
-
-    def add_path_first(path):
-        sys.path = [path] + [p for p in sys.path if (
-            not p == path and not p == (path + '/'))]
-
-    path = os.path.dirname(os.path.abspath(__file__))
-
-    if not os.path.isfile(os.path.join(path,'web2py.py')):
-        i = 0
-        while i<10:
-            i += 1
-            if os.path.exists(os.path.join(path,'web2py.py')):
-                break
-            path = os.path.abspath(os.path.join(path, '..'))
-
-    paths = [path,
-             os.path.abspath(os.path.join(path, 'site-packages')),
-             os.path.abspath(os.path.join(path, 'gluon')),
-             '']
-    [add_path_first(path) for path in paths]
-
-fix_sys_path()
+fix_sys_path(__file__)
 
 
 from utils import md5_hash

--- a/gluon/tests/test_dal.py
+++ b/gluon/tests/test_dal.py
@@ -15,40 +15,17 @@ try:
 except:
     from io import StringIO
 
-def fix_sys_path():
-    """
-    logic to have always the correct sys.path
-     '', web2py/gluon, web2py/site-packages, web2py/ ...
-    """
+from fix_path import fix_sys_path
 
-    def add_path_first(path):
-        sys.path = [path] + [p for p in sys.path if (
-            not p == path and not p == (path + '/'))]
-
-    path = os.path.dirname(os.path.abspath(__file__))
-
-    if not os.path.isfile(os.path.join(path,'web2py.py')):
-        i = 0
-        while i<10:
-            i += 1
-            if os.path.exists(os.path.join(path,'web2py.py')):
-                break
-            path = os.path.abspath(os.path.join(path, '..'))
-
-    paths = [path,
-             os.path.abspath(os.path.join(path, 'site-packages')),
-             os.path.abspath(os.path.join(path, 'gluon')),
-             '']
-    [add_path_first(path) for path in paths]
-
-fix_sys_path()
+fix_sys_path(__file__)
 
 #for travis-ci
-DEFAULT_URI = os.environ.get('DB', 'sqlite:memory')
+DEFAULT_URI = os.getenv('DB', 'sqlite:memory')
 
 print 'Testing against %s engine (%s)' % (DEFAULT_URI.partition(':')[0], DEFAULT_URI)
 
 from dal import DAL, Field, Table, SQLALL
+from gluon.cache import CacheInRam
 
 ALLOWED_DATATYPES = [
     'string',
@@ -564,9 +541,8 @@ class TestMinMaxSumAvg(unittest.TestCase):
         db.tt.drop()
 
 
-class TestSelectCache(unittest.TestCase):
+class TestCacheSelect(unittest.TestCase):
     def testRun(self):
-        from cache import CacheInRam
         cache = CacheInRam()
         db = DAL(DEFAULT_URI, check_reserved=['all'])
         db.define_table('tt', Field('aa'))
@@ -1459,7 +1435,6 @@ class TestQuoting(unittest.TestCase):
                 db._adapter.types[key]=db._adapter.types[key].replace(
                 '%(on_delete_action)s','NO ACTION')
 
-                
         t0 = db.define_table('t0',
                         Field('f', 'string'))
         t1 = db.define_table('b',

--- a/gluon/tests/test_dal_nosql.py
+++ b/gluon/tests/test_dal_nosql.py
@@ -19,34 +19,9 @@ try:
 except:
     from io import StringIO
 
+from fix_path import fix_sys_path
 
-def fix_sys_path():
-    """
-    logic to have always the correct sys.path
-     '', web2py/gluon, web2py/site-packages, web2py/ ...
-    """
-
-    def add_path_first(path):
-        sys.path = [path] + [p for p in sys.path if (
-            not p == path and not p == (path + '/'))]
-
-    path = os.path.dirname(os.path.abspath(__file__))
-
-    if not os.path.isfile(os.path.join(path,'web2py.py')):
-        i = 0
-        while i<10:
-            i += 1
-            if os.path.exists(os.path.join(path,'web2py.py')):
-                break
-            path = os.path.abspath(os.path.join(path, '..'))
-
-    paths = [path,
-             os.path.abspath(os.path.join(path, 'site-packages')),
-             os.path.abspath(os.path.join(path, 'gluon')),
-             '']
-    [add_path_first(path) for path in paths]
-
-fix_sys_path()
+fix_sys_path(__file__)
 
 #for travis-ci
 DEFAULT_URI = os.environ.get('DB', 'sqlite:memory')

--- a/gluon/tests/test_fileutils.py
+++ b/gluon/tests/test_fileutils.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+import datetime
+from fix_path import fix_sys_path
+
+fix_sys_path(__file__)
+
+from fileutils import parse_version
+
+
+class TestFileUtils(unittest.TestCase):
+
+    def testParseVersion(self):
+        rtn = parse_version('Version 1.99.0-rc.1+timestamp.2011.09.19.08.23.26')
+        self.assertEqual(rtn, (1, 99, 0, 'rc.1', datetime.datetime(2011, 9, 19, 8, 23, 26)))
+        rtn = parse_version('Version 2.9.11-stable+timestamp.2014.09.15.18.31.17')
+        self.assertEqual(rtn, (2, 9, 11, 'stable', datetime.datetime(2014, 9, 15, 18, 31, 17)))
+        rtn = parse_version('Version 1.99.0 (2011-09-19 08:23:26)')
+        self.assertEqual(rtn, (1, 99, 0, 'dev', datetime.datetime(2011, 9, 19, 8, 23, 26)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gluon/tests/test_html.py
+++ b/gluon/tests/test_html.py
@@ -5,37 +5,10 @@
     Unit tests for gluon.html
 """
 
-import sys
-import os
 import unittest
+from fix_path import fix_sys_path
 
-def fix_sys_path():
-    """
-    logic to have always the correct sys.path
-     '', web2py/gluon, web2py/site-packages, web2py/ ...
-    """
-
-    def add_path_first(path):
-        sys.path = [path] + [p for p in sys.path if (
-            not p == path and not p == (path + '/'))]
-
-    path = os.path.dirname(os.path.abspath(__file__))
-
-    if not os.path.isfile(os.path.join(path,'web2py.py')):
-        i = 0
-        while i<10:
-            i += 1
-            if os.path.exists(os.path.join(path,'web2py.py')):
-                break
-            path = os.path.abspath(os.path.join(path, '..'))
-
-    paths = [path,
-             os.path.abspath(os.path.join(path, 'site-packages')),
-             os.path.abspath(os.path.join(path, 'gluon')),
-             '']
-    [add_path_first(path) for path in paths]
-
-fix_sys_path()
+fix_sys_path(__file__)
 
 from html import *
 from storage import Storage

--- a/gluon/tests/test_http.py
+++ b/gluon/tests/test_http.py
@@ -3,38 +3,10 @@
 
 """Unit tests for http.py """
 
-import sys
-import os
 import unittest
+from fix_path import fix_sys_path
 
-
-def fix_sys_path():
-    """
-    logic to have always the correct sys.path
-     '', web2py/gluon, web2py/site-packages, web2py/ ...
-    """
-
-    def add_path_first(path):
-        sys.path = [path] + [p for p in sys.path if (
-            not p == path and not p == (path + '/'))]
-
-    path = os.path.dirname(os.path.abspath(__file__))
-
-    if not os.path.isfile(os.path.join(path,'web2py.py')):
-        i = 0
-        while i<10:
-            i += 1
-            if os.path.exists(os.path.join(path,'web2py.py')):
-                break
-            path = os.path.abspath(os.path.join(path, '..'))
-
-    paths = [path,
-             os.path.abspath(os.path.join(path, 'site-packages')),
-             os.path.abspath(os.path.join(path, 'gluon')),
-             '']
-    [add_path_first(path) for path in paths]
-
-fix_sys_path()
+fix_sys_path(__file__)
 
 
 from http import HTTP, defined_status
@@ -67,9 +39,6 @@ class TestHTTP(unittest.TestCase):
                              gen_status_str(code, message))
 
         # test wrong call detection
-
-
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/gluon/tests/test_is_url.py
+++ b/gluon/tests/test_is_url.py
@@ -4,42 +4,14 @@
 Unit tests for IS_URL()
 """
 
-import sys
-import os
 import unittest
+from fix_path import fix_sys_path
+
+fix_sys_path(__file__)
 
 
-def fix_sys_path():
-    """
-    logic to have always the correct sys.path
-     '', web2py/gluon, web2py/site-packages, web2py/ ...
-    """
-
-    def add_path_first(path):
-        sys.path = [path] + [p for p in sys.path if (
-            not p == path and not p == (path + '/'))]
-
-    path = os.path.dirname(os.path.abspath(__file__))
-
-    if not os.path.isfile(os.path.join(path,'web2py.py')):
-        i = 0
-        while i<10:
-            i += 1
-            if os.path.exists(os.path.join(path,'web2py.py')):
-                break
-            path = os.path.abspath(os.path.join(path, '..'))
-
-    paths = [path,
-             os.path.abspath(os.path.join(path, 'site-packages')),
-             os.path.abspath(os.path.join(path, 'gluon')),
-             '']
-    [add_path_first(path) for path in paths]
-
-fix_sys_path()
-
-
-from validators import IS_URL, IS_HTTP_URL, IS_GENERIC_URL, \
-    unicode_to_ascii_authority
+from validators import IS_URL, IS_HTTP_URL, IS_GENERIC_URL
+from validators import unicode_to_ascii_authority
 
 
 class TestIsUrl(unittest.TestCase):

--- a/gluon/tests/test_languages.py
+++ b/gluon/tests/test_languages.py
@@ -7,38 +7,11 @@
 
 import sys
 import os
-import unittest
 import tempfile
-import threading
-import logging
+import unittest
+from fix_path import fix_sys_path
 
-def fix_sys_path():
-    """
-    logic to have always the correct sys.path
-     '', web2py/gluon, web2py/site-packages, web2py/ ...
-    """
-
-    def add_path_first(path):
-        sys.path = [path] + [p for p in sys.path if (
-            not p == path and not p == (path + '/'))]
-
-    path = os.path.dirname(os.path.abspath(__file__))
-
-    if not os.path.isfile(os.path.join(path,'web2py.py')):
-        i = 0
-        while i<10:
-            i += 1
-            if os.path.exists(os.path.join(path,'web2py.py')):
-                break
-            path = os.path.abspath(os.path.join(path, '..'))
-
-    paths = [path,
-             os.path.abspath(os.path.join(path, 'site-packages')),
-             os.path.abspath(os.path.join(path, 'gluon')),
-             '']
-    [add_path_first(path) for path in paths]
-
-fix_sys_path()
+fix_sys_path(__file__)
 
 #support skipif also in python 2.6
 def _skipIf(cond, message=''):
@@ -55,17 +28,12 @@ else:
     skipIf = _skipIf
 
 import languages
-from storage import Storage
 MP_WORKING = 0
 try:
     import multiprocessing
     MP_WORKING = 1
     #due to http://bugs.python.org/issue10845, testing multiprocessing in python is impossible
     if sys.platform.startswith('win'):
-        MP_WORKING = 0
-    #multiprocessing is also not available on GAE. Since tests randomly
-    #fail, let's not make them on it too
-    if 'datastore' in os.getenv('DB', ''):
         MP_WORKING = 0
 except ImportError:
     pass
@@ -79,6 +47,7 @@ def read_write(args):
             return False
         languages.write_dict(filename, content)
     return True
+
 
 class TestLanguagesParallel(unittest.TestCase):
 
@@ -95,7 +64,7 @@ class TestLanguagesParallel(unittest.TestCase):
             os.remove(self.filename)
         except:
             pass
-    
+
     @skipIf(MP_WORKING == 0, 'multiprocessing tests unavailable')
     def test_reads_and_writes(self):
         readwriters = 10
@@ -103,7 +72,7 @@ class TestLanguagesParallel(unittest.TestCase):
         results = pool.map(read_write, [[self.filename, 10]] * readwriters)
         for result in results:
             self.assertTrue(result)
-    
+
     @skipIf(MP_WORKING == 1, 'multiprocessing tests available')
     def test_reads_and_writes_no_mp(self):
         results = []
@@ -111,6 +80,7 @@ class TestLanguagesParallel(unittest.TestCase):
             results.append(read_write([self.filename, 10]))
         for result in results:
             self.assertTrue(result)
+
 
 class TestTranslations(unittest.TestCase):
 
@@ -148,7 +118,6 @@ class TestTranslations(unittest.TestCase):
         T.force('it')
         self.assertEqual(str(T('Hello World')),
                          'Salve Mondo')
-      
+
 if __name__ == '__main__':
     unittest.main()
-    

--- a/gluon/tests/test_old_doctests.py
+++ b/gluon/tests/test_old_doctests.py
@@ -7,41 +7,15 @@
 """
 import sys
 import os
-import unittest
 import doctest
+import unittest
+from fix_path import fix_sys_path
 
+fix_sys_path(__file__)
 
-def fix_sys_path():
-    """
-    logic to have always the correct sys.path
-     '', web2py/gluon, web2py/site-packages, web2py/ ...
-    """
-
-    def add_path_first(path):
-        sys.path = [path] + [p for p in sys.path if (
-            not p == path and not p == (path + '/'))]
-
-    path = os.path.dirname(os.path.abspath(__file__))
-
-    if not os.path.isfile(os.path.join(path,'web2py.py')):
-        i = 0
-        while i<10:
-            i += 1
-            if os.path.exists(os.path.join(path,'web2py.py')):
-                break
-            path = os.path.abspath(os.path.join(path, '..'))
-
-    paths = [path,
-             os.path.abspath(os.path.join(path, 'site-packages')),
-             os.path.abspath(os.path.join(path, 'gluon')),
-             '']
-    [add_path_first(path) for path in paths]
-
-fix_sys_path()
 
 def load_tests(loader, tests, ignore):
 
-    
     tests.addTests(
         doctest.DocTestSuite('html')
         )

--- a/gluon/tests/test_storage.py
+++ b/gluon/tests/test_storage.py
@@ -3,40 +3,13 @@
 
 """ Unit tests for storage.py """
 
-import sys
-import os
 import unittest
+from fix_path import fix_sys_path
 
+fix_sys_path(__file__)
 
-def fix_sys_path():
-    """
-    logic to have always the correct sys.path
-     '', web2py/gluon, web2py/site-packages, web2py/ ...
-    """
-
-    def add_path_first(path):
-        sys.path = [path] + [p for p in sys.path if (
-            not p == path and not p == (path + '/'))]
-
-    path = os.path.dirname(os.path.abspath(__file__))
-
-    if not os.path.isfile(os.path.join(path,'web2py.py')):
-        i = 0
-        while i<10:
-            i += 1
-            if os.path.exists(os.path.join(path,'web2py.py')):
-                break
-            path = os.path.abspath(os.path.join(path, '..'))
-
-    paths = [path,
-             os.path.abspath(os.path.join(path, 'site-packages')),
-             os.path.abspath(os.path.join(path, 'gluon')),
-             '']
-    [add_path_first(path) for path in paths]
-
-fix_sys_path()
-
-from storage import Storage
+from storage import Storage, StorageList, List
+from http import HTTP
 import pickle
 
 
@@ -97,13 +70,71 @@ class TestStorage(unittest.TestCase):
         self.assertEquals(s.a, None)
         self.assertEquals(s['a'], None)
         self.assertTrue('a' in s)
-    
+
     def test_pickling(self):
         """ Test storage pickling """
         s = Storage(a=1)
         sd = pickle.dumps(s, pickle.HIGHEST_PROTOCOL)
         news = pickle.loads(sd)
         self.assertEqual(news.a, 1)
+
+    def test_getlist(self):
+        # usually used with request.vars
+        a = Storage()
+        a.x = 'abc'
+        a.y = ['abc', 'def']
+        self.assertEqual(a.getlist('x'), ['abc'])
+        self.assertEqual(a.getlist('y'), ['abc', 'def'])
+        self.assertEqual(a.getlist('z'), [])
+
+    def test_getfirst(self):
+        # usually with request.vars
+        a = Storage()
+        a.x = 'abc'
+        a.y = ['abc', 'def']
+        self.assertEqual(a.getfirst('x'), 'abc')
+        self.assertEqual(a.getfirst('y'), 'abc')
+        self.assertEqual(a.getfirst('z'), None)
+
+    def test_getlast(self):
+        # usually with request.vars
+        a = Storage()
+        a.x = 'abc'
+        a.y = ['abc', 'def']
+        self.assertEqual(a.getlast('x'), 'abc')
+        self.assertEqual(a.getlast('y'), 'def')
+        self.assertEqual(a.getlast('z'), None)
+
+
+class TestStorageList(unittest.TestCase):
+    """ Tests storage.StorageList """
+
+    def test_attribute(self):
+        s = StorageList(a=1)
+
+        self.assertEqual(s.a, 1)
+        self.assertEqual(s['a'], 1)
+        self.assertEqual(s.b, [])
+        s.b.append(1)
+        self.assertEqual(s.b, [1])
+
+
+class TestList(unittest.TestCase):
+    """ Tests Storage.List (fast-check for request.args()) """
+
+    def test_listcall(self):
+        a = List((1, 2, 3))
+        self.assertEqual(a(1), 2)
+        self.assertEqual(a(-1), 3)
+        self.assertEqual(a(-5), None)
+        self.assertEqual(a(-5, default='x'), 'x')
+        self.assertEqual(a(-3, cast=str), '1')
+        a.append('1234')
+        self.assertEqual(a(3), '1234')
+        self.assertEqual(a(3, cast=int), 1234)
+        a.append('x')
+        self.assertRaises(HTTP, a, 4, cast=int)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/gluon/tests/test_template.py
+++ b/gluon/tests/test_template.py
@@ -4,38 +4,10 @@
     Unit tests for gluon.template
 """
 
-import sys
-import os
 import unittest
+from fix_path import fix_sys_path
 
-
-def fix_sys_path():
-    """
-    logic to have always the correct sys.path
-     '', web2py/gluon, web2py/site-packages, web2py/ ...
-    """
-
-    def add_path_first(path):
-        sys.path = [path] + [p for p in sys.path if (
-            not p == path and not p == (path + '/'))]
-
-    path = os.path.dirname(os.path.abspath(__file__))
-
-    if not os.path.isfile(os.path.join(path,'web2py.py')):
-        i = 0
-        while i<10:
-            i += 1
-            if os.path.exists(os.path.join(path,'web2py.py')):
-                break
-            path = os.path.abspath(os.path.join(path, '..'))
-
-    paths = [path,
-             os.path.abspath(os.path.join(path, 'site-packages')),
-             os.path.abspath(os.path.join(path, 'gluon')),
-             '']
-    [add_path_first(path) for path in paths]
-
-fix_sys_path()
+fix_sys_path(__file__)
 
 from template import render
 

--- a/gluon/tests/test_utils.py
+++ b/gluon/tests/test_utils.py
@@ -3,38 +3,10 @@
 
 """ Unit tests for utils.py """
 
-import sys
-import os
 import unittest
+from fix_path import fix_sys_path
 
-
-def fix_sys_path():
-    """
-    logic to have always the correct sys.path
-     '', web2py/gluon, web2py/site-packages, web2py/ ...
-    """
-
-    def add_path_first(path):
-        sys.path = [path] + [p for p in sys.path if (
-            not p == path and not p == (path + '/'))]
-
-    path = os.path.dirname(os.path.abspath(__file__))
-
-    if not os.path.isfile(os.path.join(path,'web2py.py')):
-        i = 0
-        while i<10:
-            i += 1
-            if os.path.exists(os.path.join(path,'web2py.py')):
-                break
-            path = os.path.abspath(os.path.join(path, '..'))
-
-    paths = [path,
-             os.path.abspath(os.path.join(path, 'site-packages')),
-             os.path.abspath(os.path.join(path, 'gluon')),
-             '']
-    [add_path_first(path) for path in paths]
-
-fix_sys_path()
+fix_sys_path(__file__)
 
 from utils import md5_hash
 

--- a/gluon/tests/test_validators.py
+++ b/gluon/tests/test_validators.py
@@ -3,43 +3,17 @@
 
 """Unit tests for http.py """
 
-import sys
-import os
 import unittest
-
-
-def fix_sys_path():
-    """
-    logic to have always the correct sys.path
-     '', web2py/gluon, web2py/site-packages, web2py/ ...
-    """
-
-    def add_path_first(path):
-        sys.path = [path] + [p for p in sys.path if (
-            not p == path and not p == (path + '/'))]
-
-    path = os.path.dirname(os.path.abspath(__file__))
-
-    if not os.path.isfile(os.path.join(path,'web2py.py')):
-        i = 0
-        while i<10:
-            i += 1
-            if os.path.exists(os.path.join(path,'web2py.py')):
-                break
-            path = os.path.abspath(os.path.join(path, '..'))
-
-    paths = [path,
-             os.path.abspath(os.path.join(path, 'site-packages')),
-             os.path.abspath(os.path.join(path, 'gluon')),
-             '']
-    [add_path_first(path) for path in paths]
-
-fix_sys_path()
-
 import datetime
 import decimal
-from gluon.validators import *
 import re
+from fix_path import fix_sys_path
+
+fix_sys_path(__file__)
+
+
+from gluon.validators import *
+
 
 class TestValidators(unittest.TestCase):
 

--- a/gluon/tests/test_web.py
+++ b/gluon/tests/test_web.py
@@ -13,34 +13,9 @@ import subprocess
 import time
 import signal
 
+from fix_path import fix_sys_path
 
-def fix_sys_path():
-    """
-    logic to have always the correct sys.path
-     '', web2py/gluon, web2py/site-packages, web2py/ ...
-    """
-
-    def add_path_first(path):
-        sys.path = [path] + [p for p in sys.path if (
-            not p == path and not p == (path + '/'))]
-
-    path = os.path.dirname(os.path.abspath(__file__))
-
-    if not os.path.isfile(os.path.join(path,'web2py.py')):
-        i = 0
-        while i<10:
-            i += 1
-            if os.path.exists(os.path.join(path,'web2py.py')):
-                break
-            path = os.path.abspath(os.path.join(path, '..'))
-
-    paths = [path,
-             os.path.abspath(os.path.join(path, 'site-packages')),
-             os.path.abspath(os.path.join(path, 'gluon')),
-             '']
-    [add_path_first(path) for path in paths]
-
-fix_sys_path()
+fix_sys_path(__file__)
 
 from contrib.webclient import WebClient
 from urllib2 import HTTPError


### PR DESCRIPTION
gluon/storage.py
StorageList had a recursion error (please check the implementation before committing)

gluon/tests*
added the fix_path module to avoid those ugly lines at the beginning of each test file
added tests for gluon.contenttype and test_fileutils
added tests for missing Storage methods
