### PR TITLE
Make web2py's custom_import work with circular imports.

### DIFF
--- a/gluon/custom_import.py
+++ b/gluon/custom_import.py
@@ -81,7 +81,7 @@ def custom_importer(name, globals=None, locals=None, fromlist=None, level=-1):
                         new_mod = base_importer(
                             modules_prefix, globals, locals, [itemname], level)
                         try:
-                            result = result or new_mod.__dict__[itemname]
+                            result = result or sys.modules[modules_prefix+'.'+itemname]
                         except KeyError, e:
                             raise ImportError, 'Cannot import module %s' % str(e)
                         modules_prefix += "." + itemname


### PR DESCRIPTION
Ok, I believe this is how it should work.

The problem with original code that looks up `itemname` in `new_mod` is that in the case of circular import, `new_mod` won't have `itemname` because the original import that started the whole chain of imports hasn't finished yet.

For reference, previous attempt: https://github.com/web2py/web2py/pull/553
