### PR TITLE
Make SessionSetDb.get() a generator.

### DIFF
--- a/scripts/sessions2trash.py
+++ b/scripts/sessions2trash.py
@@ -104,12 +104,10 @@ class SessionSetDb(SessionSet):
 
     def get(self):
         """Return list of SessionDb instances for existing sessions."""
-        sessions = []
         table = current.response.session_db_table
         if table:
             for row in table._db(table.id > 0).select():
-                sessions.append(SessionDb(row))
-        return sessions
+                yield SessionDb(row)
 
 
 class SessionSetFiles(SessionSet):


### PR DESCRIPTION
Make the same change for SessionSetDb that's in SessionSetFiles: Make get() a generator, so that memory doesn't get blown out if there are 18 million sessions there to clean up.