### PR TITLE
removed merging get vars and post vars with the same name as list

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -276,10 +276,6 @@ class Request(Storage):
         for key, value in iteritems(self.post_vars):
             if key not in self._vars:
                 self._vars[key] = value
-            else:
-                if not isinstance(self._vars[key], list):
-                    self._vars[key] = [self._vars[key]]
-                self._vars[key] += value if isinstance(value, list) else [value]
 
     @property
     def get_vars(self):


### PR DESCRIPTION
it was breaking some code that excpected a single variable, like SQLFORM.grid
is this really necessary?