### PR TITLE
Make the custom_import work with circular imports.

### DIFF
--- a/gluon/custom_import.py
+++ b/gluon/custom_import.py
@@ -74,6 +74,14 @@ def custom_importer(name, globals=None, locals=None, fromlist=None, level=-1):
                 if not items[-1]:
                     items = items[:-1]
                 modules_prefix = '.'.join(items[-2:]) + '.modules'
+                pname = modules_prefix + "." + name
+
+                # if the module has been loaded, just return it to break
+                # circular imports.
+                old_mod = sys.modules.get(pname)
+                if old_mod:
+                    return old_mod
+
                 if not fromlist:
                     # import like "import x" or "import x.y"
                     result = None
@@ -88,7 +96,6 @@ def custom_importer(name, globals=None, locals=None, fromlist=None, level=-1):
                     return result
                 else:
                     # import like "from x import a, b, ..."
-                    pname = modules_prefix + "." + name
                     return base_importer(pname, globals, locals, fromlist, level)
         except ImportError, e1:
             import_tb = sys.exc_info()[2]


### PR DESCRIPTION
Although circular imports isn't a good idea, I met this problem while trying to import the `pytz` package that I placed under `modules/`. Turns out `pytz` package's `__init__.py` imports `tzinfo.py` under the package which imports `pytz` again.

Since python's built-in import allows circular imports, I think web2py should support it too.
