### PR TITLE
Fix errors with unwanted new app folder

### DIFF
--- a/gluon/shell.py
+++ b/gluon/shell.py
@@ -241,7 +241,7 @@ def run(
         if not cron_job and not scheduler_job and \
             sys.stdin and not sys.stdin.name == '/dev/null':
             confirm = raw_input(
-                'application %s does not exist, create (y/n)?' % a)
+                'application %s does not exist, create (y/N)?' % a)
         else:
             logging.warn('application does not exist and will not be created')
             return

--- a/gluon/shell.py
+++ b/gluon/shell.py
@@ -248,6 +248,9 @@ def run(
         if confirm.lower() in ('y', 'yes'):
             os.mkdir(adir)
             fileutils.create_app(adir)
+        else:
+            logging.warn('application folder does not exist and has not been created as requested')
+            return
 
     if force_migrate:
         c = 'appadmin' # Load all models (hack already used for appadmin controller)


### PR DESCRIPTION
Replying 'no' or ENTER when asked for the creation of a missing app folder was not properly managed. It gives IOError on Mac and unwanted behaviour on Win