### PR TITLE
make unique_key unique also for the database table definition

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -890,7 +890,7 @@ class Session(Storage):
                     Field('created_datetime', 'datetime',
                           default=request.now),
                     Field('modified_datetime', 'datetime'),
-                    Field('unique_key', length=64),
+                    Field('unique_key', length=64, unique=True),
                     Field('session_data', 'blob'),
                     migrate=table_migrate,
                 )


### PR DESCRIPTION
This should be a big speed improvement.  I wonder why it was not unique before.