### PR TITLE
Delete obsolete comment left behind

### DIFF
--- a/gluon/tests/test_web.py
+++ b/gluon/tests/test_web.py
@@ -108,7 +108,6 @@ class TestWeb(LiveTest):
         # check registration and login were successful
         client.get('index')
 
-        # COMMENTED BECAUSE FAILS BUT WHY?
         self.assertTrue('Welcome Homer' in client.text)
 
         client = WebClient('http://127.0.0.1:8000/admin/default/')


### PR DESCRIPTION
Comment at L111 :
         # COMMENTED BECAUSE FAILS BUT WHY?

Seems left behind and not useful anymore