### PR TITLE
Fix crash with list:reference field

### DIFF
--- a/gluon/validators.py
+++ b/gluon/validators.py
@@ -611,7 +611,7 @@ class IS_IN_DB(Validator):
 
                 def count(values, s=self.dbset, f=field):
                     return s(f.belongs(map(int, values))).count()
-                if isinstance(self.dbset.db._adapter, GoogleDatastoreAdapter):
+                if GoogleDatastoreAdapter is not None and isinstance(self.dbset.db._adapter, GoogleDatastoreAdapter):
                     range_ids = range(0, len(values), 30)
                     total = sum(count(values[i:i + 30]) for i in range_ids)
                     if total == len(values):


### PR DESCRIPTION
When using validate_and_update() or validate_and_insert() on a table with a list:reference field, the request crashes after timeout with:
```
File "web2py/gluon/globals.py", line 270, in body
raise HTTP(400, "Bad Request - HTTP body is incomplete")
```

The request crashes because there is an hidden exception with the isinstance function:
`isinstance() arg 2 must be a class, type, or tuple of classes and types`

When no using GAE, the GoogleDatastoreAdapter variable is None, so isinstance crash.
See the last line of pydal/adapters/__init__.py

This is a regression intruduced after the v2.9.12.