### PR TITLE
Fix IS_IN_DB() on db JOIN (Python 3 compatibility)

### DIFF
--- a/gluon/validators.py
+++ b/gluon/validators.py
@@ -575,7 +575,7 @@ class IS_IN_DB(Validator):
         else:
             fields = [table[k] for k in self.fieldnames]
         ignore = (FieldVirtual, FieldMethod)
-        fields = filter(lambda f: not isinstance(f, ignore), fields)
+        fields = list(filter(lambda f: not isinstance(f, ignore), fields))
         if self.dbset.db._dbname != 'gae':
             orderby = self.orderby or reduce(lambda a, b: a | b, fields)
             groupby = self.groupby


### PR DESCRIPTION
Unlike in Python 2, [Python 3's built-in `filter()` works as a generator; the filtering is lazy.](https://stackoverflow.com/questions/41666977/python-2-vs-python-3-difference-in-behavior-of-filter)  This converts the `filter()` call into an active filter by converting it to a list, therefore eliminating the `KeyError` caused when passing a JOIN into `IS_IN_DB()`.