### PR TITLE
Fix #1170 by reverting fix to #1043

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -938,8 +938,6 @@ def formstyle_bootstrap3_inline_factory(col_label_size=3):
             elif isinstance(controls, UL):
                 for e in controls.elements("input"):
                     e.add_class('form-control')
-            elif controls is None or isinstance(controls, basestring):
-                _controls = P(controls, _class="form-control-static %s" % col_class)
             if isinstance(label, LABEL):
                 label['_class'] = add_class(label.get('_class'),'control-label %s' % label_col_class)
 


### PR DESCRIPTION
The problem is only a styling issue and not a HTML one.

It was solved  in 864dbe73f251110ea690978d73d510beaeb31364 by adding a `readonly ` class to labels which allow for properly vertical align with CSS.

This reverts commit 353db90a64433d384aa27d1f2043536d6d8f76ce which add
specific HTML for some filed types and which breaks display of comments.