### PR TITLE
fixing dictionary changed size error on SQLFORM using extra_fields

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -1711,8 +1711,8 @@ class SQLFORM(FORM):
                 fields[fieldname] = self.vars[fieldname]
 
         if dbio:
-            for fieldname in fields:
-                if fieldname in self.extra_fields:
+            for fieldname in self.extra_fields:
+                if fieldname in fields:
                     del fields[fieldname]
             if 'delete_this_record' in fields:
                 # this should never happen but seems to happen to some


### PR DESCRIPTION
When uses the extra_fields keyword argument in SQLFORM rises an
"RuntimeError: dictionary changed size during iteration" exception
because is trying to remove a dictionary element while is iterating the
dict