### PR TITLE
No redirect when url ends with #

### DIFF
--- a/applications/welcome/static/js/web2py.js
+++ b/applications/welcome/static/js/web2py.js
@@ -283,7 +283,11 @@
             doc.ajaxSuccess(function (e, xhr) {
                 var redirect = xhr.getResponseHeader('web2py-redirect-location');
                 if (redirect !== null) {
-                    window.location = redirect;
+                    if (!redirect.endsWith('#')) {
+                        window.location.href = redirect;
+                    } else {
+                        window.location.reload();
+                    }
                 }
                 /* run this here only if this Ajax request is NOT for a web2py component. */
                 if (xhr.getResponseHeader('web2py-component-content') === null) {


### PR DESCRIPTION
When a redirect url ends with a hash (#) the browser (Chrome) does not redirect/refreshes the browser.

This is happening with this setting:
```
form = SQLFORM.grid(
        query,
        client_side_delete=True
    )
```