### PR TITLE
Changed file to open

### DIFF
--- a/gluon/main.py
+++ b/gluon/main.py
@@ -392,7 +392,7 @@ def wsgibase(environ, responder):
                 elif not request.is_local and exists(disabled):
                     five0three = os.path.join(request.folder, 'static', '503.html')
                     if os.path.exists(five0three):
-                        raise HTTP(503, file(five0three, 'r').read())
+                        raise HTTP(503, open(five0three, 'r').read())
                     else:
                         raise HTTP(503, "<html><body><h1>Temporarily down for maintenance</h1></body></html>")
 


### PR DESCRIPTION
file is deprecated in python 3, but open works on both. So for compatibility I would suggest to use open over file.