### PR TITLE
caching read_pyc

### DIFF
--- a/gluon/compileapp.py
+++ b/gluon/compileapp.py
@@ -581,7 +581,7 @@ def run_models_in(environment):
             if not regex.search(fname) and c != 'appadmin':
                 continue
             elif compiled:
-                code = read_pyc(model)
+                code = getcfs(model, model, lambda: read_pyc(model))
             elif is_gae:
                 code = getcfs(model, model,
                               lambda: compile2(read_file(model), model))
@@ -614,7 +614,8 @@ def run_controller_in(controller, function, environment):
                 raise HTTP(404,
                            rewrite.THREAD_LOCAL.routes.error_message % badf,
                            web2py_error=badf)
-        restricted(read_pyc(filename), environment, layer=filename)
+        code = getcfs(filename, filename, lambda: read_pyc(filename))
+        restricted(code, environment, layer=filename)
     elif function == '_TEST':
         # TESTING: adjust the path to include site packages
         from settings import global_settings

--- a/gluon/compileapp.py
+++ b/gluon/compileapp.py
@@ -707,7 +707,7 @@ def run_view_in(environment):
                 for f in files:
                     compiled = pjoin(path, f)
                     if os.path.exists(compiled):
-                        code = read_pyc(compiled)
+                        code = getcfs(compiled, compiled, lambda: read_pyc(compiled))
                         restricted(code, environment, layer=compiled)
                         return
         if not os.path.exists(filename) and allow_generic:

--- a/gluon/restricted.py
+++ b/gluon/restricted.py
@@ -199,7 +199,7 @@ class RestrictedError(Exception):
 
 
 def compile2(code, layer):
-    return compile(code.rstrip(), layer, 'exec')
+    return compile(code, layer, 'exec')
 
 
 def restricted(code, environment=None, layer='Unknown'):

--- a/gluon/tests/test_appadmin.py
+++ b/gluon/tests/test_appadmin.py
@@ -10,7 +10,7 @@ import sys
 import unittest
 
 
-from gluon.compileapp import run_controller_in, run_view_in
+from gluon.compileapp import run_controller_in, run_view_in, compile_application, remove_compiled_application
 from gluon.languages import translator
 from gluon.storage import Storage, List
 from gluon import fileutils
@@ -76,7 +76,7 @@ class TestAppAdmin(unittest.TestCase):
     def run_view(self):
         return run_view_in(self.env)
 
-    def test_index(self):
+    def _test_index(self):
         result = self.run_function()
         self.assertTrue('db' in result['databases'])
         self.env.update(result)
@@ -85,6 +85,15 @@ class TestAppAdmin(unittest.TestCase):
         except Exception as e:
             print(e.message)
             self.fail('Could not make the view')
+
+    def test_index(self):
+        self._test_index()
+
+    def test_index_compiled(self):
+        appname_path = os.path.join(os.getcwd(), 'applications', 'welcome')
+        compile_application(appname_path)
+        self._test_index()
+        remove_compiled_application(appname_path)
 
     def test_select(self):
         request = self.env['request']


### PR DESCRIPTION
Running ```ab -n 10000 -c 1 http://localhost:8000/welcome/default/index``` on an i5 with SSD
I got (current master)
```
Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:    15   23  13.1     18     166
Waiting:       15   23  13.1     18     166
Total:         15   23  13.1     18     166
```
with this PR
```
Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:    15   19  10.4     16     148
Waiting:       15   19  10.4     15     147
Total:         15   19  10.4     16     148
```
The gain is ~15% running welcome default controller. @abastardi would you mind computing TechEmpower Benchmarks?

On the other hand since application files can change, such optimization requires a way to erase the cache (maintained in a dict in cfs.py). An idea is to erase such cache in ```compile_application()```. What do you think?


