### PR TITLE
Fixed a bug whereby calling 'delete_record()' on a row object caused …

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -2364,7 +2364,7 @@ class SQLFORM(FORM):
                 if deletable(record):
                     if ondelete:
                         ondelete(table, request.args[-1])
-                    record.delete_record()
+                    db(table[table._id.name] == request.args[-1]).delete()
             if request.ajax:
                 # this means javascript is enabled, so we don't need to do
                 # a redirect


### PR DESCRIPTION
…an AttributeError.

The error is reproducible by creating an SQLFORM and specifying the 'deletable' parameter as a callback.  Upon deletion Web2Py will encounter an AttributeError because there is no such attribute of 'delete_record' for the 'record' object.  I simply copied the behavior of the block  where deletable is NOT callable by overwriting a single line of code.  This could be simplified, but I am not experienced enough with the DAL to do such a thing.