### PR TITLE
Fix b' in session.flash when storing a LazyT

### DIFF
--- a/gluon/languages.py
+++ b/gluon/languages.py
@@ -451,7 +451,7 @@ class lazyT(object):
 
 
 def pickle_lazyT(c):
-    return str, (c.xml(),)
+    return str, (to_native(c.xml()),)
 
 copyreg.pickle(lazyT, pickle_lazyT)
 


### PR DESCRIPTION
probably Fixes #2110 as putting T('foo') in the session was the only way I could reproduce it