### PR TITLE
Fire event after web2py component completed (Enhancement)

### DIFF
--- a/applications/admin/static/js/web2py.js
+++ b/applications/admin/static/js/web2py.js
@@ -338,6 +338,7 @@
                         web2py.trap_form(action, target);
                         web2py.ajax_init('#' + target);
                         web2py.after_ajax(xhr);
+                        web2py.fire(element, 'w2p:componentComplete', [xhr, status], target); // Let us know the component is finished loading
                     }
                 });
             }

--- a/applications/examples/static/js/web2py.js
+++ b/applications/examples/static/js/web2py.js
@@ -338,6 +338,7 @@
                         web2py.trap_form(action, target);
                         web2py.ajax_init('#' + target);
                         web2py.after_ajax(xhr);
+                        web2py.fire(element, 'w2p:componentComplete', [xhr, status], target); // Let us know the component is finished loading
                     }
                 });
             }

--- a/applications/welcome/static/js/web2py.js
+++ b/applications/welcome/static/js/web2py.js
@@ -338,6 +338,7 @@
                         web2py.trap_form(action, target);
                         web2py.ajax_init('#' + target);
                         web2py.after_ajax(xhr);
+                        web2py.fire(element, 'w2p:componentComplete', [xhr, status], target); // Let us know the component is finished loading
                     }
                 });
             }


### PR DESCRIPTION
Sometimes we may want to know when the component is finished with it’s
loading process entirely to trigger animations or something similar.  I
added this for my own website, and I think that others may want to use
this.  It’s a small addition, but I hope that it will be helpful to
others!