### PR TITLE
Better https detection

### DIFF
--- a/gluon/rewrite.py
+++ b/gluon/rewrite.py
@@ -204,7 +204,7 @@ def url_out(request, environ, application, controller, function,
     if host is True or (host is None and (scheme or port is not None)):
         host = request.env.http_host
     if not scheme or scheme is True:
-        scheme = request.env.get('wsgi_url_scheme', 'http').lower() if request else 'http'
+        scheme = 'https' if request and request.is_https else 'http'
     if host:
         host_port = host if not port else host.split(':', 1)[0] + ':%s' % port
         url = '%s://%s%s' % (scheme, host_port, url)


### PR DESCRIPTION
As suggested by Anthony in [this Google Group conversation](https://groups.google.com/forum/#!topic/web2py/YSGxBd4j1uQ), I'm sending out this PR to modify `URL(...)` to use `request.is_https` for better https detection, because [`request.is_https` is more sophisticated and can work in more corner cases](https://github.com/web2py/web2py/blob/R-2.18.3/gluon/main.py#L366-L367).

One thing though. Before this PR, the previous implementation would technically use whatever value provided by `wsgi_url_scheme`, be it `ws` or `wss` or whatever. Not sure whether that behavior is important. Currently the change in this PR would detect `https` and then fall back to `http`, nothing else. Please let me know if you still prefer to have that potential `wsgi_url_scheme` value back, then I can submit a new change like this next time:

```python
if request and request.is_https:
    scheme = 'https'
elif request and request.env.get('wsgi_url_scheme'):
    scheme = request.env.get('wsgi_url_scheme').lower()
else:
    scheme = 'http'
```

Just let me know. Thanks!

PS: The [CI test of this PR fails but that does not seem to be caused by this PR](https://travis-ci.org/web2py/web2py/jobs/562440673). I actually tested my PR on my own production and it did solve my issue.