### PR TITLE
script for language files update has new param to update existing tra…

### DIFF
--- a/gluon/languages.py
+++ b/gluon/languages.py
@@ -1002,17 +1002,19 @@ def update_all_languages(application_path):
             findT(application_path, language[:-3])
 
 
-def update_from_langfile(target, source):
+def update_from_langfile(target, source, force_update=False):
     """this will update untranslated messages in target from source (where both are language files)
     this can be used as first step when creating language file for new but very similar language
         or if you want update your app from welcome app of newer web2py version
         or in non-standard scenarios when you work on target and from any reason you have partial translation in source
+    Args:
+        force_update: if False existing translations remain unchanged, if True existing translations will update from source
     """
     src = read_dict(source)
     sentences = read_dict(target)
     for key in sentences:
         val = sentences[key]
-        if not val or val == key:
+        if not val or val == key or force_update:
             new_val = src.get(key)
             if new_val and new_val != val:
                 sentences[key] = new_val

--- a/scripts/lang_update_from_langfile.py
+++ b/scripts/lang_update_from_langfile.py
@@ -30,8 +30,15 @@ if __name__ == '__main__':
         dest="source",
         help="Specify language file (ro) where seek for translations"
     )
+    parser.add_argument(
+        '-f', '--force-update',
+        dest="force_update",
+        action="store_true",
+        default=False,
+        help="without it: add new + translate untranslated, if used: in addition update items if translation differs"
+    )
     args = parser.parse_args()
 
-    update_from_langfile(args.target, args.source)
+    update_from_langfile(args.target, args.source, force_update=args.force_update)
 
     print '%s was updated.' % args.target


### PR DESCRIPTION
…nslations

Example for the new -f parameter:

scripts/lang_update_from_langfile.py -t applications/**myoldapplication**/languages/cs.py -s applications/**welcome**/languages/cs.py

If you have existing application and translation files are improved with new web2py version,
then running script without -f parameter (i.e. running old version of script):
- will add new messages from current welcome,
- will translate untranslated messages in myoldapplication with help of current welcome

But with -f parameter additionally
- existing same messages in myoldapplication will be updated from current welcome
