### PR TITLE
made cas_provider response py3 compatible

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -2498,9 +2498,9 @@ class Auth(AuthAPI):
                 success = True
 
         def build_response(body):
-            return '<?xml version="1.0" encoding="UTF-8"?>\n' +\
-                TAG['cas:serviceResponse'](
-                    body, **{'_xmlns:cas': 'http://www.yale.edu/tp/cas'}).xml()
+            xml_body = to_native(TAG['cas:serviceResponse'](
+                    body, **{'_xmlns:cas': 'http://www.yale.edu/tp/cas'}).xml())
+            return '<?xml version="1.0" encoding="UTF-8"?>\n' + xml_body
         if success:
             if version == 1:
                 message = 'yes\n%s' % user[userfield]


### PR DESCRIPTION
I noticed that the cas-provider code is not python3 compliant. This fix makes the cas provider work for both python2 as well as python3.