### PR TITLE
Update SQLFORM deleted = False if readonly

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -1676,6 +1676,7 @@ class SQLFORM(FORM):
             keepvalues = True if self.record else False
 
         if self.readonly:
+            self.deleted = False
             return False
 
         if request_vars.__class__.__name__ == 'Request':


### PR DESCRIPTION
This fixes the following syntax:
```
form = SQLFORM(table, record, readonly=readonly, deletable=True)

form.process()

if form.deleted:
   pass
elif form.accepted:
   pass
```

Otherwise, form.deleted is never set when readonly=True, and throws an attribute error.

It's possible, instead, that deleted should be set to False as a part of __init__.  That way, it always has the correct default value, to be overridden on deletion.