### PR TITLE
Fix Janrain due to change in behavior

### DIFF
--- a/gluon/contrib/login_methods/janrain_account.py
+++ b/gluon/contrib/login_methods/janrain_account.py
@@ -78,10 +78,13 @@ class RPXAccount(object):
 
     def get_user(self):
         request = self.request
-        if request.vars.token:
+        # Janrain now sends the token via both a POST body and the query
+        # string, so we should keep only one of these.
+        token = request.post_vars.token or request.get_vars.token
+        if token:
             user = Storage()
             data = urllib.urlencode(
-                dict(apiKey=self.api_key, token=request.vars.token))
+                dict(apiKey=self.api_key, token=token))
             auth_info_json = fetch(self.auth_url + '?' + data)
             auth_info = json.loads(auth_info_json)
 

--- a/gluon/contrib/login_methods/rpx_account.py
+++ b/gluon/contrib/login_methods/rpx_account.py
@@ -78,10 +78,13 @@ class RPXAccount(object):
 
     def get_user(self):
         request = self.request
-        if request.vars.token:
+        # Janrain now sends the token via both a POST body and the query
+        # string, so we should keep only one of these.
+        token = request.post_vars.token or request.get_vars.token
+        if token:
             user = Storage()
             data = urllib.urlencode(
-                dict(apiKey=self.api_key, token=request.vars.token))
+                dict(apiKey=self.api_key, token=token))
             auth_info_json = fetch(self.auth_url + '?' + data)
             auth_info = json.loads(auth_info_json)
 


### PR DESCRIPTION
Janrain has started providing the login token via a POST request
in addition to including it in the query string. This results
in request.vars.token being a list containing two copies of the
token, which breaks the web2py code. This change keeps just a single
copy of the token.