### PR TITLE
remove last_query session in admin to prevent massive join when sorting tables in multiple browser tabs #2326

### DIFF
--- a/applications/admin/controllers/appadmin.py
+++ b/applications/admin/controllers/appadmin.py
@@ -194,8 +194,6 @@ def select():
             request.vars.query = '%s.%s.%s==%s' % (request.args[0],
                                                    match.group('table'), match.group('field'),
                                                    match.group('value'))
-    else:
-        request.vars.query = session.last_query
     query = get_query(request)
     if request.vars.start:
         start = int(request.vars.start)
@@ -222,7 +220,6 @@ def select():
             else:
                 orderby = '~' + orderby
     session.last_orderby = orderby
-    session.last_query = request.vars.query
     form = FORM(TABLE(TR(T('Query:'), '', INPUT(_style='width:400px',
                 _name='query', _value=request.vars.query or '', _class='form-control',
                 requires=IS_NOT_EMPTY(

--- a/applications/admin/views/appadmin.html
+++ b/applications/admin/views/appadmin.html
@@ -82,7 +82,7 @@
        <div style="overflow:auto; width:80%;">
        {{linkto = lambda f, t, r: URL('update', args=[request.args[0], r, f]) if f else "#"}}
        {{upload=URL('download',args=request.args[0])}}
-       {{=SQLTABLE(rows,linkto,upload,orderby=True,_class='table table-striped table-bordered sortable')}}
+       {{=SQLTABLE(rows,linkto,upload,orderby=True,query=query,_class='table table-striped table-bordered sortable')}}
        </div>
     {{pass}}
     <br/><br/>

--- a/applications/examples/controllers/appadmin.py
+++ b/applications/examples/controllers/appadmin.py
@@ -194,8 +194,6 @@ def select():
             request.vars.query = '%s.%s.%s==%s' % (request.args[0],
                                                    match.group('table'), match.group('field'),
                                                    match.group('value'))
-    else:
-        request.vars.query = session.last_query
     query = get_query(request)
     if request.vars.start:
         start = int(request.vars.start)
@@ -222,7 +220,6 @@ def select():
             else:
                 orderby = '~' + orderby
     session.last_orderby = orderby
-    session.last_query = request.vars.query
     form = FORM(TABLE(TR(T('Query:'), '', INPUT(_style='width:400px',
                 _name='query', _value=request.vars.query or '', _class='form-control',
                 requires=IS_NOT_EMPTY(

--- a/applications/examples/views/appadmin.html
+++ b/applications/examples/views/appadmin.html
@@ -82,7 +82,7 @@
        <div style="overflow:auto; width:80%;">
        {{linkto = lambda f, t, r: URL('update', args=[request.args[0], r, f]) if f else "#"}}
        {{upload=URL('download',args=request.args[0])}}
-       {{=SQLTABLE(rows,linkto,upload,orderby=True,_class='table table-striped table-bordered sortable')}}
+       {{=SQLTABLE(rows,linkto,upload,orderby=True,query=query,_class='table table-striped table-bordered sortable')}}
        </div>
     {{pass}}
     <br/><br/>

--- a/applications/welcome/controllers/appadmin.py
+++ b/applications/welcome/controllers/appadmin.py
@@ -194,8 +194,6 @@ def select():
             request.vars.query = '%s.%s.%s==%s' % (request.args[0],
                                                    match.group('table'), match.group('field'),
                                                    match.group('value'))
-    else:
-        request.vars.query = session.last_query
     query = get_query(request)
     if request.vars.start:
         start = int(request.vars.start)
@@ -222,7 +220,6 @@ def select():
             else:
                 orderby = '~' + orderby
     session.last_orderby = orderby
-    session.last_query = request.vars.query
     form = FORM(TABLE(TR(T('Query:'), '', INPUT(_style='width:400px',
                 _name='query', _value=request.vars.query or '', _class='form-control',
                 requires=IS_NOT_EMPTY(

--- a/applications/welcome/views/appadmin.html
+++ b/applications/welcome/views/appadmin.html
@@ -82,7 +82,7 @@
        <div style="overflow:auto; width:80%;">
        {{linkto = lambda f, t, r: URL('update', args=[request.args[0], r, f]) if f else "#"}}
        {{upload=URL('download',args=request.args[0])}}
-       {{=SQLTABLE(rows,linkto,upload,orderby=True,_class='table table-striped table-bordered sortable')}}
+       {{=SQLTABLE(rows,linkto,upload,orderby=True,query=query,_class='table table-striped table-bordered sortable')}}
        </div>
     {{pass}}
     <br/><br/>

--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -3393,6 +3393,7 @@ class SQLTABLE(TABLE):
         linkto: URL (or lambda to generate a URL) to edit individual records
         upload: URL to download uploaded files
         orderby: Add an orderby link to column headers.
+        query: Query string to support orderby headers.
         headers: dictionary of headers to headers redefinions
             headers can also be a string to generate the headers from data
             for now only headers="fieldname:capitalize",
@@ -3428,6 +3429,7 @@ class SQLTABLE(TABLE):
                  linkto=None,
                  upload=None,
                  orderby=None,
+                 query='',
                  headers={},
                  truncate=16,
                  columns=None,
@@ -3499,8 +3501,10 @@ class SQLTABLE(TABLE):
                         attrcol.update(_class=coldict['class'])
                     row.append(TH(coldict['label'], **attrcol))
                 elif orderby:
-                    row.append(TH(A(headers.get(c, c),
-                                    _href=th_link + '?orderby=' + c, cid=cid)))
+                    link = th_link + '?orderby=' + c
+                    if query:
+                        link += '&query=' + query
+                    row.append(TH(A(headers.get(c, c), _href=link, cid=cid)))
                 else:
                     row.append(TH(headers.get(c, re.sub(self.REGEX_ALIAS_MATCH, r'\2', c))))
 


### PR DESCRIPTION
- Get rid of session.last_query
- add query attribute to SQLTABLE

Please see ticket https://github.com/web2py/web2py/issues/2326 for more details about massive join bug. Thanks