### PR TITLE
Added on_succes and custom options for web2py ajax function

### DIFF
--- a/applications/admin/static/js/web2py.js
+++ b/applications/admin/static/js/web2py.js
@@ -38,7 +38,7 @@
             if (value > 0) $('#' + id).hide().fadeIn('slow');
             else $('#' + id).show().fadeOut('slow');
         },
-        ajax: function (u, s, t) {
+        ajax: function (u, s, t, options) {
             /*simple ajax function*/
             var query = '';
             if (typeof s == 'string') {
@@ -59,7 +59,9 @@
                     query = pcs.join('&');
                 }
             }
-            $.ajax({
+
+            // default options for jquery ajax function
+            var ajax_options = {
                 type: 'POST',
                 url: u,
                 data: query,
@@ -69,8 +71,23 @@
                         else if (typeof t == 'string') $('#' + t).html(msg);
                         else t(msg);
                     }
+                    // trigger on_success
+                    if (options.on_success){
+                        options.on_success();
+                    }
                 }
-            });
+            };
+
+            // merge default ajax options with user custom options
+            for (var attrname in options) {
+                // not merge custom on_success option
+                if(attrname != "on_success"){
+                    ajax_options[attrname] = options[attrname];
+                }
+            }
+
+            // call ajax function
+            $.ajax(ajax_options);
         },
         ajax_fields: function (target) {
             /*

--- a/applications/admin/static/js/web2py.js
+++ b/applications/admin/static/js/web2py.js
@@ -40,6 +40,10 @@
         },
         ajax: function (u, s, t, options) {
             /*simple ajax function*/
+
+            // set options default value
+            options = typeof options !== 'undefined' ? options : {};
+
             var query = '';
             if (typeof s == 'string') {
                 var d = $(s).serialize();
@@ -60,30 +64,39 @@
                 }
             }
 
-            // default options for jquery ajax function
+            // default success action
+            var success_function = function (msg) {
+                if (t) {
+                    if (t == ':eval') eval(msg);
+                    else if (typeof t == 'string') $('#' + t).html(msg);
+                    else t(msg);
+                }
+            };
+
+            // declare success actions as array
+            var success = [success_function];
+
+            // add user success actions
+            if ($.isArray(options.done)){
+                success = $.merge(success, options.done);
+            } else {
+                success.push(options.done);
+            }
+
+            // default jquery ajax options
             var ajax_options = {
                 type: 'POST',
                 url: u,
                 data: query,
-                success: function (msg) {
-                    if (t) {
-                        if (t == ':eval') eval(msg);
-                        else if (typeof t == 'string') $('#' + t).html(msg);
-                        else t(msg);
-                    }
-                    // trigger on_success
-                    if (options.on_success){
-                        options.on_success();
-                    }
-                }
+                success: success
             };
+
+            //remove custom "done" option if exists
+            delete options.done;
 
             // merge default ajax options with user custom options
             for (var attrname in options) {
-                // not merge custom on_success option
-                if(attrname != "on_success"){
                     ajax_options[attrname] = options[attrname];
-                }
             }
 
             // call ajax function

--- a/applications/examples/static/js/web2py.js
+++ b/applications/examples/static/js/web2py.js
@@ -38,7 +38,7 @@
             if (value > 0) $('#' + id).hide().fadeIn('slow');
             else $('#' + id).show().fadeOut('slow');
         },
-        ajax: function (u, s, t) {
+        ajax: function (u, s, t, options) {
             /*simple ajax function*/
             var query = '';
             if (typeof s == 'string') {
@@ -59,7 +59,9 @@
                     query = pcs.join('&');
                 }
             }
-            $.ajax({
+
+            // default options for jquery ajax function
+            var ajax_options = {
                 type: 'POST',
                 url: u,
                 data: query,
@@ -69,8 +71,23 @@
                         else if (typeof t == 'string') $('#' + t).html(msg);
                         else t(msg);
                     }
+                    // trigger on_success
+                    if (options.on_success){
+                        options.on_success();
+                    }
                 }
-            });
+            };
+
+            // merge default ajax options with user custom options
+            for (var attrname in options) {
+                // not merge custom on_success option
+                if(attrname != "on_success"){
+                    ajax_options[attrname] = options[attrname];
+                }
+            }
+
+            // call ajax function
+            $.ajax(ajax_options);
         },
         ajax_fields: function (target) {
             /*

--- a/applications/examples/static/js/web2py.js
+++ b/applications/examples/static/js/web2py.js
@@ -40,6 +40,10 @@
         },
         ajax: function (u, s, t, options) {
             /*simple ajax function*/
+
+            // set options default value
+            options = typeof options !== 'undefined' ? options : {};
+
             var query = '';
             if (typeof s == 'string') {
                 var d = $(s).serialize();
@@ -60,30 +64,39 @@
                 }
             }
 
-            // default options for jquery ajax function
+            // default success action
+            var success_function = function (msg) {
+                if (t) {
+                    if (t == ':eval') eval(msg);
+                    else if (typeof t == 'string') $('#' + t).html(msg);
+                    else t(msg);
+                }
+            };
+
+            // declare success actions as array
+            var success = [success_function];
+
+            // add user success actions
+            if ($.isArray(options.done)){
+                success = $.merge(success, options.done);
+            } else {
+                success.push(options.done);
+            }
+
+            // default jquery ajax options
             var ajax_options = {
                 type: 'POST',
                 url: u,
                 data: query,
-                success: function (msg) {
-                    if (t) {
-                        if (t == ':eval') eval(msg);
-                        else if (typeof t == 'string') $('#' + t).html(msg);
-                        else t(msg);
-                    }
-                    // trigger on_success
-                    if (options.on_success){
-                        options.on_success();
-                    }
-                }
+                success: success
             };
+
+            //remove custom "done" option if exists
+            delete options.done;
 
             // merge default ajax options with user custom options
             for (var attrname in options) {
-                // not merge custom on_success option
-                if(attrname != "on_success"){
                     ajax_options[attrname] = options[attrname];
-                }
             }
 
             // call ajax function

--- a/applications/welcome/static/js/web2py.js
+++ b/applications/welcome/static/js/web2py.js
@@ -38,7 +38,7 @@
             if (value > 0) $('#' + id).hide().fadeIn('slow');
             else $('#' + id).show().fadeOut('slow');
         },
-        ajax: function (u, s, t) {
+        ajax: function (u, s, t, options) {
             /*simple ajax function*/
             var query = '';
             if (typeof s == 'string') {
@@ -59,7 +59,9 @@
                     query = pcs.join('&');
                 }
             }
-            $.ajax({
+
+            // default options for jquery ajax function
+            var ajax_options = {
                 type: 'POST',
                 url: u,
                 data: query,
@@ -69,8 +71,23 @@
                         else if (typeof t == 'string') $('#' + t).html(msg);
                         else t(msg);
                     }
+                    // trigger on_success
+                    if (options.on_success){
+                        options.on_success();
+                    }
                 }
-            });
+            };
+
+            // merge default ajax options with user custom options
+            for (var attrname in options) {
+                // not merge custom on_success option
+                if(attrname != "on_success"){
+                    ajax_options[attrname] = options[attrname];
+                }
+            }
+
+            // call ajax function
+            $.ajax(ajax_options);
         },
         ajax_fields: function (target) {
             /*

--- a/applications/welcome/static/js/web2py.js
+++ b/applications/welcome/static/js/web2py.js
@@ -40,6 +40,10 @@
         },
         ajax: function (u, s, t, options) {
             /*simple ajax function*/
+
+            // set options default value
+            options = typeof options !== 'undefined' ? options : {};
+
             var query = '';
             if (typeof s == 'string') {
                 var d = $(s).serialize();
@@ -60,30 +64,39 @@
                 }
             }
 
-            // default options for jquery ajax function
+            // default success action
+            var success_function = function (msg) {
+                if (t) {
+                    if (t == ':eval') eval(msg);
+                    else if (typeof t == 'string') $('#' + t).html(msg);
+                    else t(msg);
+                }
+            };
+
+            // declare success actions as array
+            var success = [success_function];
+
+            // add user success actions
+            if ($.isArray(options.done)){
+                success = $.merge(success, options.done);
+            } else {
+                success.push(options.done);
+            }
+
+            // default jquery ajax options
             var ajax_options = {
                 type: 'POST',
                 url: u,
                 data: query,
-                success: function (msg) {
-                    if (t) {
-                        if (t == ':eval') eval(msg);
-                        else if (typeof t == 'string') $('#' + t).html(msg);
-                        else t(msg);
-                    }
-                    // trigger on_success
-                    if (options.on_success){
-                        options.on_success();
-                    }
-                }
+                success: success
             };
+
+            //remove custom "done" option if exists
+            delete options.done;
 
             // merge default ajax options with user custom options
             for (var attrname in options) {
-                // not merge custom on_success option
-                if(attrname != "on_success"){
                     ajax_options[attrname] = options[attrname];
-                }
             }
 
             // call ajax function


### PR DESCRIPTION
Added posibility to append an "add" hook and rewrite default jquery ajax options in the web2py ajax function.

Example:

    ajax{
        "url",
        ['name'],
        'target',
        {
            add: function(){
                console.log("ok!!!");
            },
            error: function(){
                console.log("error!!!");
            }
        }
    }