### PR TITLE
Provide optional per-column SQLFORM.grid CSS class

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -1977,6 +1977,7 @@ class SQLFORM(FORM):
              user_signature=True,
              maxtextlengths={},
              maxtextlength=20,
+             columnclasses={},
              onvalidation=None,
              onfailure=None,
              oncreate=None,
@@ -2746,7 +2747,11 @@ class SQLFORM(FORM):
                         value = truncate_string(value, maxlength)
                     elif not isinstance(value, XmlComponent):
                         value = field.formatter(value)
-                    trcols.append(TD(value))
+                    columnclass = columnclasses.get(str(field))
+                    if columnclass:
+                        trcols.append(TD(value, _class=columnclass))
+                    else:
+                        trcols.append(TD(value))
                 row_buttons = TD(_class='row_buttons', _nowrap=True)
                 if links and links_in_grid:
                     toadd = []


### PR DESCRIPTION
I wanted to control the CSS in the TD elements for one column in a SQLFORM.grid. I've added columnclasses={} to the grid() parameters, which is a dictionary of 'tablename.fieldname':'classname' e.g. {'t_mytable.f_myfield' : 'myclass'}. If you accept this pull request, I'll update the book pages (if you want: let me know).