### PR TITLE
Ignore internal attributes when checking whether new session was changed

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -1136,6 +1136,12 @@ class Session(Storage):
         return True
 
     def _unchanged(self, response):
+        if response.session_new:
+	    internal = ['_last_timestamp', '_secure', '_start_timestamp']
+            for item in self.keys():
+                if item not in internal:
+                    return False
+            return True
         session_pickled = pickle.dumps(self, pickle.HIGHEST_PROTOCOL)
         response.session_pickled = session_pickled
         session_hash = hashlib.md5(session_pickled).hexdigest()

--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -1137,7 +1137,7 @@ class Session(Storage):
 
     def _unchanged(self, response):
         if response.session_new:
-	    internal = ['_last_timestamp', '_secure', '_start_timestamp']
+            internal = ['_last_timestamp', '_secure', '_start_timestamp']
             for item in self.keys():
                 if item not in internal:
                     return False


### PR DESCRIPTION
The simple hash check always fails for new secure sessions because the `_secure` flag is added *after* calculating the initial `response.session_hash`. Therefore new secure sessions will be stored even when they're effectively empty. This patch makes sure that a new session contains something *other* than purely internal attributes before it is stored.