### PR TITLE
Force page reload with anchors

### DIFF
--- a/applications/admin/static/js/web2py.js
+++ b/applications/admin/static/js/web2py.js
@@ -284,6 +284,7 @@
                 var redirect = xhr.getResponseHeader('web2py-redirect-location');
                 if (redirect !== null) {
                     window.location = redirect;
+                    window.location.reload(); // Force reload even with anchors
                 }
                 /* run this here only if this Ajax request is NOT for a web2py component. */
                 if (xhr.getResponseHeader('web2py-component-content') === null) {


### PR DESCRIPTION
Force page to reload even when the location contains anchors, while using "web2py-redirect-location".
Otherwise, when the location is the same and the url has an anchor it won't redirect.