### PR TITLE
Enable Ajax file uploads

### DIFF
--- a/applications/welcome/static/js/web2py.js
+++ b/applications/welcome/static/js/web2py.js
@@ -12,6 +12,8 @@
         $.error('web2py.js has already been loaded!');
     }
 
+    var FORMDATA_IS_SUPPORTED = typeof(FormData) !== 'undefined';
+
     String.prototype.reverse = function () {
         return this.split('').reverse().join('');
     };
@@ -320,7 +322,15 @@
                 form.submit(function (e) {
                     web2py.disableElement(form.find(web2py.formInputClickSelector));
                     web2py.hide_flash();
-                    web2py.ajax_page('post', url, form.serialize(), target, form);
+
+                    var formData;
+                    if (FORMDATA_IS_SUPPORTED) {
+                        formData = new FormData(form[0]); // Allows file uploads.
+                    } else {
+                        formData = form.serialize(); // Fallback for older browsers.
+                    }
+                    web2py.ajax_page('post', url, formData, target, form);
+
                     e.preventDefault();
                 });
                 form.on('click', web2py.formInputClickSelector, function (e) {
@@ -339,11 +349,18 @@
             if (web2py.isUndefined(element)) element = $(document);
             /* if target is not there, fill it with something that there isn't in the page*/
             if (web2py.isUndefined(target) || target === '') target = 'w2p_none';
+
+            /* processData and contentType must be set to false when passing a FormData
+               object to jQuery.ajax. */
+            var isFormData = Object.prototype.toString.call(data) === '[object FormData]';
+            var contentType = isFormData ? false : 'application/x-www-form-urlencoded; charset=UTF-8';
             if (web2py.fire(element, 'ajax:before', null, target)) { /*test a usecase, should stop here if returns false */
                 $.ajax({
                     'type': method,
                     'url': action,
                     'data': data,
+                    'processData': !isFormData,
+                    'contentType': contentType,
                     'beforeSend': function (xhr, settings) {
                         xhr.setRequestHeader('web2py-component-location', document.location);
                         xhr.setRequestHeader('web2py-component-element', target);
@@ -699,8 +716,9 @@
             });
         },
         /* Disables form elements:
+        - Does not disable elements with 'data-w2p_disable' attribute
         - Caches element value in 'w2p_enable_with' data store
-        - Replaces element text with value of 'data-disable-with' attribute
+        - Replaces element text with value of 'data-w2p_disable_with' attribute
         - Sets disabled property to true
         */
         disableFormElements: function (form) {
@@ -712,13 +730,15 @@
                 if (!web2py.isUndefined(disable)) {
                     return false;
                 }
-                if (web2py.isUndefined(disable_with)) {
-                    element.data('w2p_disable_with', element[method]());
+                if (!element.is(':file')) { // Altering file input values is not allowed.
+                    if (web2py.isUndefined(disable_with)) {
+                        element.data('w2p_disable_with', element[method]());
+                    }
+                    if (web2py.isUndefined(element.data('w2p_enable_with'))) {
+                        element.data('w2p_enable_with', element[method]());
+                    }
+                    element[method](element.data('w2p_disable_with'));
                 }
-                if (web2py.isUndefined(element.data('w2p_enable_with'))) {
-                    element.data('w2p_enable_with', element[method]());
-                }
-                element[method](element.data('w2p_disable_with'));
                 element.prop('disabled', true);
             });
         },


### PR DESCRIPTION
These changes to web2py.js allow file uploads via Ajax in browsers that support the `FormData` API. Older browsers will continue to fall back to the jQuery `.serialize()` method.