### PR TITLE
Fix for #1443 - PR will enable emperor.uwsgi.service on boot

### DIFF
--- a/scripts/setup-web2py-nginx-uwsgi-ubuntu.sh
+++ b/scripts/setup-web2py-nginx-uwsgi-ubuntu.sh
@@ -216,6 +216,7 @@ fi
 
 /etc/init.d/nginx start
 systemctl start emperor.uwsgi.service
+systemctl enable emperor.uwsgi.service
 
 echo <<EOF
 you can stop uwsgi and nginx with


### PR DESCRIPTION
Currently emperor.uwsgi.service is not started on boot, see https://github.com/web2py/web2py/issues/1443
