### PR TITLE
partially restore original layout for Welcome page

### DIFF
--- a/applications/welcome/views/default/index.html
+++ b/applications/welcome/views/default/index.html
@@ -1,7 +1,7 @@
 {{extend 'layout.html'}}
 
 {{block header}}
-<div class="jumbotron jumbotron-fluid" style="background-color: #333; color:white; padding:30px;word-wrap:break-word;">
+<div class="jumbotron jumbotron-fluid background" style="background-color: #333; color:white; padding:30px;word-wrap:break-word;">
   <div class="container center">
     <h1 class="display-5">/{{=request.application}}/{{=request.controller}}/{{=request.function}}</h1>
   </div>

--- a/applications/welcome/views/layout.html
+++ b/applications/welcome/views/layout.html
@@ -35,7 +35,7 @@
   <body>
     <div class="w2p_flash alert alert-dismissable">{{=response.flash or ''}}</div>
     <!-- Navbar ======================================= -->
-    <nav class="navbar navbar-light navbar-expand-md bg-faded justify-content-center">
+    <nav class="navbar navbar-light navbar-expand-md bg-faded bg-dark navbar-dark justify-content-center">
        <a href="http://web2py.com" class="navbar-brand d-flex w-50 mr-auto">web2py</a>
        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
          <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
the bootstrap4 changes caused styles problems - see also https://github.com/web2py/web2py/issues/1929.
It is still missing a proper web2py logo in the navbar...
