### PR TITLE
Massive memory leak in Scheduler with PostgreSQL

### DIFF
--- a/gluon/contrib/pg8000/core.py
+++ b/gluon/contrib/pg8000/core.py
@@ -1568,7 +1568,9 @@ class Connection(object):
             statement, make_args = cache['statement'][operation]
         except KeyError:
             statement, make_args = convert_paramstyle(paramstyle, operation)
-            cache['statement'][operation] = statement, make_args
+            # FIXME: Rewrite PyDAL to generate query strings with placeholders,
+            # then uncomment the line below
+            #cache['statement'][operation] = statement, make_args
 
         args = make_args(vals)
         params = self.make_params(args)
@@ -1654,7 +1656,9 @@ class Connection(object):
             ps['bind_2'] = h_pack(len(output_fc)) + \
                 pack("!" + "h" * len(output_fc), *output_fc)
 
-            cache['ps'][key] = ps
+            # FIXME: Rewrite PyDAL to generate query strings with placeholders,
+            # then uncomment the line below
+            #cache['ps'][key] = ps
 
         cursor._cached_rows.clear()
         cursor._row_count = -1


### PR DESCRIPTION
When you run Web2Py scheduler on PostgreSQL, you'll get massive memory leak to the tune of 1GB RAM consumed in 48 hours. The problem is not really a bug as such but rather a horrible design mismatch between PyDAL and the pg8000 driver.

Long story short, pg8000 driver supports multiple user-friendly placeholder formats for query arguments and converts them to the format supported by PosgreSQL server. It also expects that the number of unique query strings will be fairly limited (because the arguments will be passed separately) and stores the converted query strings and some other computationally expensive metadata in cache.

Meanwhile, PyDAL happily dumps all arguments into the query string itself, which means that every single scheduler heartbeat will turn into a unique query string and bloat the pg8000 cache.

This patch is a dirty workaround that disables pg8000 query cache. The correct solution would be rewriting PyDAL to pass query arguments through placeholders. Otherwise you're giving up a pretty big performance boost.