### PR TITLE
<main> semantic element IE fix

### DIFF
--- a/applications/examples/static/css/stupid.css
+++ b/applications/examples/static/css/stupid.css
@@ -28,6 +28,7 @@ tbody tr {border-bottom:2px solid #f1f1f1}
 td, th {padding: 5px; text-align: left; vertical-align:top}
 thead th {vertical-align:bottom}
 header, footer {with:100%}
+main {display: block;} /* IE fix */
 
 @media all and (max-width:599px) {
   h1{font-size:2em}


### PR DESCRIPTION
Some versions of Internet Explorer consider the <main> semantic element as "unknown". So its initial value is "inline".If we want the behavior of the <main> element to be the same as in other browsers, we must set it explicitly as a "block."