### PR TITLE
Update groups on edit profile

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -3777,7 +3777,7 @@ class Auth(AuthAPI):
             if any(f.compute for f in extra_fields):
                 user = table_user[self.user.id]
                 self._update_session_user(user)
-		self.update_groups()
+                self.update_groups()
             else:
                 self.user.update(table_user._filter_fields(form.vars))
             session.flash = self.messages.profile_updated

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -3777,9 +3777,9 @@ class Auth(AuthAPI):
             if any(f.compute for f in extra_fields):
                 user = table_user[self.user.id]
                 self._update_session_user(user)
+		self.update_groups()
             else:
                 self.user.update(table_user._filter_fields(form.vars))
-
             session.flash = self.messages.profile_updated
             self.log_event(log, self.user)
             callback(onaccept, form)


### PR DESCRIPTION
When profile is updated `self._update_session_user(user)` set session.user_groups to None.  After the update self.update_groups() should be executed to keep session consistent.