### PR TITLE
Avoid issuing a separate sql query for each row in sqlform grid search results, for virtual fields

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -2743,7 +2743,11 @@ class SQLFORM(FORM):
                     if field.type == 'blob':
                         continue
                     if isinstance(field, Field.Virtual) and field.tablename in row:
-                        value = row[field.tablename][field.name]
+                        try:
+                            # fast path, works for joins
+                            value = row[field.tablename][field.name]
+                        except KeyError:
+                            value = dbset.db[field.tablename][row[field.tablename][field_id]][field.name]
                     else:
                         value = row[str(field)]
                     maxlength = maxtextlengths.get(str(field), maxtextlength)

--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -2743,7 +2743,7 @@ class SQLFORM(FORM):
                     if field.type == 'blob':
                         continue
                     if isinstance(field, Field.Virtual) and field.tablename in row:
-                        value = dbset.db[field.tablename][row[field.tablename][field_id]][field.name]
+                        value = row[field.tablename][field.name]
                     else:
                         value = row[str(field)]
                     maxlength = maxtextlengths.get(str(field), maxtextlength)


### PR DESCRIPTION
When deriving the value for a virtual field in a sqlform grid, this change avoids issuing a separate sql query for each row found in the search results.

Feel free to ignore the PR or simply see it as a bug report if my change doesn't make sense.

Thanks