### PR TITLE
fixes typo in wiki. 

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -6392,7 +6392,7 @@ class Wiki(object):
             count = db.wiki_tag.wiki_page.count()
             fields = [db.wiki_page.id, db.wiki_page.slug,
                       db.wiki_page.title, db.wiki_page.tags,
-                      db.wiki_page.can_read, db.wiki+page.can_edit]
+                      db.wiki_page.can_read, db.wiki_page.can_edit]
             if preview:
                 fields.append(db.wiki_page.body)
             if query is None:


### PR DESCRIPTION
As usual, lack of unittests made this possible.
We should really make each developer "adopt" a piece of web2py to test
and care if we don't want to write unittests.