### PR TITLE
fixed timing attack in gluon.utils.compare

### DIFF
--- a/gluon/utils.py
+++ b/gluon/utils.py
@@ -83,11 +83,9 @@ def compare(a, b):
     """ Compares two strings and not vulnerable to timing attacks """
     if HAVE_COMPARE_DIGEST:
         return hmac.compare_digest(a, b)
-    if len(a) != len(b):
-        return False
-    result = 0
-    for x, y in zip(a, b):
-        result |= ord(x) ^ ord(y)
+    result = len(a) ^ len(b)
+    for i in xrange(len(b)):
+		result |= ord(a[i%len(a)]) ^ ord(b[i])
     return result == 0
 
 


### PR DESCRIPTION
[Timing Attacks](https://en.wikipedia.org/wiki/Timing_attack) are a class of side channel attacks in which information is leaked from systems through differences in timing. gluon.utils.compare is designed to resist timing attacks by forcing constant-time character comparisons on the inputs, but leaks information about the relative length inputs by exiting early when lengths differ.

This patch mitigates the information leak by registering early failure when lengths differ, but still executing over the arguments. Choosing one argument to make the "max length" is necessary, but essentially arbitrary for a single set of arguments. Across multiple sets of arguments, it is preferable to use the attacker's value to avoid exposing differences in relative length between defender values. Current code appears to use the second argument for checking user-supplied values, so it was designated the "attacker" value and drives the number of comparisons.

    In [1]: import timeit
    
    In [2]: timeit.timeit('import gluon.utils;gluon.utils.compare("A"*40,"B"*1)',number=100000)
    Out[2]: 0.32759690284729004
    
    In [3]: timeit.timeit('import gluon.utils;gluon.utils.compare("A"*40,"B"*20)',number=100000)
    Out[3]: 0.31953907012939453
    
    In [4]: timeit.timeit('import gluon.utils;gluon.utils.compare("A"*40,"B"*40)',number=100000)
    Out[4]: 0.9935009479522705
    
    In [5]: timeit.timeit('import gluon.utils;gluon.utils.compare_patched("A"*40,"B"*1)',number=100000)
    Out[5]: 0.40862298011779785
    
    In [6]: timeit.timeit('import gluon.utils;gluon.utils.compare_patched("A"*40,"B"*20)',number=100000)
    Out[6]: 0.8014039993286133
    
    In [7]: timeit.timeit('import gluon.utils;gluon.utils.compare_patched("A"*40,"B"*40)',number=100000)
    Out[7]: 1.224052906036377
    
    In [8]: timeit.timeit('import gluon.utils;gluon.utils.compare_patched("A"*1,"B"*20)',number=100000)
    Out[8]: 0.8001160621643066

    In [9]: timeit.timeit('import gluon.utils;gluon.utils.compare_patched("A"*20,"B"*20)',number=100000)
    Out[9]: 0.7952229976654053

    In [10]: timeit.timeit('import gluon.utils;gluon.utils.compare_patched("A"*40,"B"*20)',number=100000)
    Out[10]: 0.8102340698242188
