### PR TITLE
Allow for firstname and lastname in verify_email message

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -3417,7 +3417,9 @@ class Auth(object):
                 link = self.url(
                     self.settings.function, args=('verify_email', key), scheme=True)
                 d = dict(form.vars)
-                d.update(dict(key=key, link=link, username=form.vars[username]))
+                d.update(dict(key=key, link=link, username=form.vars[username],
+                              firstname=form.vars['firstname'],
+                              lastname=form.vars['lastname']))
                 if not (self.settings.mailer and self.settings.mailer.send(
                         to=form.vars.email,
                         subject=self.messages.verify_email_subject,


### PR DESCRIPTION
Should fix #1518.

I have not find a simple way to add a test, as there is no existing test for registration.
We could add one by mocking smtp library, but it requires a bit more work to set up.