### PR TITLE
python3 compatibility for JSONRPCError

### DIFF
--- a/gluon/contrib/simplejsonrpc.py
+++ b/gluon/contrib/simplejsonrpc.py
@@ -35,9 +35,11 @@ import json
 class JSONRPCError(RuntimeError):
     "Error object for remote procedure call fail"
     def __init__(self, code, message, data=''):        
-        if not PY2:            
-            basestring = str
-        if isinstance(data, basestring):
+        if PY2:
+            str_type = basestring
+        else:
+            str_type = str
+        if isinstance(data, str_type):
             data = [data]
         value = "%s: %s\n%s" % (code, message, '\n'.join(data))
         RuntimeError.__init__(self, value)

--- a/gluon/contrib/simplejsonrpc.py
+++ b/gluon/contrib/simplejsonrpc.py
@@ -35,6 +35,8 @@ import json
 class JSONRPCError(RuntimeError):
     "Error object for remote procedure call fail"
     def __init__(self, code, message, data=''):        
+        if not PY2:            
+            basestring = str
         if isinstance(data, basestring):
             data = [data]
         value = "%s: %s\n%s" % (code, message, '\n'.join(data))


### PR DESCRIPTION
handle the non-existance of basestrings in py3, but maintain backward compatibility