### PR TITLE
Fix view file name in ticket traceback

### DIFF
--- a/gluon/compileapp.py
+++ b/gluon/compileapp.py
@@ -676,6 +676,7 @@ def run_view_in(environment):
     badv = 'invalid view (%s)' % view
     patterns = response.get('generic_patterns')
     layer = None
+    scode = None
     if patterns:
         regex = re_compile('|'.join(map(fnmatch.translate, patterns)))
         short_action = '%(controller)s/%(function)s.%(extension)s' % request
@@ -718,12 +719,14 @@ def run_view_in(environment):
 
         # if the view is not compiled
         if not layer:
-            # Compile the template
-            ccode = parse_template(view,
+            # Parse template
+            scode = parse_template(view,
                                    pjoin(folder, 'views'),
                                    context=environment)
+            # Compile template
+            ccode = compile2(scode, filename)
         layer = filename
-    restricted(ccode, environment, layer=layer)
+    restricted(ccode, environment, layer=layer, scode=scode)
     # parse_template saves everything in response body
     return environment['response'].body.getvalue()
 

--- a/gluon/restricted.py
+++ b/gluon/restricted.py
@@ -205,7 +205,7 @@ def compile2(code, layer):
     return compile(code, layer, 'exec')
 
 
-def restricted(ccode, environment=None, layer='Unknown'):
+def restricted(ccode, environment=None, layer='Unknown', scode=None):
     """
     Runs code in environment and returns the output. If an exception occurs
     in code it raises a RestrictedError containing the traceback. Layer is
@@ -230,7 +230,9 @@ def restricted(ccode, environment=None, layer='Unknown'):
             sys.excepthook(etype, evalue, tb)
         del tb
         output = "%s %s" % (etype, evalue)
-        raise RestrictedError(layer, ccode, output, environment)
+        # Save source code in ticket when available
+        scode = scode if scode else ccode
+        raise RestrictedError(layer, scode, output, environment)
 
 
 def snapshot(info=None, context=5, code=None, environment=None):


### PR DESCRIPTION
Explicitly compiling view to set file name, this will appear in traceback instead of `<string>`.