### PR TITLE
fixes allow translate strings at views/default/user.html

### DIFF
--- a/applications/welcome/views/default/user.html
+++ b/applications/welcome/views/default/user.html
@@ -7,14 +7,14 @@
     </h2>
     {{=form}}
     {{if request.args(0)=='login' and not 'register' in auth.settings.actions_disabled:}}
-    <a href="{{=URL('user/register')}}">Register</a>
+    <a href="{{=URL('user/register')}}">{{=T('Register')}}</a>
     <br/>
     {{pass}}
     {{if request.args(0)=='login' and not 'request_reset_password' in auth.settings.actions_disabled:}}
-    <a href="{{=URL('user/request_reset_password')}}">Lost your password?</a>
+    <a href="{{=URL('user/request_reset_password')}}">{{=T('Lost your password?')}}</a>
     {{pass}}
     {{if request.args(0)=='register':}}
-    <a href="{{=URL('user/login')}}">Login</a>
+    <a href="{{=URL('user/login')}}">{{=T('Login')}}</a>
     {{pass}}
   </div>
 </div>


### PR DESCRIPTION
The new layout for user.html had some strings not translated. 

this PR just make it translatable again using {{=T('string')}}