### PR TITLE
simplejsonrpc: Fix TypeError when data is None

### DIFF
--- a/gluon/contrib/simplejsonrpc.py
+++ b/gluon/contrib/simplejsonrpc.py
@@ -34,7 +34,7 @@ except ImportError:
 class JSONRPCError(RuntimeError):
     "Error object for remote procedure call fail"
     def __init__(self, code, message, data=None):
-        value = "%s: %s\n%s" % (code, message, '\n'.join(data))
+        value = "%s: %s\n%s" % (code, message, '\n'.join(data or ''))
         RuntimeError.__init__(self, value)
         self.code = code
         self.message = message


### PR DESCRIPTION
'\n'.join(data) breaks on data = None, which it often is.
Seems as if web2py's ticket errors became less verbose in a recent update?