### PR TITLE
Fixed open redirect security vulnerability 

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -1921,8 +1921,11 @@ class Auth(object):
             # Prevent an attacker from adding an arbitrary url after the
             # _next variable in the request.
             items = next.split('/')
-            if '//' in next and items[2] != current.request.env.http_host:
-                next = None
+            if next:
+                if next[0] != '/':
+                    if '://' not in next or next.split('://')[1].split('/')[0] != current.request.env.http_host:
+                        if ':' in next.split('/')[0]:
+                            next = None
         return next
 
     def _get_user_id(self):


### PR DESCRIPTION
The previous filter searched for two forward slashes "//" in the "_next” parameter and if the two forward slashes were found it would check the URI and determine if the hostname matched the hostname of the web server. If the hostname did not match, it would change the "next" variable to the None. However, browsers don't require two forward slashes. As a feature, browsers accept typos such as http:google.com or http:/google.com and redirect to http://google.com. This can be used to leverage an open redirect attack even with the current filter. This commit fixes the open redirect vulnerability in the _next get parameter. Thanks to jnbrex for helping debug/write the patch for this vulnerability.

Note: when testing this vulnerability, you must change the protocol in the URI. For example: if you are hosting the site using http, your redirect must go to a https site. Furthermore: http://web2py.com?_next=https:/malicioussite.com