### PR TITLE
Update ajax_examples.py so it does what it says.

### DIFF
--- a/applications/examples/controllers/ajax_examples.py
+++ b/applications/examples/controllers/ajax_examples.py
@@ -3,12 +3,13 @@ def index():
 
 
 def data():
-    if not session.m or len(session.m) == 10:
+    if not session.m:
         session.m = []
     if request.vars.q:
+        if len(session.m) == 10:
+            del(session.m[0])
         session.m.append(request.vars.q)
-    session.m.sort()
-    return TABLE(*[TR(v) for v in session.m]).xml()
+    return TABLE(*[TR(v) for v in sorted(session.m)]).xml()
 
 
 def flash():


### PR DESCRIPTION
Fixed the example so it actually does what it says. It said "The last 10 entries will appear sorted in a table below.". What it did was if the number of entries was 10, it would truncate the entries and start over again. So, in order for this to show the last 10 entries, it has to delete the oldest entry after 10. The best way to do that is to not sort the list, except when displaying and then delete the first entry in the list before inserting the 11th entry.