### PR TITLE
Changed tuple to list

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -1930,7 +1930,7 @@ class Auth(object):
             parts = next.split('/')
             if not ':' in parts[0]:
                 return next
-            elif len(parts)>2 and parts[0].endswith(':') and parts[1:3]==('', host):
+            elif len(parts)>2 and parts[0].endswith(':') and parts[1:3]==['', host]:
                 return next
         return None
 


### PR DESCRIPTION
The comparison between parts[1:3] and ('', host) would always evaluate to false because a list and a tuple were being compared.