### PR TITLE
Fix #1267 cas_login

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -1735,6 +1735,7 @@ class Auth(object):
             host = host_names[0]
         else:
             host = 'localhost'
+        return host
 
     def __init__(self, environment=None, db=None, mailer=True,
                  hmac_key=None, controller='default', function='user',


### PR DESCRIPTION
function `select_host` wasn't return the selected host