### PR TITLE
Replace the guppy library with Pympler

### DIFF
--- a/applications/welcome/controllers/appadmin.py
+++ b/applications/welcome/controllers/appadmin.py
@@ -392,12 +392,11 @@ def ccache():
                 cache.disk.clear()
                 session.flash += T("Disk Cleared")
         redirect(URL(r=request))
-
+    
     try:
-        from guppy import hpy
-        hp = hpy()
+        from pympler.asizeof import asizeof
     except ImportError:
-        hp = False
+        asizeof = False
 
     import shelve
     import os
@@ -451,9 +450,9 @@ def ccache():
             ram['ratio'] = 0
 
         for key, value in iteritems(cache.ram.storage):
-            if hp:
-                ram['bytes'] += hp.iso(value[1]).size
-                ram['objects'] += hp.iso(value[1]).count
+            if asizeof:
+                ram['bytes'] += asizeof(value[1])
+                ram['objects'] += 1
             ram['entries'] += 1
             if value[0] < ram['oldest']:
                 ram['oldest'] = value[0]
@@ -469,9 +468,9 @@ def ccache():
                 except (KeyError, ZeroDivisionError):
                     disk['ratio'] = 0
             else:
-                if hp:
-                    disk['bytes'] += hp.iso(value[1]).size
-                    disk['objects'] += hp.iso(value[1]).count
+                if asizeof:
+                    disk['bytes'] += asizeof(value[1])
+                    disk['objects'] += 1
                 disk['entries'] += 1
                 if value[0] < disk['oldest']:
                     disk['oldest'] = value[0]
@@ -511,7 +510,7 @@ def ccache():
         total['keys'] = key_table(total['keys'])
 
     return dict(form=form, total=total,
-                ram=ram, disk=disk, object_stats=hp != False)
+                ram=ram, disk=disk, object_stats=asizeof != False)
 
 
 def table_template(table):

--- a/applications/welcome/views/appadmin.html
+++ b/applications/welcome/views/appadmin.html
@@ -148,7 +148,7 @@
           {{=T.M("(**%.0d MB**)", total['bytes'] / 1048576)}}
         {{pass}}
       {{else:}}
-        {{=T.M("**not available** (requires the Python [[guppy http://pypi.python.org/pypi/guppy/ popup]] library)")}}
+        {{=T.M("**not available** (requires the Python [[Pympler https://pypi.python.org/pypi/Pympler popup]] library)")}}
       {{pass}}
     </p>
     <p>
@@ -176,7 +176,7 @@
           {{=T.M("(**%.0d MB**)", ram['bytes'] / 10485576)}}
         {{pass}}
       {{else:}}
-        {{=T.M("``**not available**``:red (requires the Python [[guppy http://pypi.python.org/pypi/guppy/ popup]] library)")}}
+        {{=T.M("``**not available**``:red (requires the Python [[Pympler https://pypi.python.org/pypi/Pympler popup]] library)")}}
       {{pass}}
     </p>
     <p>
@@ -205,7 +205,7 @@
           {{=T.M("(**%.0d MB**)", disk['bytes'] / 1048576)}}
         {{pass}}
       {{else:}}
-        {{=T.M("``**not available**``:red (requires the Python [[guppy http://pypi.python.org/pypi/guppy/ popup]] library)")}}
+        {{=T.M("``**not available**``:red (requires the Python [[Pympler https://pypi.python.org/pypi/Pympler popup]] library)")}}
       {{pass}}
       </p>
       <p>


### PR DESCRIPTION
Since guppy is no longer mantained (#1866) I replaced it with [Pympler](https://pypi.python.org/pypi/Pympler), which is newer, pure-Python and provide better results!