### PR TITLE
fixes #1407, encouraging a sane default

### DIFF
--- a/applications/admin/views/web2py_ajax.html
+++ b/applications/admin/views/web2py_ajax.html
@@ -4,7 +4,7 @@
     var w2p_ajax_date_format = "{{=T('%Y-%m-%d')}}";
     var w2p_ajax_datetime_format = "{{=T('%Y-%m-%d %H:%M:%S')}}";
     var w2p_ajax_disable_with_message = "{{=T('Working...')}}";
-    var ajax_error_500 = '{{=T.M('An error occured, please [[reload %s]] the page') % URL(args=request.args, vars=request.get_vars) }}'
+    var ajax_error_500 = "{{=T.M('An error occured, please [[reload %s]] the page') % URL(args=request.args, vars=request.get_vars) }}"
     //--></script>
 {{
 response.files.insert(0,URL('static','js/jquery.js'))

--- a/applications/examples/views/web2py_ajax.html
+++ b/applications/examples/views/web2py_ajax.html
@@ -3,7 +3,7 @@
     var w2p_ajax_confirm_message = "{{=T('Are you sure you want to delete this object?')}}";
     var w2p_ajax_date_format = "{{=T('%Y-%m-%d')}}";
     var w2p_ajax_datetime_format = "{{=T('%Y-%m-%d %H:%M:%S')}}";
-    var ajax_error_500 = '{{=T.M('An error occured, please [[reload %s]] the page') % URL(args=request.args, vars=request.get_vars) }}'
+    var ajax_error_500 = "{{=T.M('An error occured, please [[reload %s]] the page') % URL(args=request.args, vars=request.get_vars) }}"
     //--></script>
 {{
 response.files.insert(0,URL('static','js/jquery.js'))

--- a/applications/welcome/views/web2py_ajax.html
+++ b/applications/welcome/views/web2py_ajax.html
@@ -4,7 +4,7 @@
     var w2p_ajax_disable_with_message = "{{=T('Working...')}}";
     var w2p_ajax_date_format = "{{=T('%Y-%m-%d')}}";
     var w2p_ajax_datetime_format = "{{=T('%Y-%m-%d %H:%M:%S')}}";
-    var ajax_error_500 = '{{=T.M('An error occured, please [[reload %s]] the page') % URL(args=request.args, vars=request.get_vars) }}'
+    var ajax_error_500 = "{{=T.M('An error occured, please [[reload %s]] the page') % URL(args=request.args, vars=request.get_vars) }}"
     //--></script>
 {{
 response.files.insert(0,URL('static','js/jquery.js'))


### PR DESCRIPTION
this makes everything enclosed in a double quote, that has less chance to occurr in a translated string. Though it isn't a "scientific fix", but because of the above and the "de-facto" recommendation of quoting with double quotes in js, should be enough in a world of "consenting adults".
The "scientific fix" would be to pass a json object and assign vars from there. I think that would be an overkill.