### PR TITLE
Small fixes to AuthJWT

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -1346,7 +1346,7 @@ class AuthJWT(object):
             exp=expires,
             hmac_key=web2py_uuid()
         )
-        self.alter_payload(orig_payload)
+        orig_payload = self.alter_payload(orig_payload)
         return orig_payload
 
     def alter_payload(self, payload):
@@ -1398,7 +1398,7 @@ class AuthJWT(object):
             self.auth.login_user(valid_user)
         if valid_user:
             payload = self.serialize_auth_session(session.auth)
-            self.alter_payload(payload)
+            payload = self.alter_payload(payload)
             ret = {'token': self.generate_token(payload)}
         elif ret is None:
             raise HTTP(401,

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -1303,7 +1303,7 @@ class AuthJWT(object):
             # signature verification failed
             raise HTTP(400, u'Token signature is invalid')
         if self.verify_expiration:
-            now = time.mktime(datetime.datetime.utcnow().timetuple())
+            now = time.gmtime()
             if tokend['exp'] + self.leeway < now:
                 raise HTTP(400, u'Token is expired')
         if callable(self.before_authorization):
@@ -1317,11 +1317,7 @@ class AuthJWT(object):
         We (mis)use the heavy default auth mechanism to avoid any further computation,
         while sticking to a somewhat-stable Auth API.
         """
-        # TODO: Check the following comment
-        ## is the following safe or should we use
-        ## calendar.timegm(datetime.datetime.utcnow().timetuple())
-        ## result seem to be the same (seconds since epoch, in UTC)
-        now = time.mktime(datetime.datetime.now().timetuple())
+        now = time.gmtime() # seconds since epoch, UTC (see RFC 7519)
         expires = now + self.expiration
         payload = dict(
             hmac_key=session_auth['hmac_key'],
@@ -1333,7 +1329,7 @@ class AuthJWT(object):
         return payload
 
     def refresh_token(self, orig_payload):
-        now = time.mktime(datetime.datetime.now().timetuple())
+        now = time.gmtime()
         if self.verify_expiration:
             orig_exp = orig_payload['exp']
             if orig_exp + self.leeway < now:


### PR DESCRIPTION

- The time stamp was being generated in a needlessly complicated fashion.  In addition, it was inconsistent in its use of UTC; which could have led to errors in non-utc locales. Simplified this.

- the internal api clearly allows for the altered payload to be returned from the alter_payload function, or the callable self.additional_payload member.
