### PR TITLE
Closes #1059: get `response.view` from the environment

### DIFF
--- a/gluon/compileapp.py
+++ b/gluon/compileapp.py
@@ -652,7 +652,7 @@ def run_view_in(environment):
     """
     request = current.request
     response = current.response
-    view = response.view
+    view = environment['response'].view
     folder = request.folder
     path = pjoin(folder, 'compiled')
     badv = 'invalid view (%s)' % view


### PR DESCRIPTION
Make `run_view_in()` use `response.view` from the environment, instead of `current.response`.