### PR TITLE
Fix for issue 1932: Aggregrate function won't show up in SQLTABLE

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -3001,12 +3001,16 @@ class SQLTABLE(TABLE):
             return
         REGEX_TABLE_DOT_FIELD = sqlrows.db._adapter.REGEX_TABLE_DOT_FIELD
         if not columns:
-            columns = [c for c in sqlrows.colnames if REGEX_TABLE_DOT_FIELD.match(c)]
+            columns = list(sqlrows.colnames)
         if headers == 'fieldname:capitalize':
             headers = {}
             for c in columns:
-                (t, f) = REGEX_TABLE_DOT_FIELD.match(c).groups()
-                headers[t + '.' + f] = f.replace('_', ' ').title()
+                tfmatch=REGEX_TABLE_DOT_FIELD.match(c)
+                if tfmatch:
+                    (t, f) = REGEX_TABLE_DOT_FIELD.match(c).groups()
+                    headers[t + '.' + f] = f.replace('_', ' ').title()
+                else:
+                    headers[c]=c
         elif headers == 'labels':
             headers = {}
             for c in columns:
@@ -3025,7 +3029,7 @@ class SQLTABLE(TABLE):
             headers = {}
         else:
             for c in columns:  # new implement dict
-                c = '.'.join(REGEX_TABLE_DOT_FIELD.match(c).groups())
+                c = str(c)
                 if isinstance(headers.get(c, c), dict):
                     coldict = headers.get(c, c)
                     attrcol = dict()


### PR DESCRIPTION
Addresses issue https://code.google.com/p/web2py/issues/detail?id=1932

in SQLTABLE, reverted or fixed use of REGEX_TABLE_DOT_FIELD leading to ignoring calculated / aggregate columns

Use of REGEX_TABLE_DOT_FIELD.match() leads to failure to detect aggregate function columns, at least when using postgresql backend. Replace where completely unnecessary, catch otherwise, making sure to retain copy/reference behavior.
