### PR TITLE
Script for centos7 now also installs 'unzip' package

### DIFF
--- a/scripts/setup-web2py-centos7.sh
+++ b/scripts/setup-web2py-centos7.sh
@@ -56,7 +56,7 @@ echo
 yum update
 
 # Install required packages
-yum install httpd mod_ssl mod_wsgi wget python
+yum install httpd mod_ssl mod_wsgi wget python unzip
 
 ###
 ### Phase 2 - Install web2py


### PR DESCRIPTION
Some virtual server providers (like DigitalOcean) do not have unzip
installed in their centos7 image so we need to install it in our script.