### PR TITLE
Don't truncate texts on SQLFORM.grid HTML Export

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -2476,7 +2476,8 @@ class SQLFORM(FORM):
                 response.headers['Content-Type'] = oExp.content_type
                 response.headers['Content-Disposition'] = \
                     'attachment;filename=' + filename + ';'
-                raise HTTP(200, oExp.export(), **response.headers)
+                document = oExp.export(maxtextlength) if oExp.__class__.__name__== 'ExporterHTML' else oExp.export()
+                raise HTTP(200, document, **response.headers)
 
         elif request.vars.records and not isinstance(
                 request.vars.records, list):
@@ -3549,9 +3550,9 @@ class ExporterHTML(ExportClass):
     def __init__(self, rows):
         ExportClass.__init__(self, rows)
 
-    def export(self):
-        xml = self.rows.xml() if self.rows else ''
-        return '<html>\n<head>\n<meta http-equiv="content-type" content="text/html; charset=UTF-8" />\n</head>\n<body>\n%s\n</body>\n</html>' % (xml or '')
+    def export(self, truncate=16):
+        table = SQLTABLE(self.rows, truncate=truncate) if self.rows else ''
+        return '<html>\n<head>\n<meta http-equiv="content-type" content="text/html; charset=UTF-8" />\n</head>\n<body>\n%s\n</body>\n</html>' % (table or '')
 
 
 class ExporterXML(ExportClass):

--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -2476,8 +2476,7 @@ class SQLFORM(FORM):
                 response.headers['Content-Type'] = oExp.content_type
                 response.headers['Content-Disposition'] = \
                     'attachment;filename=' + filename + ';'
-                document = oExp.export(maxtextlength) if oExp.__class__.__name__== 'ExporterHTML' else oExp.export()
-                raise HTTP(200, document, **response.headers)
+                raise HTTP(200, oExp.export(), **response.headers)
 
         elif request.vars.records and not isinstance(
                 request.vars.records, list):
@@ -3550,8 +3549,8 @@ class ExporterHTML(ExportClass):
     def __init__(self, rows):
         ExportClass.__init__(self, rows)
 
-    def export(self, truncate=16):
-        table = SQLTABLE(self.rows, truncate=truncate) if self.rows else ''
+    def export(self):
+        table = SQLTABLE(self.rows, truncate=None) if self.rows else ''
         return '<html>\n<head>\n<meta http-equiv="content-type" content="text/html; charset=UTF-8" />\n</head>\n<body>\n%s\n</body>\n</html>' % (table or '')
 
 


### PR DESCRIPTION
Allow HTML export to display long texts.