### PR TITLE
Fixes #1800

### DIFF
--- a/gluon/authapi.py
+++ b/gluon/authapi.py
@@ -988,7 +988,8 @@ class AuthAPI(object):
             requires = [requires]
         requires = list(filter(lambda t: isinstance(t, CRYPT), requires))
         if requires:
-            requires[0] = CRYPT(key=settings.hmac_key, min_length=0)
+            requires[0] = CRYPT(**requires[0].__dict__) # Copy the existing CRYPT attributes
+            requires[0].min_length = 0 # But do not enforce minimum length for the old password
 
         old_password = kwargs.get('old_password', '')
         new_password = kwargs.get('new_password', '')

--- a/gluon/authapi.py
+++ b/gluon/authapi.py
@@ -988,7 +988,7 @@ class AuthAPI(object):
             requires = [requires]
         requires = list(filter(lambda t: isinstance(t, CRYPT), requires))
         if requires:
-            requires[0].min_length = 0
+            requires[0] = CRYPT(key=settings.hmac_key, min_length=0)
 
         old_password = kwargs.get('old_password', '')
         new_password = kwargs.get('new_password', '')

--- a/gluon/tests/test_authapi.py
+++ b/gluon/tests/test_authapi.py
@@ -138,6 +138,9 @@ class TestAuthAPI(unittest.TestCase):
         self.assertTrue('new_password2' in result['errors'])
         result = self.auth.change_password(old_password='bart_password', new_password='1234', new_password2='1234')
         self.assertTrue('old_password' in result['errors'])
+        # Test the default 4 min_length is enforced on change password
+        result = self.auth.change_password(old_password='1234', new_password='123', new_password2='123')
+        self.assertTrue('new_password' in result['errors'])
 
     def test_verify_key(self):
         self.auth.settings.registration_requires_verification = True

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -3693,7 +3693,8 @@ class Auth(AuthAPI):
             requires = [requires]
         requires = list(filter(lambda t: isinstance(t, CRYPT), requires))
         if requires:
-            requires[0] = CRYPT(key=self.settings.hmac_key, min_length=0)
+            requires[0] = CRYPT(**requires[0].__dict__) # Copy the existing CRYPT attributes
+            requires[0].min_length = 0 # But do not enforce minimum length for the old password
         form = SQLFORM.factory(
             Field('old_password', 'password', requires=requires,
                   label=self.messages.old_password),

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -3693,7 +3693,7 @@ class Auth(AuthAPI):
             requires = [requires]
         requires = list(filter(lambda t: isinstance(t, CRYPT), requires))
         if requires:
-            requires[0].min_length = 0
+            requires[0] = CRYPT(key=self.settings.hmac_key, min_length=0)
         form = SQLFORM.factory(
             Field('old_password', 'password', requires=requires,
                   label=self.messages.old_password),


### PR DESCRIPTION
Use a new instance of CRYPT instead of setting min_length to 0 in the instance that will later be used with the new_password