### PR TITLE
F redirect in admin/default/design (install of plugin)

### DIFF
--- a/applications/admin/controllers/default.py
+++ b/applications/admin/controllers/default.py
@@ -1088,10 +1088,10 @@ def design():
         else:
             session.flash = \
                 T('unable to create application "%s"', request.vars.filename)
-        redirect(URL(r=request))
+        redirect(URL(r=request, args=app))
     elif isinstance(request.vars.pluginfile, str):
         session.flash = T('plugin not specified')
-        redirect(URL(r=request))
+        redirect(URL(r=request, args=app))
 
     # If we have only pyc files it means that
     # we cannot design

--- a/applications/admin/controllers/default.py
+++ b/applications/admin/controllers/default.py
@@ -1087,7 +1087,7 @@ def design():
             redirect(URL('design', args=app))
         else:
             session.flash = \
-                T('unable to create application "%s"', request.vars.filename)
+                T('unable to install plugin "%s"', filename)
         redirect(URL(r=request, args=app))
     elif isinstance(request.vars.pluginfile, str):
         session.flash = T('plugin not specified')


### PR DESCRIPTION
Otherwise causes error if plugin install fails, because redirects to default/design without args/appname.