### PR TITLE
correct SAML authorization request binding

### DIFF
--- a/gluon/contrib/login_methods/saml2_auth.py
+++ b/gluon/contrib/login_methods/saml2_auth.py
@@ -118,7 +118,7 @@ def saml2_handler(session, request, config_filename = None, entityid = None):
     elif request.env.request_method == 'POST':
         binding = BINDING_HTTP_POST
     if not request.vars.SAMLResponse:
-        req_id, req = client.create_authn_request(destination, binding=binding)
+        req_id, req = client.create_authn_request(destination, binding=BINDING_HTTP_POST)
         relay_state = web2py_uuid().replace('-','')
         session.saml_outstanding_queries = {req_id: request.url}    
         session.saml_req_id = req_id


### PR DESCRIPTION
AuthnRequest cannot use BINDING_HTTP_REDIRECT, according to the SAML v2 specifications.  See:
https://github.com/IdentityPython/pysaml2/issues/163