### PR TITLE
unicode() is not a standard python 3 function so using str() if pytho…

### DIFF
--- a/gluon/languages.py
+++ b/gluon/languages.py
@@ -326,6 +326,8 @@ def write_plural_dict(filename, contents):
 
 
 def sort_function(x):
+    if sys.version_info.major == 3: # python 3 compatibility
+        unicode = str
     return unicode(x, 'utf-8').lower()
 
 


### PR DESCRIPTION
unicode() is not a standard python 3 function so using str() if python 3 test is true
in 
gluon/languages.py
