### PR TITLE
Only decode Markdown text when needed

### DIFF
--- a/gluon/contrib/markdown/__init__.py
+++ b/gluon/contrib/markdown/__init__.py
@@ -9,7 +9,8 @@ def WIKI(text, encoding="utf8", safe_mode='escape', html4tags=False, **attribute
         del attributes['extras']
     else:
         extras=None
-    text = text.decode(encoding,'replace')
+    if hasattr(text, "decode"):
+        text = text.decode(encoding,'replace')
 
     return XML(markdown(text,extras=extras,
                         safe_mode=safe_mode, html4tags=html4tags)\

--- a/gluon/contrib/markdown/__init__.py
+++ b/gluon/contrib/markdown/__init__.py
@@ -1,5 +1,6 @@
 from .markdown2 import *
 from gluon.html import XML
+from gluon._compat import to_unicode
 
 def WIKI(text, encoding="utf8", safe_mode='escape', html4tags=False, **attributes):
     if not text:
@@ -9,8 +10,7 @@ def WIKI(text, encoding="utf8", safe_mode='escape', html4tags=False, **attribute
         del attributes['extras']
     else:
         extras=None
-    if hasattr(text, "decode"):
-        text = text.decode(encoding,'replace')
+    text = to_unicode(text, encoding, 'replace')
 
     return XML(markdown(text,extras=extras,
                         safe_mode=safe_mode, html4tags=html4tags)\


### PR DESCRIPTION
Python 3 treats strings as unicode, so there's no reason to decode them into unicode again.  This will only decode when a byte string is passed into the function.