### PR TITLE
Update setup-web2py-fedora.sh

### DIFF
--- a/scripts/setup-web2py-fedora.sh
+++ b/scripts/setup-web2py-fedora.sh
@@ -158,6 +158,9 @@ if [ -e web2py_src.zip* ]; then
     rm web2py_src.zip*
 fi
 
+# Centos 7.6 minimal does not have zip installed. So there was ab error a few lines below. Unzip failed
+yum install unzip
+
 wget http://web2py.com/examples/static/web2py_src.zip
 unzip web2py_src.zip
 mv web2py/handlers/wsgihandler.py web2py/wsgihandler.py


### PR DESCRIPTION
# Centos 7.6 minimal, does not have zip installed. So there was ab error a few lines below. Unzip failed.
If possible also mention in the desctiption that this script is for Fedora and Centos. The filename can stay. 