### PR TITLE
fix: controller function invocation via shell

### DIFF
--- a/gluon/shell.py
+++ b/gluon/shell.py
@@ -260,7 +260,7 @@ def run(
     if c:
         pyfile = os.path.join('applications', a, 'controllers', c + '.py')
         pycfile = os.path.join('applications', a, 'compiled',
-                                 "controllers_%s_%s.pyc" % (c, f))
+                                 "controllers.%s.%s.pyc" % (c, f))
         if ((cron_job and os.path.isfile(pycfile))
             or not os.path.isfile(pyfile)):
             exec(read_pyc(pycfile), _env)


### PR DESCRIPTION
If only a compiled version is available and a controller function is invoked with -S app/c/f an
IOError is raised as '_' is used as delimiter instead of '.'.

web2py.py  -S test/test/test -M would lead to:

IOError: [Errno 2] No such file or directory: 'applications/test/compiled/controllers_test_test.pyc'