### PR TITLE
Changed order of imports

### DIFF
--- a/gluon/portalocker.py
+++ b/gluon/portalocker.py
@@ -53,8 +53,8 @@ except:
     except:
         try:
             import win32con
-            import win32file
             import pywintypes
+            import win32file
             os_locking = 'windows'
         except:
             pass


### PR DESCRIPTION
I ran into issue with running cron on Windows 10 even after installing pywin32. When I manually tried to find out why `web2py` won't determine LOCK_EX it turned out that order of imports mattered:

```
Python 2.7.9 (default, Dec 10 2014, 12:28:03) [MSC v.1500 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import win32con
>>> import win32file
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: DLL load failed: The specified module could not be found.
>>>
```

```
Python 2.7.9 (default, Dec 10 2014, 12:28:03) [MSC v.1500 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import win32con
>>> import pywintypes
>>> import win32file
>>>
```

After this change cron is running happily.

Regards,
Adam