### PR TITLE
Waiting for a sane "prefixing", a much more efficient way to find errors

### DIFF
--- a/applications/admin/static/js/web2py.js
+++ b/applications/admin/static/js/web2py.js
@@ -141,7 +141,7 @@
     },
     /* manage errors in forms */
     manage_errors: function(target) {
-      $('.error', target).hide().slideDown('slow');
+      $('div.error', target).hide().slideDown('slow');
     },
     after_ajax: function(xhr) {
       /* called whenever an ajax request completes */

--- a/applications/examples/static/js/web2py.js
+++ b/applications/examples/static/js/web2py.js
@@ -141,7 +141,7 @@
     },
     /* manage errors in forms */
     manage_errors: function(target) {
-      $('.error', target).hide().slideDown('slow');
+      $('div.error', target).hide().slideDown('slow');
     },
     after_ajax: function(xhr) {
       /* called whenever an ajax request completes */

--- a/applications/welcome/static/js/web2py.js
+++ b/applications/welcome/static/js/web2py.js
@@ -141,7 +141,7 @@
     },
     /* manage errors in forms */
     manage_errors: function(target) {
-      $('.error', target).hide().slideDown('slow');
+      $('div.error', target).hide().slideDown('slow');
     },
     after_ajax: function(xhr) {
       /* called whenever an ajax request completes */


### PR DESCRIPTION
This comes from an unfortunate choice of naming conventions and the fact that 
manage errors gets called even on the full document on page load.
I had a table full of .error-"classed" elements and it took nearly 30 seconds for that
snippet to hide and fade them in. We should definitevely prefix every css class with
something that won't clash with everything else.
