### PR TITLE
Added followlinks argument to listdir

### DIFF
--- a/gluon/fileutils.py
+++ b/gluon/fileutils.py
@@ -148,7 +148,8 @@ def listdir(path,
             add_dirs=False,
             sort=True,
             maxnum=None,
-            exclude_content_from=None
+            exclude_content_from=None,
+            followlinks=False
             ):
     """
     Like `os.listdir()` but you can specify a regex pattern to filter files.
@@ -164,7 +165,7 @@ def listdir(path,
         n = 0
     regex = re.compile(expression)
     items = []
-    for (root, dirs, files) in os.walk(path, topdown=True):
+    for (root, dirs, files) in os.walk(path, topdown=True, followlinks=followlinks):
         for dir in dirs[:]:
             if dir.startswith('.'):
                 dirs.remove(dir)


### PR DESCRIPTION
The followlinks argument is then used by the function when it calls os.walk(path...
Notice the "followlinks" argument of os.walk() is False by default, so this change won't make any difference. Every actual call to listdir() function won't need to be changed.
This change is needed to resolve issue #2221