### PR TITLE
Fix bug on Mail.send() when text or input are Unicode

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -777,16 +777,16 @@ class Mail(object):
                 if attachments:
                     result = mail.send_mail(
                         sender=sender, to=origTo,
-                        subject=str(subject), body=str(text), html=html,
+                        subject=unicode(subject, encoding), body=unicode(text, encoding), html=html,
                         attachments=attachments, **xcc)
                 elif html and (not raw):
                     result = mail.send_mail(
                         sender=sender, to=origTo,
-                        subject=str(subject), body=str(text), html=html, **xcc)
+                        subject=unicode(subject, encoding), body=unicode(text, encoding), html=html, **xcc)
                 else:
                     result = mail.send_mail(
                         sender=sender, to=origTo,
-                        subject=str(subject), body=str(text), **xcc)
+                        subject=unicode(subject, encoding), body=unicode(text, encoding), **xcc)
             else:
                 smtp_args = self.settings.server.split(':')
                 kwargs = dict(timeout=self.settings.timeout)

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -777,16 +777,16 @@ class Mail(object):
                 if attachments:
                     result = mail.send_mail(
                         sender=sender, to=origTo,
-                        subject=unicode(subject), body=unicode(text), html=html,
+                        subject=str(subject), body=str(text), html=html,
                         attachments=attachments, **xcc)
                 elif html and (not raw):
                     result = mail.send_mail(
                         sender=sender, to=origTo,
-                        subject=unicode(subject), body=unicode(text), html=html, **xcc)
+                        subject=str(subject), body=str(text), html=html, **xcc)
                 else:
                     result = mail.send_mail(
                         sender=sender, to=origTo,
-                        subject=unicode(subject), body=unicode(text), **xcc)
+                        subject=str(subject), body=str(text), **xcc)
             else:
                 smtp_args = self.settings.server.split(':')
                 kwargs = dict(timeout=self.settings.timeout)


### PR DESCRIPTION
On PR #964 @matclab forced the encoding of both subject and
text variables to unicode.

After merging it, matclab realized that when we send Unicode
text to the method it raises an exception and asked if he should
change the commit. Unfortunately this thing was kept untouched.

This problem exists because we previously encode the unicode variables
to utf-8 (for instance here https://github.com/web2py/web2py/blob/master/gluon/tools.py#L478-L481) 
and then convert to unicode again. This piece of code shows the exception being raised:

```
>>> a = u'áéí'
>>> a
u'\xe1\xe9\xed'
>>> b = a.encode('utf-8')
>>> b
'\xc3\xa1\xc3\xa9\xc3\xad'
>>> unicode(a)
u'\xe1\xe9\xed'
>>> unicode(b)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 0: ordinal not in range(128)
```

If we force to str, just like @matclab suggested, we solve this issue.