### PR TITLE
fix web2py/web2py#896, avoid to select blob fields in sqlform.grid

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -2148,7 +2148,7 @@ class SQLFORM(FORM):
         else:
             fields = []
             columns = []
-            filter1 = lambda f: isinstance(f, Field)
+            filter1 = lambda f: isinstance(f, Field) and f.type != 'blob'
             filter2 = lambda f: isinstance(f, Field) and f.readable
             for table in tables:
                 fields += filter(filter1, table)


### PR DESCRIPTION
Blob files can be still be shown by explicitly selecting them