### PR TITLE
Proposed fix to solve crash on markdown2 module

### DIFF
--- a/gluon/contrib/markdown/__init__.py
+++ b/gluon/contrib/markdown/__init__.py
@@ -1,4 +1,4 @@
-from markdown2 import *
+from .markdown2 import *
 from gluon.html import XML
 
 def WIKI(text, encoding="utf8", safe_mode='escape', html4tags=False, **attributes):

--- a/gluon/contrib/markdown/markdown2.py
+++ b/gluon/contrib/markdown/markdown2.py
@@ -4,6 +4,7 @@
 # License: MIT (http://www.opensource.org/licenses/mit-license.php)
 
 from __future__ import generators
+from __future__ import print_function
 
 r"""A fast and complete Python implementation of Markdown.
 
@@ -35,7 +36,6 @@ This implementation of Markdown implements the full "core" syntax plus a
 number of extras (e.g., code syntax coloring, footnotes) as described on
 <https://github.com/trentm/python-markdown2/wiki/Extras>.
 """
-from __future__ import print_function
 
 cmdln_desc = """A fast and complete Python implementation of Markdown, a
 text-to-HTML conversion tool for web writers.


### PR DESCRIPTION
When I tried to run my app **https://github.com/UniversidadDelEste/OpenLex**
I found it crashed sending this message 
   https://linkode.org/#QQ5sZNikJ1rtKHUmwfJyB6
when I fixed it changing gluon/contrib/markdown/__init__.py, it gave this error:
   https://linkode.org/#2AzrXFOHBISr1F2NnUHd96
I fix it changing  gluon/contrib/markdown/markdown2.py


