### PR TITLE
Bug fix request

### DIFF
--- a/gluon/compileapp.py
+++ b/gluon/compileapp.py
@@ -480,7 +480,7 @@ def compile_views(folder, skip_failed_views=False):
             else:
                 raise Exception("%s in %s" % (e, fname))
         else:
-            filename = ('views/%s.py' % fname).replace('/', '_').replace('\\', '_')
+            filename = ('views/%s.py' % fname).replace('/', '.').replace('\\', '_')
             filename = pjoin(folder, 'compiled', filename)
             write_file(filename, data)
             save_pyc(filename)


### PR DESCRIPTION
I am developing a Mac Desktop application using Web2py. My application
worked perfect before compilation. However, after compilation, my
custom views could not be displayed, so the generic ones were used.

I figured out that the names of the compiled views were not consistent
with the ones of the other compiled files. For example:
views_01_conglomerado_index.html.pyc

instead of:
views.01_conglomerado.index.html.pyc

I have not tried in Windows, but maybe the correction should be done as
well, yielding:

filename = ('views/%s.py' % fname).replace('/', '.').replace('\\', '.')