### PR TITLE
Fix debugger interaction due new DAL

### DIFF
--- a/applications/admin/controllers/debug.py
+++ b/applications/admin/controllers/debug.py
@@ -72,8 +72,7 @@ def interact():
         f_globals = {}
         for name, value in env['globals'].items():
             if name not in gluon.html.__all__ and \
-                name not in gluon.validators.__all__ and \
-                    name not in gluon.dal.__all__:
+                name not in gluon.validators.__all__:
                 f_globals[name] = pydoc.text.repr(value)
     else:
         f_locals = {}


### PR DESCRIPTION
Originally, **all** was used to filter DAL and Field globals, but now the new module doesn't explicity set that attribute, so this filter was removed.
Note that using **dict** as a replacement is not an option, as the new dal module exports a lot of common names like connection, base, etc.
For more info, see:
https://groups.google.com/d/msg/web2py/zbSgN5qAQi0/pBWjsv6EElAJ
