### PR TITLE
Don't set form in trap_form as ajax_page element

### DIFF
--- a/applications/welcome/static/js/web2py.js
+++ b/applications/welcome/static/js/web2py.js
@@ -335,7 +335,7 @@
                     } else {
                         formData = form.serialize(); // Fallback for older browsers.
                     }
-                    web2py.ajax_page('post', url, formData, target, form);
+                    web2py.ajax_page('post', url, formData, target);
 
                     e.preventDefault();
                 });


### PR DESCRIPTION
A big project of mine has been a smooth loading system that's designed to work for any Web2py app (see https://www.gooborg.com/ for a live example), and most of my code relies heavily on the use of web2py components.  As I was going through, I was trying to hook up a function to the completion of the AJAX load after forms, however every time that I tried to, I couldn't find the element that was getting the component completion event.  So I dug a little deeper, and I had a realization.

I wasn't able to get an event because the AJAX load was removing the `form` element it was trying to fire the event on, so it would be replaced with whatever came from the AJAX load.  In other words, _the `w2p:componenetComplete` event was firing onto an element non-existent in the DOM._  This PR intends to fix the issue I found by removing the `form` as the `element` argument to `ajax_page()`, therefore allowing the events to fire on the document like most other AJAX loads do.

I do not believe that this breaks any backwards compatibility, as there was no real compatibility to begin with.  However, **I am open to constructive critique and feedback.**  Please feel free to ask me anything or suggest changes/improvements!

(Oh, and if anyone's interested in that smooth loading code, I might post it out on web2py slices sometime soon!)