### PR TITLE
Parse GET vars from rewritten query string, not the original. Fixes #730

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -208,7 +208,7 @@ class Request(Storage):
     def parse_get_vars(self):
         """Takes the QUERY_STRING and unpacks it to get_vars
         """
-        query_string = self.env.get('QUERY_STRING', '')
+        query_string = self.env.get('query_string', '')
         dget = urlparse.parse_qs(query_string, keep_blank_values=1)  # Ref: https://docs.python.org/2/library/cgi.html#cgi.parse_qs
         get_vars = self._get_vars = Storage(dget)
         for (key, value) in get_vars.iteritems():


### PR DESCRIPTION
From what I can tell, request.env.QUERY_STRING contains the original query string before URL rewrite while request.env.query_string contains the new query string after rewrite. Both Apache (2.4.17) and the built-in Rocket server keep both query strings on my Linux machine. This little patch just switches query string parsing to the rewritten one, which is the expected behavior.