### PR TITLE
limit widget rebuilding on form error to ListWidget

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -1814,7 +1814,7 @@ class SQLFORM(FORM):
                 if not field.widget and field.type.startswith('list:') and \
                         not OptionsWidget.has_options(field):
                     field.widget = self.widgets.list.widget
-                if field.widget and fieldname in request_vars:
+                if field.widget == self.widgets.list.widget and fieldname in request_vars:
                     if fieldname in self.request_vars:
                         value = self.request_vars[fieldname]
                     elif self.record:


### PR DESCRIPTION
I think this would close #1048 and #1577, but I could use some verification by someone with more experience of the code.

From my testing, it prevents a ListWidget's values from being wiped out when there has been a validation error on the SQLFORM, but doesn't affect any other widgets, leaving their styling intact.