### PR TITLE
Enable map_hyphen to work for application names

### DIFF
--- a/gluon/rewrite.py
+++ b/gluon/rewrite.py
@@ -878,10 +878,8 @@ class MapUrlIn(object):
         self.domain_application = None
         self.domain_controller = None
         self.domain_function = None
-        if base.map_hyphen:
-            arg0 = self.harg0.replace('-', '_')
-        else:
-            arg0 = self.harg0
+        self.map_hyphen = base.map_hyphen
+        arg0 = self.harg0
         if not base.exclusive_domain and base.applications and arg0 in base.applications:
             self.application = arg0
         elif not base.exclusive_domain and arg0 and not base.applications:


### PR DESCRIPTION
1) Set self.map_hyphen early in map_app(), so the first call to harg0 properly replaces hyphens with underscores.  Without this, the rewriter can't find the application, and reverts to the default

2) Disable hyphen mapping of the application when producing /static URLs.  Without this, the generated URL will be to a non-existent folder.
