### PR TITLE
Add ability to pass a list of extensions

### DIFF
--- a/gluon/validators.py
+++ b/gluon/validators.py
@@ -3349,7 +3349,7 @@ class IS_UPLOAD_FILENAME(Validator):
 
     Args:
         filename: filename (before dot) regex
-        extension: extension (after dot) regex
+        extension: extension (after dot) regex or list of valid extensions
         lastdot: which dot should be used as a filename / extension separator:
             True means last dot, eg. file.png -> file / png
             False means first dot, eg. file.tar.gz -> file / tar.gz
@@ -3364,6 +3364,11 @@ class IS_UPLOAD_FILENAME(Validator):
 
         INPUT(_type='file', _name='name',
                 requires=IS_UPLOAD_FILENAME(extension='pdf'))
+
+        Check if file has a tar.gz or zip extension:
+
+            INPUT(_type='file', _name='name',
+                requires=IS_UPLOAD_FILENAME(extension=['tar.gz', 'zip']))
 
         Check if file has a tar.gz extension and name starting with backup:
 
@@ -3386,6 +3391,8 @@ class IS_UPLOAD_FILENAME(Validator):
             filename = re.compile(filename)
         if isinstance(extension, str):
             extension = re.compile(extension)
+        elif isinstance(extension, list):
+            extension = re.compile('^(%s)$' %'|'.join(extension))
         self.filename = filename
         self.extension = extension
         self.lastdot = lastdot


### PR DESCRIPTION
This is something that's been bugging me enough that I wrote a child validator specifically designed to take a list of extensions.  This PR is designed to add support to `IS_UPLOAD_FILENAME` for handling lists of extensions by mapping it into regex, eliminating an extra step on the app developer's side.  This fixes #2073.