### PR TITLE
'unique_key' shouldn't be saved as bytes

### DIFF
--- a/gluon/contrib/redis_session.py
+++ b/gluon/contrib/redis_session.py
@@ -186,8 +186,8 @@ class MockQuery(object):
             if rtn:
                 if self.unique_key:
                     # make sure the id and unique_key are correct
-                    if rtn[b'unique_key'] == to_bytes(self.unique_key):
-                        rtn[b'update_record'] = self.update  # update record support
+                    if rtn['unique_key'] == self.unique_key:
+                        rtn['update_record'] = self.update  # update record support
                     else:
                         rtn = None
             return [Storage(rtn)] if rtn else []

--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -1051,7 +1051,7 @@ class Session(Storage):
             if record_id.isdigit() and long(record_id) > 0:
                 new_unique_key = web2py_uuid()
                 row = table(record_id)
-                if row and row[b'unique_key'] == to_bytes(unique_key):
+                if row and row['unique_key'] == unique_key:
                     table._db(table.id == record_id).update(unique_key=new_unique_key)
                 else:
                     record_id = None


### PR DESCRIPTION
We started using a custom version of Web2Py for Python 3 compatibility. We want to start using the official release of Web2Py again but we were having issues that were fixed by changing this 2 lines. I think these 2 changes should be implemented in Web2Py but this should be thoroughly tested.