### PR TITLE
Fixes in generic layouts for python 3 compatibility

### DIFF
--- a/applications/admin/views/generic.html
+++ b/applications/admin/views/generic.html
@@ -7,7 +7,7 @@ It is used as default when a view is not provided for your controllers
 """}}
 <h2>{{=' '.join(x.capitalize() for x in request.function.split('_'))}}</h2>
 {{if len(response._vars)==1:}}
-{{=BEAUTIFY(response._vars.values()[0])}}
+{{=BEAUTIFY(response._vars[next(iter(response._vars))])}}
 {{elif len(response._vars)>1:}}
 {{=BEAUTIFY(response._vars)}}
 {{pass}}

--- a/applications/examples/views/generic.html
+++ b/applications/examples/views/generic.html
@@ -7,7 +7,7 @@ It is used as default when a view is not provided for your controllers
 """}}
 <h2>{{=' '.join(x.capitalize() for x in request.function.split('_'))}}</h2>
 {{if len(response._vars)==1:}}
-{{=BEAUTIFY(response._vars.values()[0])}}
+{{=BEAUTIFY(response._vars[next(iter(response._vars))])}}
 {{elif len(response._vars)>1:}}
 {{=BEAUTIFY(response._vars)}}
 {{pass}}

--- a/applications/examples/views/generic.load
+++ b/applications/examples/views/generic.load
@@ -1,1 +1,1 @@
-{{response.headers['web2py-response-flash']=response.flash}}{{if len(response._vars)==1:}}{{=response._vars.values()[0]}}{{else:}}{{=BEAUTIFY(response._vars)}}{{pass}}
+{{response.headers['web2py-response-flash']=response.flash}}{{if len(response._vars)==1:}}{{=response._vars[next(iter(response._vars))]}}{{else:}}{{=BEAUTIFY(response._vars)}}{{pass}}

--- a/applications/welcome/views/generic.html
+++ b/applications/welcome/views/generic.html
@@ -7,7 +7,7 @@ It is used as default when a view is not provided for your controllers
 """}}
 <h2>{{=' '.join(x.capitalize() for x in request.function.split('_'))}}</h2>
 {{if len(response._vars)==1:}}
-{{=BEAUTIFY(response._vars.values()[0])}}
+{{=BEAUTIFY(response._vars[next(iter(response._vars))])}}
 {{elif len(response._vars)>1:}}
 {{=BEAUTIFY(response._vars)}}
 {{pass}}

--- a/applications/welcome/views/generic.load
+++ b/applications/welcome/views/generic.load
@@ -27,4 +27,4 @@ Notice:
 - no need to return a string
 even if the function is called via ajax.
 
-'''}}{{if len(response._vars)==1:}}{{=response._vars.values()[0]}}{{else:}}{{=BEAUTIFY(response._vars)}}{{pass}}
+'''}}{{if len(response._vars)==1:}}{{=response._vars[next(iter(response._vars))]}}{{else:}}{{=BEAUTIFY(response._vars)}}{{pass}}


### PR DESCRIPTION
Python 3 dict.values() function behaviour has changed, replaced by a python 2.7 and 3.x compatible alternative.