### PR TITLE
Fixed appadmin action of cleaning an application of errors, sessions, and cahce

### DIFF
--- a/gluon/cache.py
+++ b/gluon/cache.py
@@ -433,7 +433,7 @@ class CacheOnDisk(CacheAbstract):
 
         # Lets test if the cache folder exists, if not
         # we are going to create it
-        folder = os.path.join(folder or request.folder, 'cache')
+        folder = os.path.join(folder or (request.folder, 'cache'))
 
         if not os.path.exists(folder):
             os.mkdir(folder)


### PR DESCRIPTION
The current web2py action for cleaning a project from the app admin interface has an error when trying to run "clean" due to adding an extra "cache" folder to the path when trying to clear the on-disk cache. 