### PR TITLE
Fix DB2 Adapter for executesql and placeholders

### DIFF
--- a/gluon/dal/adapters/db2.py
+++ b/gluon/dal/adapters/db2.py
@@ -78,7 +78,7 @@ class DB2Adapter(BaseAdapter):
         self.connector = connector
         if do_connect: self.reconnect()
 
-    def execute(self,commandi,placeholders=None):
+    def execute(self,command,placeholders=None):
         if command[-1:]==';':
             command = command[:-1]
         if placeholders:


### PR DESCRIPTION
Allow usesers of DB2 to take advantage of parameterized/pre-compiled quries using the optional placeholders parameter.

The issue stems from the DB2 adapter not supporting the placeholders parameter in the execute method. It is likely this issue exists in other DB adapters however I have not checked. 
