### PR TITLE
A step to PY3  closes #1792 and may be closes #1727

### DIFF
--- a/gluon/_compat.py
+++ b/gluon/_compat.py
@@ -35,6 +35,7 @@ if PY2:
     from gluon.contrib import ipaddress
     BytesIO = StringIO
     reduce = reduce
+    reload = reload
     hashlib_md5 = hashlib.md5
     iterkeys = lambda d: d.iterkeys()
     itervalues = lambda d: d.itervalues()
@@ -77,6 +78,7 @@ else:
     import pickle
     from io import StringIO, BytesIO
     import copyreg
+    from importlib import reload
     from functools import reduce
     from html.parser import HTMLParser
     from http import cookies as Cookie

--- a/gluon/compileapp.py
+++ b/gluon/compileapp.py
@@ -18,7 +18,7 @@ import fnmatch
 import os
 import copy
 import random
-from gluon._compat import builtin, PY2, unicodeT, to_native, to_bytes, iteritems, basestring, reduce, xrange, long
+from gluon._compat import builtin, PY2, unicodeT, to_native, to_bytes, iteritems, basestring, reduce, xrange, long, reload
 from gluon.storage import Storage, List
 from gluon.template import parse_template
 from gluon.restricted import restricted, compile2

--- a/gluon/custom_import.py
+++ b/gluon/custom_import.py
@@ -8,7 +8,7 @@
 Support for smart import syntax for web2py applications
 -------------------------------------------------------
 """
-from gluon._compat import builtin, unicodeT, PY2, to_native
+from gluon._compat import builtin, unicodeT, PY2, to_native, reload
 import os
 import sys
 import threading

--- a/gluon/languages.py
+++ b/gluon/languages.py
@@ -110,15 +110,17 @@ def markmin(s):
 
 
 def upper_fun(s):
-    return unicode(s, 'utf-8').upper().encode('utf-8')
+    return to_unicode(s).upper()
 
 
 def title_fun(s):
-    return unicode(s, 'utf-8').title().encode('utf-8')
+    return to_unicode(s).title()
 
 
 def cap_fun(s):
-    return unicode(s, 'utf-8').capitalize().encode('utf-8')
+    return to_unicode(s).capitalize()
+
+
 ttab_in = maketrans("\\%{}", '\x1c\x1d\x1e\x1f')
 ttab_out = maketrans('\x1c\x1d\x1e\x1f', "\\%{}")
 


### PR DESCRIPTION
Add compatible reload to 2 places

Also fixes unicode conversion in languages.py
But in PY2 there were back conversion to plain str (bytes)
Here util functions return the unicode. Needs tests?
But I am user only. Have no much experience in unittests