### PR TITLE
GoogleSQLAdapter: Fix NDB orderby without limitby broken in 2.9.6

### DIFF
--- a/gluon/dal/adapters/google.py
+++ b/gluon/dal/adapters/google.py
@@ -507,7 +507,7 @@ class GoogleDatastoreAdapter(NoSQLAdapter):
                     db['_lastcursor'] = cursor
             else:
                 # if a limit is not specified, always return an iterator
-                rows = query
+                items = query
 
         return (items, tablename, projection or db[tablename].fields)
 


### PR DESCRIPTION
Commit 8d648f6137cea5 ("restore beahvior in gae that if no limitby,
returns iterator") made select_raw() store the query iterator in a
wrong variable ("rows", which is unused, should be "items"), causing
unsorted results to be returned.

Fix the assignment.