### PR TITLE
gluon/languages.py: import escape from html instead of cgi

### DIFF
--- a/gluon/languages.py
+++ b/gluon/languages.py
@@ -16,7 +16,10 @@ import re
 import sys
 import pkgutil
 import logging
-from cgi import escape
+try:
+    from html import escape
+except ImportError:
+    from cgi import escape
 from threading import RLock
 
 from pydal._compat import copyreg, PY2, maketrans, iterkeys, unicodeT, to_unicode, to_bytes, iteritems, to_native, pjoin


### PR DESCRIPTION
import escape from html instead of cgi to fix the following build
failure with python 3.8:
```
/home/buildroot/autobuild/run/instance-2/output-1/host/bin/python -c 'import os; os.chdir("/home/buildroot/autobuild/run/instance-2/output-1/build/python-web2py-2.17.2"); from gluon.main import save_password; save_password("web2py",8000)'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/buildroot/autobuild/run/instance-2/output-1/build/python-web2py-2.17.2/gluon/__init__.py", line 34, in <module>
    from .globals import current
  File "/home/buildroot/autobuild/run/instance-2/output-1/build/python-web2py-2.17.2/gluon/globals.py", line 24, in <module>
    from gluon.serializers import json, custom_json
  File "/home/buildroot/autobuild/run/instance-2/output-1/build/python-web2py-2.17.2/gluon/serializers.py", line 10, in <module>
    from gluon.languages import lazyT
  File "/home/buildroot/autobuild/run/instance-2/output-1/build/python-web2py-2.17.2/gluon/languages.py", line 19, in <module>
    from cgi import escape
ImportError: cannot import name 'escape' from 'cgi' (/home/buildroot/autobuild/run/instance-2/output-1/host/lib/python3.8/cgi.py)
```

Fixes:
 - http://autobuild.buildroot.org/results/fa515627ae888d08fc10074e8d9f6e9dbede91a7

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>