### PR TITLE
Catch KeyError in download function

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -667,7 +667,7 @@ class Response(Storage):
         (t, f) = (items.group('table'), items.group('field'))
         try:
             field = db[t][f]
-        except AttributeError:
+        except (AttributeError, KeyError):
             raise HTTP(404)
         try:
             (filename, stream) = field.retrieve(name, nameonly=True)


### PR DESCRIPTION
This change is necessary to avoid an error ticket when you delete an upload field from a table (and also from the model definition). In those cases, requests to old URLs will throw a KeyError. With this fix, those requests return 404 as expected.

Also, catching AttributeError is still necessary for the situation when the table is removed entirely. If an old request come in, that sentence will throw an AttributeError, that will be catched properly, and request will return 404.