### PR TITLE
The allows_jwt method does NOT throw any error if a token is missing

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -1335,6 +1335,8 @@ class AuthJWT(object):
                     if required:
                         raise e
                     token = None
+                if not token:
+                    raise HTTP(400, 'Invalid token')
                 if token and len(token) < self.max_header_length:
                     old_verify_expiration = self.verify_expiration
                     try:


### PR DESCRIPTION
This could cause potential security issues as developers decorate their methods with @allows_jwt and then not pass a token and this method allows the call.