### PR TITLE
Fix the problem with chunked encoding with an empty body.

### DIFF
--- a/gluon/rocket.py
+++ b/gluon/rocket.py
@@ -1854,7 +1854,7 @@ class WSGIWorker(Worker):
                 # Send headers if the body was empty
                 self.send_headers('', sections)
 
-            if self.chunked:
+            if self.chunked and self.request_method != 'HEAD':
                 # If chunked, send our final chunk length
                 self.conn.sendall(b('0\r\n\r\n'))
 


### PR DESCRIPTION
When the response body is empty, rocket won't send the final zero-length
terminating chunk for chunked encoding. I think this causes the browser
to wait for the connection close in order to tell the end of a
response. The symptom of this is that of a slow response, and it arises when, for example, one tries to use `gluon.streamer.streamer` directly, passing it an opened file object that is either an empty file or a file that has no more data to read from.
