### PR TITLE
Mobile (iOS) fix for dismissing flashes

### DIFF
--- a/applications/admin/static/js/web2py.js
+++ b/applications/admin/static/js/web2py.js
@@ -563,7 +563,7 @@
             var flash = $('.w2p_flash');
             web2py.hide_flash();
             flash.html(message).addClass(status);
-            if (flash.html()) flash.append('<a id="closeflash" href="#" style="text-decoration: inherit; color: inherit;"> &times; </a>').slideDown();
+            if (flash.html()) flash.append('<a id="closeflash" href="javascript:null;" style="text-decoration: inherit; color: inherit;"> &times; </a>').slideDown();
         },
         hide_flash: function () {
             $('.w2p_flash').fadeOut(0).html('');

--- a/applications/admin/static/js/web2py.js
+++ b/applications/admin/static/js/web2py.js
@@ -563,7 +563,7 @@
             var flash = $('.w2p_flash');
             web2py.hide_flash();
             flash.html(message).addClass(status);
-            if (flash.html()) flash.append('<span id="closeflash"> &times; </span>').slideDown();
+            if (flash.html()) flash.append('<a id="closeflash" href="#" style="text-decoration: inherit; color: inherit;"> &times; </a>').slideDown();
         },
         hide_flash: function () {
             $('.w2p_flash').fadeOut(0).html('');

--- a/applications/examples/static/js/web2py.js
+++ b/applications/examples/static/js/web2py.js
@@ -563,7 +563,7 @@
             var flash = $('.w2p_flash');
             web2py.hide_flash();
             flash.html(message).addClass(status);
-            if (flash.html()) flash.append('<a id="closeflash" href="#" style="text-decoration: inherit; color: inherit;"> &times; </a>').slideDown();
+            if (flash.html()) flash.append('<a id="closeflash" href="javascript:null;" style="text-decoration: inherit; color: inherit;"> &times; </a>').slideDown();
         },
         hide_flash: function () {
             $('.w2p_flash').fadeOut(0).html('');

--- a/applications/examples/static/js/web2py.js
+++ b/applications/examples/static/js/web2py.js
@@ -563,7 +563,7 @@
             var flash = $('.w2p_flash');
             web2py.hide_flash();
             flash.html(message).addClass(status);
-            if (flash.html()) flash.append('<span id="closeflash"> &times; </span>').slideDown();
+            if (flash.html()) flash.append('<a id="closeflash" href="#" style="text-decoration: inherit; color: inherit;"> &times; </a>').slideDown();
         },
         hide_flash: function () {
             $('.w2p_flash').fadeOut(0).html('');

--- a/applications/welcome/static/js/web2py.js
+++ b/applications/welcome/static/js/web2py.js
@@ -563,7 +563,7 @@
             var flash = $('.w2p_flash');
             web2py.hide_flash();
             flash.html(message).addClass(status);
-            if (flash.html()) flash.append('<a id="closeflash" href="#" style="text-decoration: inherit; color: inherit;"> &times; </a>').slideDown();
+            if (flash.html()) flash.append('<a id="closeflash" href="javascript:null;" style="text-decoration: inherit; color: inherit;"> &times; </a>').slideDown();
         },
         hide_flash: function () {
             $('.w2p_flash').fadeOut(0).html('');

--- a/applications/welcome/static/js/web2py.js
+++ b/applications/welcome/static/js/web2py.js
@@ -563,7 +563,7 @@
             var flash = $('.w2p_flash');
             web2py.hide_flash();
             flash.html(message).addClass(status);
-            if (flash.html()) flash.append('<span id="closeflash"> &times; </span>').slideDown();
+            if (flash.html()) flash.append('<a id="closeflash" href="#" style="text-decoration: inherit; color: inherit;"> &times; </a>').slideDown();
         },
         hide_flash: function () {
             $('.w2p_flash').fadeOut(0).html('');


### PR DESCRIPTION
iOS devices don’t like listening to clicks on most objects.  They
typically prefer a and button objects.  This fix replaces the
#closeflash span with a link to “javascript:null;” instead (while also inheriting
text-decoration and color styling), so that mobile (iOS) devices will
allow you to close the flash.