### PR TITLE
make make_min_web2py.py run for python3

### DIFF
--- a/scripts/make_min_web2py.py
+++ b/scripts/make_min_web2py.py
@@ -48,7 +48,7 @@ def main():
     global REQUIRED, IGNORED
 
     if len(sys.argv) < 2:
-        print USAGE
+        print(USAGE)
 
     # make target folder
     target = sys.argv[1]


### PR DESCRIPTION
i tried to minify the web2py server and this script was not able to run with python3.5.
So i change it.