### PR TITLE
fix Py3 encoding problem

### DIFF
--- a/gluon/serializers.py
+++ b/gluon/serializers.py
@@ -84,7 +84,7 @@ def custom_json(o):
     elif isinstance(o, decimal.Decimal):
         return float(o)
     elif isinstance(o, (bytes, bytearray)):
-        return str(o)
+        return str(o) if harattr(str, 'decode') else str(o, encoding='utf-8')
     elif isinstance(o, lazyT):
         return str(o)
     elif isinstance(o, XmlComponent):


### PR DESCRIPTION
Fix for python 3.6
>>>str(b'123')
>>>"b'123'"
>>>str(b'123', encoding='utf-8')
>>>"123"