### PR TITLE
Allow to specify a function for requires_login at auth decoration.

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -3739,7 +3739,12 @@ class Auth(object):
 
                 basic_allowed, basic_accepted, user = self.basic()
                 user = user or self.user
-                if requires_login:
+
+                login_required = requires_login
+                if callable(login_required):
+                    login_required = login_required()
+
+                if login_required:
                     if not user:
                         if current.request.ajax:
                             raise HTTP(401, self.messages.ajax_failed_authentication)


### PR DESCRIPTION
auth.requires_login: Allow functions for parameter requires_login.
This allows to postpone the decision whether or not a login is required.

Use case:
    def is_local_ip():
        ....

    def requires_local_ip_or_user():
       auth.requires(lambda: is_local_ip(), requires_login: lambda: not local_ip())

That way we can get login prompts for non-local ip addresses only.
