### PR TITLE
better breadcrumb divider for smartgrid

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -2920,7 +2920,7 @@ class SQLFORM(FORM):
     def smartgrid(table, constraints=None, linked_tables=None,
                   links=None, links_in_grid=True,
                   args=None, user_signature=True,
-                  divider='>', breadcrumbs_class='',
+                  divider=2*unichr(160) + '>' + 2*unichr(160), breadcrumbs_class='',
                   **kwargs):
         """
         Builds a system of SQLFORM.grid(s) between any referenced tables


### PR DESCRIPTION
What about this minimalistic change?
Provides better divider in smartgrid:

places  >  Paris  >  campaigns  >  Edit 2016-05

instead of

places>Paris>campaigns>Edit 2016-05

160 is &nbsp
On narrow (mobile) display where breadcrumb splits into more lines it looks good too.
