### PR TITLE
Enhancement/1557

### DIFF
--- a/gluon/contrib/login_methods/cas_auth.py
+++ b/gluon/contrib/login_methods/cas_auth.py
@@ -49,7 +49,8 @@ class CasAuth(object):
                            email=lambda v: v.get('email', None),
                            user_id=lambda v: v['user']),
                  casversion=1,
-                 casusername='cas:user'
+                 casusername='cas:user',
+		 change_password_url=None
                  ):
         self.urlbase = urlbase
         self.cas_login_url = "%s/%s" % (self.urlbase, actions[0])
@@ -64,6 +65,9 @@ class CasAuth(object):
                               #vars=current.request.vars,
                               scheme=True)
 
+	# URL to let users change their password in the IDP system
+        self.cas_change_password_url = change_password_url
+
     def login_url(self, next="/"):
         current.session.token = self._CAS_login()
         return next
@@ -72,6 +76,10 @@ class CasAuth(object):
         current.session.token = None
         current.session.auth = None
         self._CAS_logout()
+        return next
+
+    def change_password_url(self, next="/"):
+        self._CAS_change_password()
         return next
 
     def get_user(self):
@@ -135,3 +143,6 @@ class CasAuth(object):
         redirects to the CAS logout page
         """
         redirect("%s?service=%s" % (self.cas_logout_url, self.cas_my_url))
+
+    def _CAS_change_password(self):
+        redirect(self.cas_change_password_url)

--- a/gluon/contrib/login_methods/saml2_auth.py
+++ b/gluon/contrib/login_methods/saml2_auth.py
@@ -145,9 +145,15 @@ class Saml2Auth(object):
             username=lambda v:v['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn'][0],
             email=lambda v:v['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn'][0],
             user_id=lambda v:v['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn'][0],
-            )):
+            ), logout_url=None, change_password_url=None):
         self.config_file = config_file
         self.maps = maps
+
+	# URL for redirecting users to when they sign out
+        self.saml_logout_url = logout_url
+
+        # URL to let users change their password in the IDP system
+        self.saml_change_password_url = change_password_url
 
     def login_url(self, next="/"):
         d = saml2_handler(current.session, current.request)
@@ -170,6 +176,12 @@ class Saml2Auth(object):
 
     def logout_url(self, next="/"):
         current.session.saml2_info = None
+        current.session.auth = None
+        self._SAML_logout()
+        return next
+
+    def change_password_url(self, next="/"):
+        self._SAML_change_password()
         return next
 
     def get_user(self):        
@@ -180,3 +192,13 @@ class Saml2Auth(object):
                 d[key] = self.maps[key](user)
             return d
         return None
+
+    def _SAML_logout(self):
+        """
+        exposed SAML.logout()
+        redirects to the SAML logout page
+        """
+        redirect(self.saml_logout_url)
+
+    def _SAML_change_password(self):
+        redirect(self.saml_change_password_url)

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -3663,6 +3663,16 @@ class Auth(AuthAPI):
         if not self.is_logged_in():
             redirect(self.settings.login_url,
                      client_side=self.settings.client_side)
+
+        # Go to external link to change the password
+        if self.settings.login_form != self:
+            cas = self.settings.login_form
+            # To prevent error if change_password_url function is not defined in alternate login
+            if hasattr(cas, 'change_password_url'):
+                next = cas.change_password_url(next)
+                if next is not None:
+                    redirect(next)
+
         db = self.db
         table_user = self.table_user()
         s = db(table_user.id == self.user.id)

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -1792,6 +1792,7 @@ class Auth(AuthAPI):
                              servicevalidate='serviceValidate',
                              proxyvalidate='proxyValidate',
                              logout='logout'),
+	    cas_create_user=True,
             extra_fields={},
             actions_disabled=[],
             controller=controller,
@@ -2284,6 +2285,7 @@ class Auth(AuthAPI):
         If the user doesn't yet exist, then they are created.
         """
         table_user = self.table_user()
+	create_user = self.settings.cas_create_user
         user = None
         checks = []
         # make a guess about who this user is
@@ -2316,6 +2318,11 @@ class Auth(AuthAPI):
                     update_keys[key] = keys[key]
             user.update_record(**update_keys)
         elif checks:
+	    if create_user is False:
+                # Remove current open session a send message
+                self.logout(next=None, onlogout=None, log=None)
+                raise HTTP(403, "Forbidden. User need to be created first.")
+
             if 'first_name' not in keys and 'first_name' in table_user.fields:
                 guess = keys.get('email', 'anonymous').split('@')[0]
                 keys['first_name'] = keys.get('username', guess)


### PR DESCRIPTION
These changes I have been testing and working correctly in my computer. If you approve I can merge the changes.

When web2py SAML SP os CAS client is configured as alternate login the system auto create the users once he is logged into the SAML IDP or CAS server. Now with auth.settings.cas_create_user you can specify if the user is autocreated or you need to created first.

Another improvement is to have a custom change password url for external methods. For example, when the user configure the CAS client or SAML SP and click in change password. If change_password_url is configured. The SP will redirect to change_password_url. Good if the you want to configure the IDP change password page.

