### PR TITLE
Fix grid TSV export bug

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -3570,7 +3570,9 @@ class ExportClass(object):
                 if not self.rows.db._adapter.REGEX_TABLE_DOT_FIELD.match(col):
                     row.append(record._extra[col])
                 else:
-                    (t, f) = col.split('.')
+                    # The grid code modifies rows.colnames, adding double quotes
+                    # around the table and field names -- so they must be removed here.
+                    (t, f) = [name.strip('"') for name in col.split('.')]
                     field = self.rows.db[t][f]
                     if isinstance(record.get(t, None), (Row, dict)):
                         value = record[t][f]


### PR DESCRIPTION
The grid TSV export stopped working due to double quotes being added to `rows.colnames` by the grid code (i.e., `"tablename"."fieldname"` instead of `tablename.fieldname`). The `represented` method of the base `ExportClass` class extracts the tablename and fieldname to get the `Field` object from the table definition, so it ended up doing `db['"tablename"']['"fieldname"']`, which generated an error. The `ExportTSV` class is the only exporter that uses the `represented` method, so it was the only one affected.