### PR TITLE
simplified oneall dname handling

### DIFF
--- a/gluon/contrib/login_methods/oneall_account.py
+++ b/gluon/contrib/login_methods/oneall_account.py
@@ -51,7 +51,7 @@ class OneallAccount(object):
             reg_id=profile.get('identity_token','')
             username=profile.get('preferredUsername',email)
             first_name=name.get('givenName', dname.split(' ')[0])
-            last_name=profile.get('familyName', dname.split(' ')[1] if(len(dname.split(' ')) > 1) else None)
+            last_name=profile.get('familyName', dname.split(' ')[1] if(dname.count(' ') > 0) else None)
             return dict(registration_id=reg_id,username=username,email=email,
                         first_name=first_name,last_name=last_name)
         self.mappings.default = defaultmapping


### PR DESCRIPTION
len(dname.split(' ')) is less clear and efficient than dname.count(' ')