### PR TITLE
 represent none

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -2318,6 +2318,10 @@ class SQLFORM(FORM):
         elif details and request.args(-3) == 'view':
             table = db[request.args[-2]]
             record = table(request.args[-1]) or redirect(referrer)
+            if represent_none is not None:
+                for field in record.iterkeys():
+                    if record[field] is None:
+                        record[field] = represent_none
             sqlformargs = dict(upload=upload, ignore_rw=ignore_rw,
                                formstyle=formstyle, readonly=True,
                                _class='web2py_form')

--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -2041,7 +2041,8 @@ class SQLFORM(FORM):
              client_side_delete=False,
              ignore_common_filters=None,
              auto_pagination=True,
-             use_cursor=False):
+             use_cursor=False,
+             represent_none=None):
 
         formstyle = formstyle or current.response.formstyle
         if isinstance(query, Set):
@@ -2789,6 +2790,8 @@ class SQLFORM(FORM):
                         value = truncate_string(value, maxlength)
                     elif not isinstance(value, XmlComponent):
                         value = field.formatter(value)
+                    if value is None:
+                        value = represent_none
                     trcols.append(TD(value))
                 row_buttons = TD(_class='row_buttons', _nowrap=True)
                 if links and links_in_grid:


### PR DESCRIPTION
Gives a possibility to redefine format of None values in grid.
Default behaviour is: None, ie. exactly as earlier. Developer can set: T("unknown") or "" or ....
Applies in grid itselves and in record view.

Reason:
It is not convenient for the user to see "None" (especially in non-english applications).
Outside of grid the solution is easy like: <td>{{=employee.company or ""}}</td>
But inside the grid it is not easy for the developer set the format via represent= (especially for foreign keys, date values,..).
