### PR TITLE
Fixing https://github.com/web2py/web2py/issues/969

### DIFF
--- a/gluon/shell.py
+++ b/gluon/shell.py
@@ -41,9 +41,7 @@ def enable_autocomplete_and_history(adir, env):
     except ImportError:
         pass
     else:
-        readline.parse_and_bind("bind ^I rl_complete"
-                                if sys.platform == 'darwin'
-                                else "tab: complete")
+        readline.parse_and_bind("tab: complete")
         history_file = os.path.join(adir, '.pythonhistory')
         try:
             readline.read_history_file(history_file)


### PR DESCRIPTION
Running readline.parse_and_bind("bind ^I rl_complete") makes the letter "b" stop working on the console. This patch solves the issue and correctly enables tab completition on OSX.