### PR TITLE
Fix next redirect if only one / exists

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -1918,11 +1918,13 @@ class Auth(object):
         if isinstance(next, (list, tuple)):
             next = next[0]
         if next and self.settings.prevent_open_redirect_attacks:
-            # Prevent an attacker from adding an arbitrary url after the
-            # _next variable in the request.
-            items = next.split('/')
-            if '//' in next and items[2] != current.request.env.http_host:
-                next = None
+            # Prevent an attacker from adding an arbitrary url after the _next variable in the request.
+            # Browsers will fix a single / so check multiple things just in case
+            items = filter(None, next.split('/'))
+            has_url = any(x in next for x in ['//', ':', 'ftp', 'http', 'rss', 'xml'])
+            if has_url and len(items) > 1:
+                if items[1] != current.request.env.http_host:
+                    next = None
         return next
 
     def _get_user_id(self):


### PR DESCRIPTION
Current next= allows for redirect to an external site if a single / is entered instead of //. Example: next=http:/example.com will redirect as most browsers will fix the single slash and the function only checks for //