### PR TITLE
Add events for form upload progress

### DIFF
--- a/applications/welcome/static/js/web2py.js
+++ b/applications/welcome/static/js/web2py.js
@@ -367,6 +367,24 @@
                     'data': data,
                     'processData': !isFormData,
                     'contentType': contentType,
+                    'xhr': function() {
+                        var xhr = new window.XMLHttpRequest();
+
+                        xhr.upload.addEventListener("progress", function(evt) {
+                            if (evt.lengthComputable) {
+                                var percentComplete = evt.loaded / evt.total;
+                                percentComplete = parseInt(percentComplete * 100);
+                                web2py.fire(element, 'w2p:uploadProgress', [percentComplete], target);
+
+                                if (percentComplete === 100) {
+                                    web2py.fire(element, 'w2p:uploadComplete', [], target);
+                                }
+
+                            }
+                        }, false);
+
+                        return xhr;
+                    },
                     'beforeSend': function (xhr, settings) {
                         xhr.setRequestHeader('web2py-component-location', document.location);
                         xhr.setRequestHeader('web2py-component-element', target);


### PR DESCRIPTION
This PR adds a new feature to form uploads, where the upload progress is shared via an event (`w2p:uploadProgress`) gradually, until it is complete and fires another event (`w2p:uploadComplete`).  This will allow for progress bars to be added to web2py components -- or in my case, smooth-loaded pages.

The code is sourced from the following StackOverflow answer: https://stackoverflow.com/a/22987941/2608838