### PR TITLE
Add Python 3 compatibility to languages.py

### DIFF
--- a/gluon/languages.py
+++ b/gluon/languages.py
@@ -326,7 +326,7 @@ def write_plural_dict(filename, contents):
 
 
 def sort_function(x):
-    return unicode(x, 'utf-8').lower()
+    return to_unicode(x, 'utf-8').lower()
 
 
 def write_dict(filename, contents):


### PR DESCRIPTION
Since Python 3 doesn't have a `unicode()` function any longer, this replaces the call with `to_unicode()`, fixing compatibility.  This also closes #2075 as the PR does the same thing, but does not use the compatibility function.