### PR TITLE
auth.settings.*_case_sensitivity support for password retrieval

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -3097,10 +3097,15 @@ class Auth(object):
                 IS_EMAIL(error_message=self.messages.invalid_email),
                 IS_IN_DB(self.db, table_user.email,
                          error_message=self.messages.invalid_email)]
+            if not self.settings.email_case_sensitive:
+                table_user.email.requires.insert(0, IS_LOWER())
         else:
             table_user.username.requires = [
                 IS_IN_DB(self.db, table_user.username,
                          error_message=self.messages.invalid_username)]
+            if not self.settings.username_case_sensitive:
+                table_user.username.requires.insert(0, IS_LOWER())
+
         form = SQLFORM(table_user,
                        fields=[userfield],
                        hidden=dict(_next=next),


### PR DESCRIPTION
There is a missing IS_LOWER() validator when username or email should be validated without case sesitivity.
