### PR TITLE
[Py3] Open shell executed files in binary mode, fixes #2060

### DIFF
--- a/gluon/shell.py
+++ b/gluon/shell.py
@@ -37,7 +37,7 @@ logger = logging.getLogger("web2py")
 
 if not PY2:
     def execfile(filename, global_vars=None, local_vars=None):
-        with open(filename) as f:
+        with open(filename, "rb") as f:
             code = compile(f.read(), filename, 'exec')
             exec(code, global_vars, local_vars)
     raw_input = input


### PR DESCRIPTION
Non-ASCII characters in executed files caused a crash, this fixes such
behaviour.