### PR TITLE
Create generic.csv

### DIFF
--- a/applications/welcome/views/generic.csv
+++ b/applications/welcome/views/generic.csv
@@ -1,0 +1,17 @@
+{{"""Usage:
+
+  def controller():
+      return {"": db().select(db.thing.ALL)}
+
+And then visit that controller with a .csv extention name
+"""
+}}{{if len(response._vars)==1:}}{{
+# Not yet find a Python 2/3 compatible StringIO pattern,
+# we avoid this solution http://web2py.com/books/default/chapter/29/10/services#CSV
+# Here we buffer the entire csv file instead (it is your controller's job to limit the volume anyway),
+# based on: http://web2py.com/books/default/chapter/29/06/the-database-abstraction-layer#CSV-one-Table-at-a-time-
+
+content = response._vars[next(iter(response._vars))]
+response.headers['Content-Type'] = 'application/vnd.ms-excel'
+response.write(str(content), escape=False)
+}}{{pass}}


### PR DESCRIPTION
[The book said "web2py does not define a generic.csv file"](http://web2py.com/books/default/chapter/29/10/services#CSV). I think we can still provide one default implementation to suit the most basic need. The application developers can always implement their own view file.

PS: When/if this PR would be accepted, please consider also changing that sentence in the book.

On a side note, I was the author of the generic.load too. It feels good to contribute to web2py again. :-)