### PR TITLE
we should always avoid importing "optionals" without a try:except.

### DIFF
--- a/gluon/dal.py
+++ b/gluon/dal.py
@@ -126,11 +126,17 @@ class DAL(pyDAL):
 #: add web2py contrib drivers to pyDAL
 from pydal.drivers import DRIVERS
 if not DRIVERS.get('pymysql'):
-    from .contrib import pymysql
-    DRIVERS['pymysql'] = pymysql
+    try:
+        from .contrib import pymysql
+        DRIVERS['pymysql'] = pymysql
+    except:
+        pass
 #if not DRIVERS.get('pg8000'):
 #    from .contrib import pg8000
 #    DRIVERS['pg8000'] = pg8000
 if not DRIVERS.get('pyodbc'):
-    from .contrib import pypyodbc as pyodbc
-    DRIVERS['pyodbc'] = pyodbc
+    try:
+        from .contrib import pypyodbc as pyodbc
+        DRIVERS['pyodbc'] = pyodbc
+    except:
+        pass


### PR DESCRIPTION
one clear case of "should never happen"... that happened.
in this case docs were failing builds on readthedocs because of 
pypyodbc not being able to load any odbc library.