### PR TITLE
Update redis_cache.py to allow sharing cache between applications

### DIFF
--- a/gluon/contrib/redis_cache.py
+++ b/gluon/contrib/redis_cache.py
@@ -22,7 +22,7 @@ logger = logging.getLogger("web2py.cache.redis")
 locker = Lock()
 
 
-def RedisCache(redis_conn=None, debug=False, with_lock=False, fail_gracefully=False, db=None):
+def RedisCache(redis_conn=None, debug=False, with_lock=False, fail_gracefully=False, db=None, application=None):
     """
     Usage example: put in models::
 
@@ -83,7 +83,7 @@ def RedisCache(redis_conn=None, debug=False, with_lock=False, fail_gracefully=Fa
 
     locker.acquire()
     try:
-        instance_name = 'redis_instance_' + current.request.application
+        instance_name = 'redis_instance_' + (application or current.request.application)
         if not hasattr(RedisCache, instance_name):
             setattr(RedisCache, instance_name,
                     RedisClient(redis_conn=redis_conn, debug=debug,


### PR DESCRIPTION
I'm not sure if this would help someone else. I've always had this scenario where some of my web2py applications share the models, and therefore, need to share the cache (I use Redis). In the past I've asked if there was any possibility to share cache between applications, but I got no answers:
https://groups.google.com/forum/#!searchin/web2py/share$20cache$20application%7Csort:date/web2py/iNCzMq8ADnw/ufyPBWajBQAJ

Anyway, I've noticed that I could make a simple change to redis_cache.py to achieve what I was looking for: I've added the optional argument "application" to RedisCache(). If you inspect the RedisCache() code, you will notice that previously it was forced to use current.request.application for the instance_name. With this simple change I did, it's possible to provide an application name to the RedisCache() constructor.

This has worked like a charm for my specific scenario, and I think I can say that it has backwards compatibility. Still, if this proposal isn't accepted, I would like to hear about some alternative to share cache between applications. Thanks!