### PR TITLE
revert wiki to earlier (properly working) state

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -6503,10 +6503,8 @@ class Wiki(object):
             'wiki_editor' not in auth.user_groups.values() and
                 self.settings.groups == auth.user_groups.values()):
             group = db.auth_group(role='wiki_editor')
-            if group:
-                gid = group.id
-            else:
-                db.auth_group.insert(role='wiki_editor')
+            gid = group.id if group else db.auth_group.insert(
+                role='wiki_editor')
             auth.add_membership(gid)
 
         settings.lock_keys = True


### PR DESCRIPTION
Seems wiki functionality is broken with some previous commit.
Giving back the working code from 2.14.5:

https://groups.google.com/forum/#!topic/web2py/f3UBu1t4wrQ
