### PR TITLE
Fix router functions check

### DIFF
--- a/gluon/rewrite.py
+++ b/gluon/rewrite.py
@@ -1040,7 +1040,7 @@ class MapUrlIn(object):
         else:
             default_function = self.router.default_function  # str or None
         default_function = self.domain_function or default_function
-        if not arg0 or functions and arg0 not in functions:
+        if not arg0 or functions and arg0.split('.')[0] not in functions:
             self.function = default_function or ""
             self.pop_arg_if(arg0 and self.function == arg0)
         else:

--- a/gluon/tests/test_router.py
+++ b/gluon/tests/test_router.py
@@ -873,6 +873,27 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(str(URL(a='app2', c='default', f='index',
                          args=['ctr'])), "/app2/index/ctr")
 
+        # outbound - with extensions
+        self.assertEqual(
+            str(URL(a='app', c='default', f='index.json')), "/index.json")
+        self.assertEqual(
+            str(URL(a='app', c='default', f='index.json', args=['arg1'])), "/index.json/arg1")
+        self.assertEqual(str(
+            URL(a='app', c='default', f='user.json')), "/user.json")
+        self.assertEqual(str(
+            URL(a='app', c='default', f='user.json', args=['arg1'])), "/user.json/arg1")
+        self.assertEqual(str(URL(
+            a='app', c='default', f='user.json', args=['index'])), "/user.json/index")
+        self.assertEqual(str(
+            URL(a='app', c='default', f='index.json', args=['ctr'])), "/index.json/ctr")
+        self.assertEqual(
+            str(URL(a='app', c='ctr', f='ctrf1.json', args=['arg'])), "/ctr/ctrf1.json/arg")
+
+        self.assertEqual(str(URL(
+            a='app2', c='default', f='index.json', args=['arg1'])), "/app2/index.json/arg1")
+        self.assertEqual(str(URL(
+            a='app2', c='ctr', f='index.json', args=['arg1'])), "/app2/ctr/index.json/arg1")
+
         # inbound
         self.assertEqual(
             filter_url('http://d.com/arg'), "/app/default/index ['arg']")
@@ -893,6 +914,30 @@ class TestRouter(unittest.TestCase):
             filter_url('http://d.com/app2/ctr'), "/app2/ctr/index")
         self.assertEqual(filter_url(
             'http://d.com/app2/ctr/index/arg'), "/app2/ctr/index ['arg']")
+        self.assertEqual(
+            filter_url('http://d.com/app2/ctr/arg'), "/app2/ctr/arg")
+
+        # inbound - with extensions
+        self.assertEqual(
+            filter_url('http://d.com/index.json'), "/app/default/index.json")
+        self.assertEqual(filter_url('http://d.com/user.json'), "/app/default/user.json")
+        self.assertEqual(
+            filter_url('http://d.com/user.json/arg'), "/app/default/user.json ['arg']")
+        self.assertEqual(
+            filter_url('http://d.com/user.json/index'), "/app/default/user.json ['index']")
+        self.assertEqual(
+            filter_url('http://d.com/index.json/ctr'), "/app/default/index.json ['ctr']")
+        self.assertEqual(
+            filter_url('http://d.com/ctr/ctrf1.json/arg'), "/app/ctr/ctrf1.json ['arg']")
+
+        self.assertEqual(filter_url(
+            'http://d.com/app2/index.json/arg'), "/app2/default/index.json ['arg']")
+        self.assertEqual(
+            filter_url('http://d.com/app2/user.json'), "/app2/default/user.json")
+        self.assertEqual(filter_url(
+            'http://d.com/app2/user.json/arg'), "/app2/default/user.json ['arg']")
+        self.assertEqual(filter_url(
+            'http://d.com/app2/ctr/index.json/arg'), "/app2/ctr/index.json ['arg']")
         self.assertEqual(
             filter_url('http://d.com/app2/ctr/arg'), "/app2/ctr/arg")
 


### PR DESCRIPTION
Consider the following router:

    routers=dict(
        BASE=dict(
            default_controller='default',
            default_function='index',
                functions=['index', 'func1', 'comp1']
        )
    )

Now include the following component in a view:

    {{=LOAD('default', 'comp1.load', ajax=True)}}

This component will make an Ajax request to `/comp1.load`. The router must then determine whether `"comp1.load"` is a URL arg for the `/default/index` function, or whether it is actually a function itself (to be routed to `/default/comp.load`). To make this determination, it simply checks whether `"comp.load"` is in the `router['BASE']['functions']` list. This check fails, so the request gets routed to `/default/index/comp.load` rather than the correct `/default/comp.load`.

Currently, the `functions` list in the router only works properly if it includes all permutations of functions and extensions that the app will use. In the above example, it would have to be:

                functions=['index', 'func1', 'comp1.load']

This pull request strips the extension before checking the functions list, so a request to "comp.load" would correctly match "comp" in the functions list.

Perhaps there is some rationale for the current behavior, but in that case, the rewrite code that maps outgoing URLs must be changed. Given the above example, `URL('default', 'comp1.load')` would generate `/comp1.load`, which will then be routed to `/default/index/comp1.load`. It should instead generate `/default/comp1.load` -- otherwise, there is no way to generate a URL for the `/default/comp1.load` route.