### PR TITLE
fixed most of py3 warnings, output is much cleaner this way

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ install:
   - pip install codecov
   - git submodule update --init --recursive
   - pip install pycrypto
+  - pip install pypiwin32
   # Check that we have the expected version and architecture for Python
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""

--- a/gluon/tests/test_recfile.py
+++ b/gluon/tests/test_recfile.py
@@ -29,7 +29,8 @@ class TestRecfile(unittest.TestCase):
             filename = os.path.join('tests', str(uuid.uuid4()) + '.test')
             with recfile.open(filename, "w") as g:
                 g.write(teststring)
-            self.assertEqual(recfile.open(filename, "r").read(), teststring)
+            with recfile.open(filename, "r") as f:
+                self.assertEqual(f.read(), teststring)
             is_there = recfile.exists(filename)
             self.assertTrue(is_there)
             recfile.remove(filename)
@@ -40,7 +41,8 @@ class TestRecfile(unittest.TestCase):
             filename = str(uuid.uuid4()) + '.test'
             with recfile.open(filename, "w", path='tests') as g:
                 g.write(teststring)
-            self.assertEqual(recfile.open(filename, "r", path='tests').read(), teststring)
+            with recfile.open(filename, "r", path='tests') as f:
+                self.assertEqual(f.read(), teststring)
             is_there = recfile.exists(filename, path='tests')
             self.assertTrue(is_there)
             recfile.remove(filename, path='tests')
@@ -51,7 +53,8 @@ class TestRecfile(unittest.TestCase):
             filename = os.path.join('tests', str(uuid.uuid4()), str(uuid.uuid4()) + '.test')
             with recfile.open(filename, "w") as g:
                 g.write(teststring)
-            self.assertEqual(recfile.open(filename, "r").read(), teststring)
+            with recfile.open(filename, "r") as f:
+                self.assertEqual(f.read(), teststring)
             is_there = recfile.exists(filename)
             self.assertTrue(is_there)
             recfile.remove(filename)
@@ -63,7 +66,9 @@ class TestRecfile(unittest.TestCase):
         with open(filename, 'w') as g:
             g.write('this file exists')
         self.assertTrue(recfile.exists(filename))
-        self.assertTrue(hasattr(recfile.open(filename, "r"), 'read'))
+        r = recfile.open(filename, "r")
+        self.assertTrue(hasattr(r, 'read'))
+        r.close()
         recfile.remove(filename, path='tests')
         self.assertFalse(recfile.exists(filename))
         self.assertRaises(IOError, recfile.remove, filename)

--- a/gluon/tests/test_router.py
+++ b/gluon/tests/test_router.py
@@ -21,7 +21,7 @@ from gluon.fileutils import abspath
 from gluon.settings import global_settings
 from gluon.http import HTTP
 from gluon.storage import Storage
-from gluon._compat import to_bytes, to_native
+from gluon._compat import to_bytes, to_native, PY2
 
 logger = None
 oldcwd = None
@@ -93,6 +93,11 @@ def tearDownModule():
 class TestRouter(unittest.TestCase):
     """ Tests the routers logic from gluon.rewrite """
 
+    def myassertRaisesRegex(self, *args, **kwargs):
+        if PY2:
+            return getattr(self, 'assertRaisesRegexp')(*args, **kwargs)
+        return getattr(self, 'assertRaisesRegex')(*args, **kwargs)
+
     def test_router_syntax(self):
         """ Test router syntax error """
         level = logger.getEffectiveLevel()
@@ -102,16 +107,13 @@ class TestRouter(unittest.TestCase):
             SyntaxError, load, rdict=dict(BASE=dict(badkey="value")))
         self.assertRaises(SyntaxError, load, rdict=dict(
             BASE=dict(), app=dict(default_application="name")))
-        try:
-            # 2.7+ only
-            self.assertRaisesRegexp(SyntaxError, "invalid syntax",
-                                    load, data='x:y')
-            self.assertRaisesRegexp(SyntaxError, "unknown key",
-                                    load, rdict=dict(BASE=dict(badkey="value")))
-            self.assertRaisesRegexp(SyntaxError, "BASE-only key",
-                                    load, rdict=dict(BASE=dict(), app=dict(default_application="name")))
-        except AttributeError:
-            pass
+
+        self.myassertRaisesRegex(SyntaxError, "invalid syntax",
+                                load, data='x:y')
+        self.myassertRaisesRegex(SyntaxError, "unknown key",
+                                load, rdict=dict(BASE=dict(badkey="value")))
+        self.myassertRaisesRegex(SyntaxError, "BASE-only key",
+                                load, rdict=dict(BASE=dict(), app=dict(default_application="name")))
         logger.setLevel(level)
 
     def test_router_null(self):
@@ -135,11 +137,7 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(filter_url('http://domain.com/welcome/static/path/to/static').replace('/', os.sep),
             norm_root("%s/applications/welcome/static/path/to/static" % root))
         self.assertRaises(HTTP, filter_url, 'http://domain.com/welcome/static/bad/path/to/st~tic')
-        try:
-            # 2.7+ only
-            self.assertRaisesRegexp(HTTP, "400.*invalid static file", filter_url, 'http://domain.com/welcome/static/bad/path/to/st~tic')
-        except AttributeError:
-            pass
+        self.myassertRaisesRegex(HTTP, "400.*invalid static file", filter_url, 'http://domain.com/welcome/static/bad/path/to/st~tic')
         # outgoing
         self.assertEqual(
             filter_url('http://domain.com/init/default/index', out=True), '/')
@@ -287,15 +285,10 @@ class TestRouter(unittest.TestCase):
         # incoming
         self.assertRaises(HTTP, filter_url, 'http://domain.com')
         self.assertRaises(HTTP, filter_url, 'http://domain.com/appadmin')
-        try:
-            # 2.7+ only
-            self.assertRaisesRegexp(HTTP, "400.*invalid application",
-                                    filter_url, 'http://domain.com')
-            self.assertRaisesRegexp(HTTP, "400.*invalid application",
+        self.myassertRaisesRegex(HTTP, "400.*invalid application",
+                                filter_url, 'http://domain.com')
+        self.myassertRaisesRegex(HTTP, "400.*invalid application",
                                     filter_url, 'http://domain.com/appadmin')
-        except AttributeError:
-            pass
-
         routers = dict(
             BASE=dict(default_application='welcome', applications=None),
         )
@@ -324,12 +317,7 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(
             filter_url('http://domain.com/'), '/welcome/default/index')
         self.assertRaises(HTTP, filter_url, 'http://domain.com/appadmin')
-        try:
-            # 2.7+ only
-            self.assertRaisesRegexp(HTTP, "400.*unknown application: 'appadmin'", filter_url, 'http://domain.com/appadmin')
-        except AttributeError:
-            pass
-
+        self.myassertRaisesRegex(HTTP, "400.*unknown application: 'appadmin'", filter_url, 'http://domain.com/appadmin')
         routers = dict(
             BASE=dict(default_application='welcome', applications=None),
             welcome=dict(controllers=None),
@@ -359,11 +347,7 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(
             filter_url('http://domain.com/'), '/welcome/default/index')
         self.assertRaises(HTTP, filter_url, 'http://domain.com/appadmin')
-        try:
-            # 2.7+ only
-            self.assertRaisesRegexp(HTTP, "400.*unknown application: 'appadmin'", filter_url, 'http://domain.com/appadmin')
-        except AttributeError:
-            pass
+        self.myassertRaisesRegex(HTTP, "400.*unknown application: 'appadmin'", filter_url, 'http://domain.com/appadmin')
 
         routers = dict(
             BASE=dict(default_application='welcome', applications=None),
@@ -391,13 +375,9 @@ class TestRouter(unittest.TestCase):
         # incoming
         self.assertRaises(HTTP, filter_url, 'http://domain.com')
         self.assertRaises(HTTP, filter_url, 'http://domain.com/appadmin')
-        try:
-            # 2.7+ only
-            self.assertRaisesRegexp(HTTP, "400.*invalid controller",
-                                    filter_url, 'http://domain.com')
-            self.assertRaisesRegexp(HTTP, "400.*unknown application: 'appadmin'", filter_url, 'http://domain.com/appadmin')
-        except AttributeError:
-            pass
+        self.myassertRaisesRegex(HTTP, "400.*invalid controller",
+                                filter_url, 'http://domain.com')
+        self.myassertRaisesRegex(HTTP, "400.*unknown application: 'appadmin'", filter_url, 'http://domain.com/appadmin')
 
         routers = dict(
             BASE=dict(default_application='welcome', applications=None),
@@ -425,13 +405,9 @@ class TestRouter(unittest.TestCase):
         # incoming
         self.assertRaises(HTTP, filter_url, 'http://domain.com')
         self.assertRaises(HTTP, filter_url, 'http://domain.com/appadmin')
-        try:
-            # 2.7+ only
-            self.assertRaisesRegexp(HTTP, "400.*invalid function",
-                                    filter_url, 'http://domain.com')
-            self.assertRaisesRegexp(HTTP, "400.*unknown application: 'appadmin'", filter_url, 'http://domain.com/appadmin')
-        except AttributeError:
-            pass
+        self.myassertRaisesRegex(HTTP, "400.*invalid function",
+                                filter_url, 'http://domain.com')
+        self.myassertRaisesRegex(HTTP, "400.*unknown application: 'appadmin'", filter_url, 'http://domain.com/appadmin')
 
     def test_router_app(self):
         """ Tests the doctest router app resolution"""
@@ -474,21 +450,13 @@ class TestRouter(unittest.TestCase):
             filter_url('http://domain.com/goodapp', app=True), 'goodapp')
         self.assertRaises(
             HTTP, filter_url, 'http://domain.com/bad!app', app=True)
-        try:
-            # 2.7+ only
-            self.assertRaisesRegexp(HTTP, '400.*invalid application',
+        self.myassertRaisesRegex(HTTP, '400.*invalid application',
                                     filter_url, 'http://domain.com/bad!app')
-        except AttributeError:
-            pass
 
         routers['BASE']['domains']['domain3.com'] = 'app3'
         self.assertRaises(SyntaxError, load, rdict=routers)
-        try:
-            # 2.7+ only
-            self.assertRaisesRegexp(
+        self.myassertRaisesRegex(
                 SyntaxError, "unknown.*app3", load, rdict=routers)
-        except AttributeError:
-            pass
 
     def test_router_domains_fs(self):
         '''
@@ -632,11 +600,8 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(filter_url('http://domain2.com/app3/c3a/f3',
                          domain=('app2b', None), out=True), "/app3/c3a/f3")
         self.assertRaises(SyntaxError, filter_url, 'http://domain1.com/app1/c1/f1', domain=('app2b', None), out=True)
-        try:
-            # 2.7+ only
-            self.assertRaisesRegexp(SyntaxError, 'cross-domain conflict', filter_url, 'http://domain1.com/app1/c1/f1', domain=('app2b', None), out=True)
-        except AttributeError:
-            pass
+        self.myassertRaisesRegex(SyntaxError, 'cross-domain conflict', filter_url,
+                                 'http://domain1.com/app1/c1/f1', domain=('app2b', None), out=True)
         self.assertEqual(filter_url('http://domain1.com/app1/c1/f1', domain=(
             'app2b', None), host='domain2.com', out=True), "/app1")
 
@@ -752,11 +717,8 @@ class TestRouter(unittest.TestCase):
 
         self.assertRaises(SyntaxError, filter_url, 'http://domain2.com/app3/c3a/f3', domain=('app2b', None), out=True)
         self.assertRaises(SyntaxError, filter_url, 'http://domain1.com/app1/c1/f1', domain=('app2b', None), out=True)
-        try:
-            # 2.7+ only
-            self.assertRaisesRegexp(SyntaxError, 'cross-domain conflict', filter_url, 'http://domain1.com/app1/c1/f1', domain=('app2b', None), out=True)
-        except AttributeError:
-            pass
+        self.myassertRaisesRegex(SyntaxError, 'cross-domain conflict', filter_url,
+                                 'http://domain1.com/app1/c1/f1', domain=('app2b', None), out=True)
         self.assertEqual(filter_url('http://domain1.com/app1/c1/f1', domain=(
             'app2b', None), host='domain2.com', out=True), "/app1")
 
@@ -789,28 +751,20 @@ class TestRouter(unittest.TestCase):
             HTTP, filter_url, 'http://domain.com/ctl/fcn.bad!ext')
         self.assertRaises(
             HTTP, filter_url, 'http://domain.com/ctl/fcn/bad!arg')
-        try:
-            # 2.7+ only
-            self.assertRaisesRegexp(HTTP, '400.*invalid controller', filter_url, 'http://domain.com/init/bad!ctl')
-            self.assertRaisesRegexp(HTTP, '400.*invalid function', filter_url,
-                                    'http://domain.com/init/ctlr/bad!fcn')
-            self.assertRaisesRegexp(HTTP, '400.*invalid extension', filter_url,
-                                    'http://domain.com/init/ctlr/fcn.bad!ext')
-            self.assertRaisesRegexp(HTTP, '400.*invalid arg', filter_url,
-                                    'http://domain.com/appc/init/fcn/bad!arg')
-        except AttributeError:
-            pass
+        self.myassertRaisesRegex(HTTP, '400.*invalid controller', filter_url, 'http://domain.com/init/bad!ctl')
+        self.myassertRaisesRegex(HTTP, '400.*invalid function', filter_url,
+                                'http://domain.com/init/ctlr/bad!fcn')
+        self.myassertRaisesRegex(HTTP, '400.*invalid extension', filter_url,
+                                'http://domain.com/init/ctlr/fcn.bad!ext')
+        self.myassertRaisesRegex(HTTP, '400.*invalid arg', filter_url,
+                                'http://domain.com/appc/init/fcn/bad!arg')
 
         self.assertEqual(filter_url('http://domain.com/welcome/default/fcn_1'),
                          "/welcome/default/fcn_1")
         self.assertRaises(
             HTTP, filter_url, 'http://domain.com/welcome/default/fcn-1')
-        try:
-            # 2.7+ only
-            self.assertRaisesRegexp(HTTP, '400.*invalid function', filter_url,
+        self.myassertRaisesRegex(HTTP, '400.*invalid function', filter_url,
                                     'http://domain.com/welcome/default/fcn-1')
-        except AttributeError:
-            pass
 
     def test_router_out(self):
         '''
@@ -1047,7 +1001,7 @@ class TestRouter(unittest.TestCase):
 
         from gluon.globals import current
         current.response.static_version = None
-        
+
         self.assertEqual(str(URL(a='init', c='default', f='a_b')), "/a_b")
         self.assertEqual(str(URL(a='app1', c='default', f='a_b')), "/app1/a-b")
         self.assertEqual(str(URL(a='app2', c='default', f='a_b')), "/app2/a_b")

--- a/gluon/tests/test_storage.py
+++ b/gluon/tests/test_storage.py
@@ -67,8 +67,8 @@ class TestStorage(unittest.TestCase):
         #self.assertRaises(KeyError, lambda x: s[x], 'd')   # old Storage
         s.a = 1
         s['a'] = None
-        self.assertEquals(s.a, None)
-        self.assertEquals(s['a'], None)
+        self.assertEqual(s.a, None)
+        self.assertEqual(s['a'], None)
         self.assertTrue('a' in s)
 
     def test_pickling(self):

--- a/gluon/tests/test_validators.py
+++ b/gluon/tests/test_validators.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """Unit tests for http.py """
@@ -16,6 +16,11 @@ from gluon.validators import *
 from gluon._compat import PY2, to_bytes
 
 class TestValidators(unittest.TestCase):
+
+    def myassertRegex(self, *args, **kwargs):
+        if PY2:
+            return getattr(self, 'assertRegexpMatches')(*args, **kwargs)
+        return getattr(self, 'assertRegex')(*args, **kwargs)
 
     def test_MISC(self):
         """ Test miscelaneous utility functions and some general behavior guarantees """
@@ -791,20 +796,20 @@ class TestValidators(unittest.TestCase):
 
     def test_CRYPT(self):
         rtn = str(CRYPT(digest_alg='md5', salt=True)('test')[0])
-        self.assertRegexpMatches(rtn, r'^md5\$.{16}\$.{32}$')
+        self.myassertRegex(rtn, r'^md5\$.{16}\$.{32}$')
         rtn = str(CRYPT(digest_alg='sha1', salt=True)('test')[0])
-        self.assertRegexpMatches(rtn, r'^sha1\$.{16}\$.{40}$')
+        self.myassertRegex(rtn, r'^sha1\$.{16}\$.{40}$')
         rtn = str(CRYPT(digest_alg='sha256', salt=True)('test')[0])
-        self.assertRegexpMatches(rtn, r'^sha256\$.{16}\$.{64}$')
+        self.myassertRegex(rtn, r'^sha256\$.{16}\$.{64}$')
         rtn = str(CRYPT(digest_alg='sha384', salt=True)('test')[0])
-        self.assertRegexpMatches(rtn, r'^sha384\$.{16}\$.{96}$')
+        self.myassertRegex(rtn, r'^sha384\$.{16}\$.{96}$')
         rtn = str(CRYPT(digest_alg='sha512', salt=True)('test')[0])
-        self.assertRegexpMatches(rtn, r'^sha512\$.{16}\$.{128}$')
+        self.myassertRegex(rtn, r'^sha512\$.{16}\$.{128}$')
         alg = 'pbkdf2(1000,20,sha512)'
         rtn = str(CRYPT(digest_alg=alg, salt=True)('test')[0])
-        self.assertRegexpMatches(rtn, r'^pbkdf2\(1000,20,sha512\)\$.{16}\$.{40}$')
+        self.myassertRegex(rtn, r'^pbkdf2\(1000,20,sha512\)\$.{16}\$.{40}$')
         rtn = str(CRYPT(digest_alg='md5', key='mykey', salt=True)('test')[0])
-        self.assertRegexpMatches(rtn, r'^md5\$.{16}\$.{32}$')
+        self.myassertRegex(rtn, r'^md5\$.{16}\$.{32}$')
         a = str(CRYPT(digest_alg='sha1', salt=False)('test')[0])
         self.assertEqual(CRYPT(digest_alg='sha1', salt=False)('test')[0], a)
         self.assertEqual(CRYPT(digest_alg='sha1', salt=False)('test')[0], a[6:])

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -6270,7 +6270,8 @@ class Expose(object):
         self.filenames = [f[dirname_len:]
                           for f in allowed if not os.path.isdir(f)]
         if 'README' in self.filenames:
-            readme = open(os.path.join(filename, 'README')).read()
+            with open(os.path.join(filename, 'README')) as f:
+                readme = f.read()
             self.paragraph = MARKMIN(readme)
         else:
             self.paragraph = None

--- a/gluon/utils.py
+++ b/gluon/utils.py
@@ -40,7 +40,7 @@ import hmac
 if hasattr(hashlib, "pbkdf2_hmac"):
     def pbkdf2_hex(data, salt, iterations=1000, keylen=24, hashfunc=None):
         hashfunc = hashfunc or sha1
-        hmac = hashlib.pbkdf2_hmac(hashfunc().name, to_bytes(data), 
+        hmac = hashlib.pbkdf2_hmac(hashfunc().name, to_bytes(data),
                                    to_bytes(salt), iterations, keylen)
         return binascii.hexlify(hmac)
     HAVE_PBKDF2 = True
@@ -171,7 +171,7 @@ def secure_dumps(data, encryption_key, hash_key=None, compression_level=None):
     key = pad(encryption_key)[:32]
     cipher, IV = AES_new(key)
     encrypted_data = base64.urlsafe_b64encode(IV + cipher.encrypt(pad(dump)))
-    signature = to_bytes(hmac.new(to_bytes(hash_key), encrypted_data).hexdigest())
+    signature = to_bytes(hmac.new(to_bytes(hash_key), encrypted_data, hashlib.md5).hexdigest())
     return signature + b':' + encrypted_data
 
 
@@ -184,7 +184,7 @@ def secure_loads(data, encryption_key, hash_key=None, compression_level=None):
         hash_key = sha1(encryption_key).hexdigest()
     signature, encrypted_data = data.split(':', 1)
     encrypted_data = to_bytes(encrypted_data)
-    actual_signature = hmac.new(to_bytes(hash_key), encrypted_data).hexdigest()
+    actual_signature = hmac.new(to_bytes(hash_key), encrypted_data, hashlib.md5).hexdigest()
     if not compare(signature, actual_signature):
         return None
     key = pad(encryption_key)[:32]


### PR DESCRIPTION
same should be done with pydal (and (or?) a better "import" of pydal unittests)