### PR TITLE
Fixed authentication using different login methods.

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -2323,8 +2323,8 @@ class Auth(object):
             # user not in database try other login methods
             for login_method in self.settings.login_methods:
                 if login_method != self and login_method(username, password):
-                    self.user = username
-                    return username
+                    self.user = user
+                    return user
         return False
 
     def register_bare(self, **fields):


### PR DESCRIPTION
There is a bug when attempting to use basic authentication with the auth plugins like LDAP. 

The bug was that after authentication was successful, a user name was returned rather than a user object. 

I just replaced username with user for the two lines appropriate in the login_bare() method. 

This should allow others to still use AD/LDAP/etc authentication but use web2py as a REST API. 