### PR TITLE
Python 3 compatibility clarification

### DIFF
--- a/applications/examples/views/default/download.html
+++ b/applications/examples/views/default/download.html
@@ -62,16 +62,16 @@
 </center>
 
 <p style="text-align:left;">
-  The source code version works on all supported platforms, including Linux, but it requires Python 2.6, or 2.7 (recommended).
-  It runs on Windows and most Unix systems, including <b>Linux</b> and <b>BSD</b>.
+  The source code version works on Windows and most Unix systems, including <b>Linux</b>,  <b>BSD</b> and  <b>Mac</b> . It requires Python 2.6 (no more supported),  Python 2.7 (stable) or Python 3.5+ (recommended for new projects) already installed on your system.
+  There are also binary packages for Windows and Mac OS X. They include the Python 2.7 interpreter so you do not need to have it pre-installed.
 </p>
 
 <h3>Instructions</h3>
-<p>After download, unzip it and click on web2py.exe (windows) or web2py.app (osx).
-  To run from source, type:</p>
-{{=CODE("python2.7 web2py.py", language=None, counter='>', _class='boxCode')}}
+<p>With the binary packages, after download, just unzip it and then click on web2py.exe (windows) or web2py.app (osx).
+  If you prefer to run it from source with your own Python interpreter alreay installed, type:</p>
+{{=CODE("python web2py.py", language=None, counter='>', _class='boxCode')}}
 <p>or for more info type:</p>
-{{=CODE("python2.7 web2py.py -h", language=None, counter='>', _class='boxCode')}}
+{{=CODE("python web2py.py -h", language=None, counter='>', _class='boxCode')}}
 
 
 <h3>Caveats</h3>


### PR DESCRIPTION
Officially states Python 2.6, 2.7 and 3.5+ compatibility.
Also, it  explains better the differences between the source and the binary version.