### PR TITLE
Update sqlhtml.py - fix failed validation removing styling

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -1515,31 +1515,6 @@ class SQLFORM(FORM):
         elif (not ret) and (not auch):
             # auch is true when user tries to delete a record
             # that does not pass validation, yet it should be deleted
-            for fieldname in self.fields:
-
-                field = (self.table[fieldname]
-                         if fieldname in self.table.fields
-                         else self.extra_fields[fieldname])
-                # this is a workaround! widgets should always have default not None!
-                if not field.widget and field.type.startswith('list:') and \
-                        not OptionsWidget.has_options(field):
-                    field.widget = self.widgets.list.widget
-                if field.widget and fieldname in request_vars:
-                    if fieldname in self.request_vars:
-                        value = self.request_vars[fieldname]
-                    elif self.record:
-                        value = self.record[fieldname]
-                    else:
-                        value = field.default
-                    row_id = '%s_%s%s' % (
-                        self.table, fieldname, SQLFORM.ID_ROW_SUFFIX)
-                    widget = field.widget(field, value)
-                    parent = self.field_parent[row_id]
-                    if parent:
-                        parent.components = [widget]
-                        if self.errors.get(fieldname):
-                            parent._traverse(False, hideerror)
-                    self.custom.widget[fieldname] = widget
             self.accepted = ret
             return ret
 


### PR DESCRIPTION
Addresses https://github.com/web2py/web2py/issues/1048, and works in my application.

However, I don't know what the purpose of the existing code is: why does it override widgets, and why only those which are explicitly set?  Isn't this just replicating work done in __init__()?  What could this break?