### PR TITLE
implemented base support for CASv3

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -2005,6 +2005,12 @@ class Auth(object):
                 return self.cas_validate(version=2, proxy=False)
             elif args(1) == self.settings.cas_actions['proxyvalidate']:
                 return self.cas_validate(version=2, proxy=True)
+            elif (args(1) == 'p3'
+                  and args(2) == self.settings.cas_actions['servicevalidate']):
+                return self.cas_validate(version=3, proxy=False)
+            elif (args(1) == 'p3'
+                  and args(2) == self.settings.cas_actions['proxyvalidate']):
+                return self.cas_validate(version=3, proxy=True)
             elif args(1) == self.settings.cas_actions['logout']:
                 return self.logout(next=request.vars.service or DEFAULT)
         else:
@@ -2830,6 +2836,15 @@ class Auth(object):
         if success:
             if version == 1:
                 message = 'yes\n%s' % user[userfield]
+            elif version == 3:
+                username = user.get('username', user[userfield])
+                message = build_response(
+                    TAG['cas:authenticationSuccess'](
+                        TAG['cas:user'](username),
+                        TAG['cas:attributes'](
+                            *[TAG['cas:' + field.name](user[field.name])
+                              for field in self.table_user()
+                              if field.readable])))
             else:  # assume version 2
                 username = user.get('username', user[userfield])
                 message = build_response(


### PR DESCRIPTION
This commit extend the base CAS support also to v3 protocol. The only assumption is that the url for cas login for 'servicevalidate' and 'proxyvalidate' for V3 of protocol is like the following: 

```
- v3:
provider/default/user/cas/p3/{serviceValidate, proxyValidate}
- v2:
provider/default/user/cas/{serviceValidate, proxyValidate}
```
