### PR TITLE
invalid view for purely compiled app

### DIFF
--- a/gluon/compileapp.py
+++ b/gluon/compileapp.py
@@ -676,8 +676,8 @@ def run_view_in(environment):
     else:
         filename = pjoin(folder, 'views', view)
         if os.path.exists(path): # compiled views
-            x = view.replace('/', '_')
-            files = ['views_%s.pyc' % x]
+            x = view.replace('/', '.')
+            files = ['views.%s.pyc' % x]
             is_compiled = os.path.exists(pjoin(path, files[0]))
             # Don't use a generic view if the non-compiled view exists.
             if is_compiled or (not is_compiled and not os.path.exists(filename)):


### PR DESCRIPTION
When packing a compiled app, and distributing it without the non-compiled views, run_view_in(...) searches only the old style compiled view file: e.g. views_default_index.html.pyc and not in views.default.index.html.pyc, resulting in "invalid view (default/index.html)" 404 Exception.
