### PR TITLE
fixed "/app/static" throwing AttributeError instead of HTTP(404)

### DIFF
--- a/gluon/rewrite.py
+++ b/gluon/rewrite.py
@@ -638,9 +638,10 @@ def regex_url_in(request, environ):
         request.raw_args = request.raw_args[1:]
     if match.group('c') == 'static':
         application = match.group('a')
-        version, filename = None, match.group('z').replace(' ', '_')
+        version, filename = None, match.group('z')
         if not filename:
             raise HTTP(404)
+        filename = filename.replace(' ','_')
         items = filename.split('/', 1)
         if regex_version.match(items[0]):
             version, filename = items


### PR DESCRIPTION
HTTP requests for `/app/static` currently throw an AttributeError due to attempting a string replacement when the filename is None. Patch raises HTTP(404) before attempting the string replacement if filename is None.