### PR TITLE
fix: typo

### DIFF
--- a/gluon/scheduler.py
+++ b/gluon/scheduler.py
@@ -656,7 +656,7 @@ class Scheduler(threading.Thread):
             ctx = multiprocessing.get_context('spawn')
             outq = ctx.Queue()
             retq = ctx.Queue(maxsize=1)
-            sel.process = p = ctx.Process(target=executor, args=(retq, task, outq))
+            self.process = p = ctx.Process(target=executor, args=(retq, task, outq))
         else:
             outq = multiprocessing.Queue()
             retq = multiprocessing.Queue(maxsize=1)


### PR DESCRIPTION
Fix a typo introduced in commit 7038758960c5bf79e609329cdf709b65f1924517.