### PR TITLE
Add aspect ratio to IS_IMAGE() validator

### DIFF
--- a/gluon/tests/test_validators.py
+++ b/gluon/tests/test_validators.py
@@ -977,6 +977,8 @@ class TestValidators(unittest.TestCase):
         self.assertEqual(rtn, (img, 'oops'))
         rtn = IS_IMAGE(error_message='oops', minsize=(100, 50))(img)
         self.assertEqual(rtn, (img, 'oops'))
+        rtn = IS_IMAGE(error_message='oops', aspectratio=(1, 1))(img)
+        self.assertEqual(rtn, (img, 'oops'))
 
         img = DummyImageFile('test', 'gif', 50, 100)
         rtn = IS_IMAGE()(img)
@@ -984,6 +986,8 @@ class TestValidators(unittest.TestCase):
         rtn = IS_IMAGE(error_message='oops', maxsize=(100, 50))(img)
         self.assertEqual(rtn, (img, 'oops'))
         rtn = IS_IMAGE(error_message='oops', minsize=(100, 50))(img)
+        self.assertEqual(rtn, (img, 'oops'))
+        rtn = IS_IMAGE(error_message='oops', aspectratio=(1, 1))(img)
         self.assertEqual(rtn, (img, 'oops'))
 
         img = DummyImageFile('test', 'jpeg', 50, 100)
@@ -993,6 +997,8 @@ class TestValidators(unittest.TestCase):
         self.assertEqual(rtn, (img, 'oops'))
         rtn = IS_IMAGE(error_message='oops', minsize=(100, 50))(img)
         self.assertEqual(rtn, (img, 'oops'))
+        rtn = IS_IMAGE(error_message='oops', aspectratio=(1, 1))(img)
+        self.assertEqual(rtn, (img, 'oops'))
 
         img = DummyImageFile('test', 'png', 50, 100)
         rtn = IS_IMAGE()(img)
@@ -1000,6 +1006,8 @@ class TestValidators(unittest.TestCase):
         rtn = IS_IMAGE(error_message='oops', maxsize=(100, 50))(img)
         self.assertEqual(rtn, (img, 'oops'))
         rtn = IS_IMAGE(error_message='oops', minsize=(100, 50))(img)
+        self.assertEqual(rtn, (img, 'oops'))
+        rtn = IS_IMAGE(error_message='oops', aspectratio=(1, 1))(img)
         self.assertEqual(rtn, (img, 'oops'))
 
         img = DummyImageFile('test', 'xls', 50, 100)

--- a/gluon/validators.py
+++ b/gluon/validators.py
@@ -3230,8 +3230,10 @@ class IS_IMAGE(Validator):
         ('jpg' extension of uploaded file counts as 'jpeg')
         maxsize: iterable containing maximum width and height of the image
         minsize: iterable containing minimum width and height of the image
+        aspectratio: iterable containing target aspect ratio
 
     Use (-1, -1) as minsize to pass image size check.
+    Use (-1, -1) as aspectratio to pass aspect ratio check.
 
     Examples:
         Check if uploaded file is in any of supported image formats:
@@ -3247,17 +3249,24 @@ class IS_IMAGE(Validator):
 
             INPUT(_type='file', _name='name',
                 requires=IS_IMAGE(extensions=('png'), maxsize=(200, 200)))
+
+        Check if uploaded file has a 16:9 aspect ratio:
+
+            INPUT(_type='file', _name='name',
+                requires=IS_IMAGE(aspectratio=(16, 9)))
     """
 
     def __init__(self,
                  extensions=('bmp', 'gif', 'jpeg', 'png'),
                  maxsize=(10000, 10000),
                  minsize=(0, 0),
+                 aspectratio=(-1, -1),
                  error_message='Invalid image'):
 
         self.extensions = extensions
         self.maxsize = maxsize
         self.minsize = minsize
+        self.aspectratio = aspectratio
         self.error_message = error_message
 
     def __call__(self, value):
@@ -3279,8 +3288,16 @@ class IS_IMAGE(Validator):
             else:
                 width = -1
                 height = -1
+
             assert self.minsize[0] <= width <= self.maxsize[0] \
                 and self.minsize[1] <= height <= self.maxsize[1]
+
+            if self.aspectratio > (-1, -1):
+                target_ratio = (1.0 * self.aspectratio[1]) / self.aspectratio[0]
+                actual_ratio = (1.0 * height) / width
+
+                assert actual_ratio == target_ratio
+
             value.file.seek(0)
             return (value, None)
         except Exception as e:


### PR DESCRIPTION
There are a lot of cases where someone may want a perfect square, or a 16:9 screenshot, or whatever other aspect ratio you can think of.  Lately, my site's users have been unfortunately uploading profile pictures with aspect ratios that cause some display issues on certain parts of the website, and I want to enforce a perfect square on all profile pictures.

This PR adds an aspect ratio check to IS_IMAGE().  It defaults to `(-1, -1)`, which disables the check like `minsize`.