### PR TITLE
Repair cache status page in appadmin for welcome, admin and examples …

### DIFF
--- a/applications/admin/controllers/appadmin.py
+++ b/applications/admin/controllers/appadmin.py
@@ -445,30 +445,31 @@ def ccache():
         gae_stats['oldest'] = GetInHMS(time.time() - gae_stats['oldest_item_age'])
         total.update(gae_stats)
     else:
+        # get ram stats directly from the cache object
+        ram_stats = cache.ram.stats[request.application]
+        ram['hits'] = ram_stats['hit_total'] - ram_stats['misses']
+        ram['misses'] = ram_stats['misses']
+        try:
+            ram['ratio'] = ram['hits'] * 100 / ram_stats['hit_total']
+        except (KeyError, ZeroDivisionError):
+            ram['ratio'] = 0
+
         for key, value in cache.ram.storage.iteritems():
-            if isinstance(value, dict):
-                ram['hits'] = value['hit_total'] - value['misses']
-                ram['misses'] = value['misses']
-                try:
-                    ram['ratio'] = ram['hits'] * 100 / value['hit_total']
-                except (KeyError, ZeroDivisionError):
-                    ram['ratio'] = 0
-            else:
-                if hp:
-                    ram['bytes'] += hp.iso(value[1]).size
-                    ram['objects'] += hp.iso(value[1]).count
-                ram['entries'] += 1
-                if value[0] < ram['oldest']:
-                    ram['oldest'] = value[0]
-                ram['keys'].append((key, GetInHMS(time.time() - value[0])))
+            if hp:
+                ram['bytes'] += hp.iso(value[1]).size
+                ram['objects'] += hp.iso(value[1]).count
+            ram['entries'] += 1
+            if value[0] < ram['oldest']:
+                ram['oldest'] = value[0]
+            ram['keys'].append((key, GetInHMS(time.time() - value[0])))
 
         for key in cache.disk.storage:
             value = cache.disk.storage[key]
-            if isinstance(value, dict):
-                disk['hits'] = value['hit_total'] - value['misses']
-                disk['misses'] = value['misses']
+            if isinstance(value[1], dict):
+                disk['hits'] = value[1]['hit_total'] - value[1]['misses']
+                disk['misses'] = value[1]['misses']
                 try:
-                    disk['ratio'] = disk['hits'] * 100 / value['hit_total']
+                    disk['ratio'] = disk['hits'] * 100 / value[1]['hit_total']
                 except (KeyError, ZeroDivisionError):
                     disk['ratio'] = 0
             else:
@@ -485,7 +486,7 @@ def ccache():
         ram_keys.remove('oldest')
         for key in ram_keys:
             total[key] = ram[key] + disk[key]
-            
+
         try:
             total['ratio'] = total['hits'] * 100 / (total['hits'] +
                                                 total['misses'])

--- a/applications/admin/views/appadmin.html
+++ b/applications/admin/views/appadmin.html
@@ -137,9 +137,9 @@
     <h4>{{=T("Overview")}}</h4>
     <p>{{=T.M("Number of entries: **%s**", total['entries'])}}</p>
     {{if total['entries'] > 0:}}
-      <p>{{=T.M("Hit Ratio: **%(ratio)s%%** (**%(hits)s** %%{hit(hits)} and **%(misses)s** %%{miss(misses})",
-              dict(ratio=total['ratio'], hits=total['hits'], misses=total['misses']))}}
-     </p>
+    <p>{{=T.M("Hit Ratio: **%(ratio)s%%** (**%(hits)s** %%{hit(hits)} and **%(misses)s** %%{miss(misses)})",
+             dict( ratio=total['ratio'], hits=total['hits'], misses=total['misses']))}}
+    </p>
     <p>
       {{=T("Size of cache:")}}
       {{if object_stats:}}
@@ -155,7 +155,7 @@
       {{=T.M("Cache contains items up to **%(hours)02d** %%{hour(hours)} **%(min)02d** %%{minute(min)} **%(sec)02d** %%{second(sec)} old.",
               dict(hours=total['oldest'][0], min=total['oldest'][1], sec=total['oldest'][2]))}}
     </p>
-    {{=BUTTON(T('Cache Keys'), _onclick='jQuery("#all_keys").toggle();')}}
+    {{=BUTTON(T('Cache Keys'), _onclick='jQuery("#all_keys").toggle().toggleClass( "hidden" );')}}
     <div class="hidden" id="all_keys">
       {{=total['keys']}}
     </div>
@@ -183,7 +183,7 @@
       {{=T.M("RAM contains items up to **%(hours)02d** %%{hour(hours)} **%(min)02d** %%{minute(min)} **%(sec)02d** %%{second(sec)} old.",
               dict(hours=ram['oldest'][0], min=ram['oldest'][1], sec=ram['oldest'][2]))}}
     </p>
-    {{=BUTTON(T('RAM Cache Keys'), _onclick='jQuery("#ram_keys").toggle();')}}
+    {{=BUTTON(T('RAM Cache Keys'), _onclick='jQuery("#ram_keys").toggle().toggleClass( "hidden" );')}}
     <div class="hidden" id="ram_keys">
       {{=ram['keys']}}
     </div>
@@ -212,7 +212,7 @@
       {{=T.M("DISK contains items up to **%(hours)02d** %%{hour(hours)} **%(min)02d** %%{minute(min)} **%(sec)02d** %%{second(sec)} old.",
                 dict(hours=disk['oldest'][0], min=disk['oldest'][1], sec=disk['oldest'][2]))}}
       </p>
-      {{=BUTTON(T('Disk Cache Keys'), _onclick='jQuery("#disk_keys").toggle();')}}
+      {{=BUTTON(T('Disk Cache Keys'), _onclick='jQuery("#disk_keys").toggle().toggleClass( "hidden" );')}}
       <div class="hidden" id="disk_keys">
       {{=disk['keys']}}
       </div>

--- a/applications/examples/controllers/appadmin.py
+++ b/applications/examples/controllers/appadmin.py
@@ -445,30 +445,31 @@ def ccache():
         gae_stats['oldest'] = GetInHMS(time.time() - gae_stats['oldest_item_age'])
         total.update(gae_stats)
     else:
+        # get ram stats directly from the cache object
+        ram_stats = cache.ram.stats[request.application]
+        ram['hits'] = ram_stats['hit_total'] - ram_stats['misses']
+        ram['misses'] = ram_stats['misses']
+        try:
+            ram['ratio'] = ram['hits'] * 100 / ram_stats['hit_total']
+        except (KeyError, ZeroDivisionError):
+            ram['ratio'] = 0
+
         for key, value in cache.ram.storage.iteritems():
-            if isinstance(value, dict):
-                ram['hits'] = value['hit_total'] - value['misses']
-                ram['misses'] = value['misses']
-                try:
-                    ram['ratio'] = ram['hits'] * 100 / value['hit_total']
-                except (KeyError, ZeroDivisionError):
-                    ram['ratio'] = 0
-            else:
-                if hp:
-                    ram['bytes'] += hp.iso(value[1]).size
-                    ram['objects'] += hp.iso(value[1]).count
-                ram['entries'] += 1
-                if value[0] < ram['oldest']:
-                    ram['oldest'] = value[0]
-                ram['keys'].append((key, GetInHMS(time.time() - value[0])))
+            if hp:
+                ram['bytes'] += hp.iso(value[1]).size
+                ram['objects'] += hp.iso(value[1]).count
+            ram['entries'] += 1
+            if value[0] < ram['oldest']:
+                ram['oldest'] = value[0]
+            ram['keys'].append((key, GetInHMS(time.time() - value[0])))
 
         for key in cache.disk.storage:
             value = cache.disk.storage[key]
-            if isinstance(value, dict):
-                disk['hits'] = value['hit_total'] - value['misses']
-                disk['misses'] = value['misses']
+            if isinstance(value[1], dict):
+                disk['hits'] = value[1]['hit_total'] - value[1]['misses']
+                disk['misses'] = value[1]['misses']
                 try:
-                    disk['ratio'] = disk['hits'] * 100 / value['hit_total']
+                    disk['ratio'] = disk['hits'] * 100 / value[1]['hit_total']
                 except (KeyError, ZeroDivisionError):
                     disk['ratio'] = 0
             else:
@@ -485,7 +486,7 @@ def ccache():
         ram_keys.remove('oldest')
         for key in ram_keys:
             total[key] = ram[key] + disk[key]
-            
+
         try:
             total['ratio'] = total['hits'] * 100 / (total['hits'] +
                                                 total['misses'])

--- a/applications/examples/views/appadmin.html
+++ b/applications/examples/views/appadmin.html
@@ -137,9 +137,9 @@
     <h4>{{=T("Overview")}}</h4>
     <p>{{=T.M("Number of entries: **%s**", total['entries'])}}</p>
     {{if total['entries'] > 0:}}
-      <p>{{=T.M("Hit Ratio: **%(ratio)s%%** (**%(hits)s** %%{hit(hits)} and **%(misses)s** %%{miss(misses})",
-              dict(ratio=total['ratio'], hits=total['hits'], misses=total['misses']))}}
-     </p>
+    <p>{{=T.M("Hit Ratio: **%(ratio)s%%** (**%(hits)s** %%{hit(hits)} and **%(misses)s** %%{miss(misses)})",
+             dict( ratio=total['ratio'], hits=total['hits'], misses=total['misses']))}}
+    </p>
     <p>
       {{=T("Size of cache:")}}
       {{if object_stats:}}
@@ -155,7 +155,7 @@
       {{=T.M("Cache contains items up to **%(hours)02d** %%{hour(hours)} **%(min)02d** %%{minute(min)} **%(sec)02d** %%{second(sec)} old.",
               dict(hours=total['oldest'][0], min=total['oldest'][1], sec=total['oldest'][2]))}}
     </p>
-    {{=BUTTON(T('Cache Keys'), _onclick='jQuery("#all_keys").toggle();')}}
+    {{=BUTTON(T('Cache Keys'), _onclick='jQuery("#all_keys").toggle().toggleClass( "hidden" );')}}
     <div class="hidden" id="all_keys">
       {{=total['keys']}}
     </div>
@@ -183,7 +183,7 @@
       {{=T.M("RAM contains items up to **%(hours)02d** %%{hour(hours)} **%(min)02d** %%{minute(min)} **%(sec)02d** %%{second(sec)} old.",
               dict(hours=ram['oldest'][0], min=ram['oldest'][1], sec=ram['oldest'][2]))}}
     </p>
-    {{=BUTTON(T('RAM Cache Keys'), _onclick='jQuery("#ram_keys").toggle();')}}
+    {{=BUTTON(T('RAM Cache Keys'), _onclick='jQuery("#ram_keys").toggle().toggleClass( "hidden" );')}}
     <div class="hidden" id="ram_keys">
       {{=ram['keys']}}
     </div>
@@ -212,7 +212,7 @@
       {{=T.M("DISK contains items up to **%(hours)02d** %%{hour(hours)} **%(min)02d** %%{minute(min)} **%(sec)02d** %%{second(sec)} old.",
                 dict(hours=disk['oldest'][0], min=disk['oldest'][1], sec=disk['oldest'][2]))}}
       </p>
-      {{=BUTTON(T('Disk Cache Keys'), _onclick='jQuery("#disk_keys").toggle();')}}
+      {{=BUTTON(T('Disk Cache Keys'), _onclick='jQuery("#disk_keys").toggle().toggleClass( "hidden" );')}}
       <div class="hidden" id="disk_keys">
       {{=disk['keys']}}
       </div>

--- a/applications/welcome/controllers/appadmin.py
+++ b/applications/welcome/controllers/appadmin.py
@@ -445,30 +445,31 @@ def ccache():
         gae_stats['oldest'] = GetInHMS(time.time() - gae_stats['oldest_item_age'])
         total.update(gae_stats)
     else:
+        # get ram stats directly from the cache object
+        ram_stats = cache.ram.stats[request.application]
+        ram['hits'] = ram_stats['hit_total'] - ram_stats['misses']
+        ram['misses'] = ram_stats['misses']
+        try:
+            ram['ratio'] = ram['hits'] * 100 / ram_stats['hit_total']
+        except (KeyError, ZeroDivisionError):
+            ram['ratio'] = 0
+
         for key, value in cache.ram.storage.iteritems():
-            if isinstance(value, dict):
-                ram['hits'] = value['hit_total'] - value['misses']
-                ram['misses'] = value['misses']
-                try:
-                    ram['ratio'] = ram['hits'] * 100 / value['hit_total']
-                except (KeyError, ZeroDivisionError):
-                    ram['ratio'] = 0
-            else:
-                if hp:
-                    ram['bytes'] += hp.iso(value[1]).size
-                    ram['objects'] += hp.iso(value[1]).count
-                ram['entries'] += 1
-                if value[0] < ram['oldest']:
-                    ram['oldest'] = value[0]
-                ram['keys'].append((key, GetInHMS(time.time() - value[0])))
+            if hp:
+                ram['bytes'] += hp.iso(value[1]).size
+                ram['objects'] += hp.iso(value[1]).count
+            ram['entries'] += 1
+            if value[0] < ram['oldest']:
+                ram['oldest'] = value[0]
+            ram['keys'].append((key, GetInHMS(time.time() - value[0])))
 
         for key in cache.disk.storage:
             value = cache.disk.storage[key]
-            if isinstance(value, dict):
-                disk['hits'] = value['hit_total'] - value['misses']
-                disk['misses'] = value['misses']
+            if isinstance(value[1], dict):
+                disk['hits'] = value[1]['hit_total'] - value[1]['misses']
+                disk['misses'] = value[1]['misses']
                 try:
-                    disk['ratio'] = disk['hits'] * 100 / value['hit_total']
+                    disk['ratio'] = disk['hits'] * 100 / value[1]['hit_total']
                 except (KeyError, ZeroDivisionError):
                     disk['ratio'] = 0
             else:
@@ -485,7 +486,7 @@ def ccache():
         ram_keys.remove('oldest')
         for key in ram_keys:
             total[key] = ram[key] + disk[key]
-            
+
         try:
             total['ratio'] = total['hits'] * 100 / (total['hits'] +
                                                 total['misses'])

--- a/applications/welcome/views/appadmin.html
+++ b/applications/welcome/views/appadmin.html
@@ -137,9 +137,9 @@
     <h4>{{=T("Overview")}}</h4>
     <p>{{=T.M("Number of entries: **%s**", total['entries'])}}</p>
     {{if total['entries'] > 0:}}
-      <p>{{=T.M("Hit Ratio: **%(ratio)s%%** (**%(hits)s** %%{hit(hits)} and **%(misses)s** %%{miss(misses})",
-              dict(ratio=total['ratio'], hits=total['hits'], misses=total['misses']))}}
-     </p>
+    <p>{{=T.M("Hit Ratio: **%(ratio)s%%** (**%(hits)s** %%{hit(hits)} and **%(misses)s** %%{miss(misses)})",
+             dict( ratio=total['ratio'], hits=total['hits'], misses=total['misses']))}}
+    </p>
     <p>
       {{=T("Size of cache:")}}
       {{if object_stats:}}
@@ -155,7 +155,7 @@
       {{=T.M("Cache contains items up to **%(hours)02d** %%{hour(hours)} **%(min)02d** %%{minute(min)} **%(sec)02d** %%{second(sec)} old.",
               dict(hours=total['oldest'][0], min=total['oldest'][1], sec=total['oldest'][2]))}}
     </p>
-    {{=BUTTON(T('Cache Keys'), _onclick='jQuery("#all_keys").toggle();')}}
+    {{=BUTTON(T('Cache Keys'), _onclick='jQuery("#all_keys").toggle().toggleClass( "hidden" );')}}
     <div class="hidden" id="all_keys">
       {{=total['keys']}}
     </div>
@@ -183,7 +183,7 @@
       {{=T.M("RAM contains items up to **%(hours)02d** %%{hour(hours)} **%(min)02d** %%{minute(min)} **%(sec)02d** %%{second(sec)} old.",
               dict(hours=ram['oldest'][0], min=ram['oldest'][1], sec=ram['oldest'][2]))}}
     </p>
-    {{=BUTTON(T('RAM Cache Keys'), _onclick='jQuery("#ram_keys").toggle();')}}
+    {{=BUTTON(T('RAM Cache Keys'), _onclick='jQuery("#ram_keys").toggle().toggleClass( "hidden" );')}}
     <div class="hidden" id="ram_keys">
       {{=ram['keys']}}
     </div>
@@ -212,7 +212,7 @@
       {{=T.M("DISK contains items up to **%(hours)02d** %%{hour(hours)} **%(min)02d** %%{minute(min)} **%(sec)02d** %%{second(sec)} old.",
                 dict(hours=disk['oldest'][0], min=disk['oldest'][1], sec=disk['oldest'][2]))}}
       </p>
-      {{=BUTTON(T('Disk Cache Keys'), _onclick='jQuery("#disk_keys").toggle();')}}
+      {{=BUTTON(T('Disk Cache Keys'), _onclick='jQuery("#disk_keys").toggle().toggleClass( "hidden" );')}}
       <div class="hidden" id="disk_keys">
       {{=disk['keys']}}
       </div>


### PR DESCRIPTION
…apps.

This fixes how values are read. For cache.disk, we need to use the second value in the dict.
For cache.ram everything is already there in the object, no need trying to get the stats (which are not there) in the loop.
Also small fix for buttons that did not open the detailed statistics when clicked (class hidden has !important in bootstrap3).