### PR TITLE
fix download file error with chinesefilename

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -638,6 +638,7 @@ class Response(Storage):
         if download_filename is None:
             download_filename = filename
         if attachment:
+            download_filename =download_filename.encode("utf-8")
             headers['Content-Disposition'] = \
                 'attachment; filename="%s"' % download_filename.replace('"', '\"')
         return self.stream(stream, chunk_size=chunk_size, request=request)


### PR DESCRIPTION
when using `response.download(request, db)` to download a file name was chinese . (just like "his系统用户确认.txt") ,
 i got server error.  
```
ERROR:Rocket.Errors.Thread-6:Traceback (most recent call last):

  File "/root/web2py/gluon/rocket.py", line 1320, in run
    self.run_app(conn)

  File "/root/web2py/gluon/rocket.py", line 1821, in run_app
    output = self.app(environ, self.start_response)

  File "/root/web2py/gluon/main.py", line 651, in app_with_logging
    ret[0] = wsgiapp(environ, responder2)

  File "/root/web2py/gluon/main.py", line 565, in wsgibase
    return http_response.to(responder, env=env)

  File "/root/web2py/gluon/http.py", line 120, in to
    rheaders.append((k, str(v)))

UnicodeEncodeError: 'ascii' codec can't encode characters in position 25-30: ordinal not in range(128)
```
when i debug  `http.py `. 
 i find the error cause by `headers['Content-Disposition']`  ,
when i download the  file name by chinese , the content of `headers['Content-Disposition']` will be `unicode` .
```
for k, v in iteritems(headers):
    if isinstance(v, list):
        rheaders += [(k, str(item)) for item in v]
    elif not v is None:
        rheaders.append((k, str(v)))
```
ops , str() a unicode string will error.
so i encode the filename into utf-8 in file `ingluon/globals.py` before using it .
```
         if attachment:
+            download_filename =download_filename.encode("utf-8")
             headers['Content-Disposition'] = \
                 'attachment; filename="%s"' % download_filename.replace('"', '\"')
```
and it works. 