### PR TITLE
gnigats: fix doctest from shell for python3: clone ignores dict, and …

### DIFF
--- a/gluon/shell.py
+++ b/gluon/shell.py
@@ -430,14 +430,14 @@ def test(testpath, import_models=True, verbose=False):
             files = glob.glob(os.path.join(cdir, '*.py'))
     for testfile in files:
         globs = env(a, import_models)
-        ignores = globs.keys()
+        ignores = globs.copy().keys()
         execfile(testfile, globs)
 
         def doctest_object(name, obj):
             """doctest obj and enclosed methods and classes."""
 
             if type(obj) in (types.FunctionType, type, ClassType, types.MethodType,
-                             types.UnboundMethodType):
+                             types.ModuleType):
 
                 # Reload environment before each test.
 


### PR DESCRIPTION
I traced the command 'python web2py.py -v -T welcome' and found out the shell.py does not execute doctest for two readons: (1) the ignores was not cloned correctly so the function to be executed was not picked up because the type got into global_vars after execfile(...), (2) for python3, the type has changed.  after I made the changes, now I can get execution results back from running all doctests in an application.