### PR TITLE
python3 compatibility for JSONRPCError

### DIFF
--- a/gluon/contrib/simplejsonrpc.py
+++ b/gluon/contrib/simplejsonrpc.py
@@ -30,7 +30,7 @@ else:
     from io import StringIO
 import random
 import json
-
+from gluon._compat import basestring
 
 class JSONRPCError(RuntimeError):
     "Error object for remote procedure call fail"


### PR DESCRIPTION
Trying this again, now that I learned about gluon._compat