### PR TITLE
when mkdir of missing app folders, handle broken links properly

### DIFF
--- a/gluon/admin.py
+++ b/gluon/admin.py
@@ -438,7 +438,11 @@ def add_path_first(path):
 def try_mkdir(path):
     if not os.path.exists(path):
         try:
-            os.mkdir(path)
+            if os.path.islink(path):
+                # path is a broken link, try to mkdir the target of the link instead of the link itself.
+                os.mkdir(os.path.realpath(path))
+            else:
+                os.mkdir(path)
         except OSError as e:
             if e.strerror == 'File exists': # In case of race condition.
                 pass


### PR DESCRIPTION
The code for creating missing application folders doesn't take symlinks into account.

If a web2py app is configured to have symlinks for some system folders (in my case `uploads` exists on a larger volume), and the link is broken because the target dir was removed, then the code in try_mkdir won't work.

`if not os.path.exists(path)` will return True when path is a broken symlink, but `os.mkdir(path)` will fail because the file exists (as a symlink). 

The fix is to identify broken links and mkdir the target instead of the link.