### PR TITLE
Converts dict_keys object to list (py3)

### DIFF
--- a/gluon/contrib/login_methods/saml2_auth.py
+++ b/gluon/contrib/login_methods/saml2_auth.py
@@ -109,7 +109,7 @@ def saml2_handler(session, request, config_filename = None, entityid = None):
     client = Saml2Client(config_file = config_filename)
     if not entityid:
         idps = client.metadata.with_descriptor("idpsso")
-        entityid = idps.keys()[0]
+        entityid = list(idps.keys())[0]
     bindings = [BINDING_HTTP_REDIRECT, BINDING_HTTP_POST]
     binding, destination = client.pick_binding(
         "single_sign_on_service", bindings, "idpsso", entity_id=entityid)


### PR DESCRIPTION
In python 3, keys() method returns a dict_keys object instead of a list. Trying to access the zero index causes an error. Converting the dict_keys object to a list is enough to make it work (and still works in python 2).