### PR TITLE
boolean widgets in the SQLFORM.grid search widget should be "off" if unc...

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -1882,7 +1882,7 @@ class SQLFORM(FORM):
           var $value_item = jQuery('#%(value_id)s_'+b);
           if ($value_item.is(':checkbox')){
             if  ($value_item.is(':checked'))
-                    value = "on";
+                    value = 'on';
             else  value = 'off';
           }
           else


### PR DESCRIPTION
...hecked.
Boolean widgets are currently always "on" when the search query is built. The javascript code from sqlhtml.py doesn't allow for boolean widgets as checkboxes. Using jQuery .val() always returns "on" regardless of the checked/unchecked nature of the checkbox. But please carefully verify this patch. My jQuery is googling StackOverflow. 
