### PR TITLE
initialize env with abspath

### DIFF
--- a/gluon/shell.py
+++ b/gluon/shell.py
@@ -233,7 +233,7 @@ def run(
     errmsg = 'invalid application name: %s' % appname
     if not a:
         die(errmsg, error_preamble=False)
-    adir = os.path.join('applications', a)
+    adir = os.path.absdir(os.path.join('applications', a))
 
     if not os.path.exists(adir):
         if not cron_job and not scheduler_job and \
@@ -270,7 +270,7 @@ def run(
     if vars:
         # underscore necessary because request.vars is a property
         extra_request['_vars'] = vars
-    _env = env(a, c=c, f=f, import_models=import_models, extra_request=extra_request)
+    _env = env(a, c=c, f=f, import_models=import_models, extra_request=extra_request, dir=adir)
 
     if c:
         pyfile = os.path.join('applications', a, 'controllers', c + '.py')


### PR DESCRIPTION
When running scripts, the path used is relative to the web2py root instead of the full path. This causes differences in migrations when using InDBMigrator - this causes pydal to try to repeat migrations already done.