### PR TITLE
DAL imports portalocker from gluon to avoid conflict with another portal...

### DIFF
--- a/gluon/dal/_load.py
+++ b/gluon/dal/_load.py
@@ -19,7 +19,7 @@ except (ImportError, SystemError):
     def web2py_uuid(): return str(uuid.uuid4())
 
 try:
-    import portalocker
+    from gluon import portalocker
     have_portalocker = True
 except ImportError:
     portalocker = None


### PR DESCRIPTION
...ocker module

web2py 2.9.12 started failing with error
  File "/usr/srv/web2py/gluon/dal/adapters/base.py", line 146, in file_open
    fileobj = portalocker.LockedFile(filename,mode)
AttributeError: 'module' object has no attribute 'LockedFile'

The "portalocker" module in web2py was conflicting with another "portalocker" module we have installed: https://pypi.python.org/pypi/portalocker

This commit modifies gluon/dal/_load.py to import portalocker from gluon.