### PR TITLE
correct rendering of jsonrpcerrors

### DIFF
--- a/gluon/contrib/simplejsonrpc.py
+++ b/gluon/contrib/simplejsonrpc.py
@@ -34,7 +34,9 @@ import json
 
 class JSONRPCError(RuntimeError):
     "Error object for remote procedure call fail"
-    def __init__(self, code, message, data=''):
+    def __init__(self, code, message, data=''):        
+        if isinstance(data, basestring):
+            data = [data]
         value = "%s: %s\n%s" % (code, message, '\n'.join(data))
         RuntimeError.__init__(self, value)
         self.code = code


### PR DESCRIPTION
Currently, JSONRPCErrors get spit into a console or ticket one line per character (due to the  '\n'.join(data) applying to a string).  This fixes that issue while preserving new lines for arrays.