### PR TITLE
Update compileapp.py

### DIFF
--- a/gluon/compileapp.py
+++ b/gluon/compileapp.py
@@ -640,7 +640,7 @@ def run_controller_in(controller, function, environment):
         ccode = getcfs(layer, filename, lambda: compile2(code, layer))
 
     restricted(ccode, environment, layer=filename)
-    response = current.response
+    response = environment["response"]
     vars = response._vars
     if response.postprocessing:
         vars = reduce(lambda vars, p: p(vars), response.postprocessing, vars)


### PR DESCRIPTION
Issue #1552
The  "current" may have been altered by the controller.  This is the case for admin/controllers/shell.py, in callback(), where a new shell environment is created (from gluon/shell)
If this happens, the incorrect "response" is being referenced and the output of the controller is lost.