### PR TITLE
fix error block location in radio buttons

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -461,7 +461,12 @@ class RadioWidget(OptionsWidget):
             opts.append(child(tds))
 
         if opts:
-            opts[-1][0][0]['hideerror'] = False
+            opts.append(
+                INPUT(requires=attr.get('requires', None),
+                      _style="display:none;",
+                      _disabled="disabled",
+                      _name=field.name,
+                      hideerror=False))
         return parent(*opts, **attr)
 
 


### PR DESCRIPTION
Currently, radio widget error messages appear between the final checkbox and the final label.  Instead, use CheckboxesWidget's invisible input method to display errors on radio widgets.