### PR TITLE
Add hash_extension functionality to URLs

### DIFF
--- a/gluon/html.py
+++ b/gluon/html.py
@@ -190,7 +190,8 @@ def URL(a=None,
         port=None,
         encode_embedded_slash=False,
         url_encode=True,
-        language=None
+        language=None,
+        hash_extension=True
         ):
     """
     generates a url '/a/c/f' corresponding to application a, controller c
@@ -339,7 +340,8 @@ def URL(a=None,
         if '.' in function:
             function, extension = function.rsplit('.', 1)
 
-    function2 = '%s.%s' % (function, extension or 'html')
+    # only include the extension as part of the variables for the hash if requested
+    function2 = '%s.%s' % (function, extension or 'html') if hash_extension else function
 
     if not (application and controller and function):
         raise SyntaxError('not enough information to build the url (%s %s %s)' % (application, controller, function))
@@ -416,7 +418,7 @@ def URL(a=None,
     return url
 
 
-def verifyURL(request, hmac_key=None, hash_vars=True, salt=None, user_signature=None):
+def verifyURL(request, hmac_key=None, hash_vars=True, salt=None, user_signature=None, hash_extension=True):
     """
     Verifies that a request's args & vars have not been tampered with by the user
 
@@ -477,10 +479,19 @@ def verifyURL(request, hmac_key=None, hash_vars=True, salt=None, user_signature=
 
     # always include all of the args
     other = args and urllib_quote('/' + '/'.join([str(x) for x in args])) or ''
+    
+    # decide whether the extension should be part of the hash verification
+    h_extension = request.extension if hash_extension else ''
+
+    # only add a period to the extension when it exists otherwise empty
+    # extensions will fail to validate
+    if h_extension:
+        h_extension = '.%s' % (h_extension)
+        
     h_args = '/%s/%s/%s.%s%s' % (request.application,
                                  request.controller,
                                  request.function,
-                                 request.extension,
+                                 h_extension,
                                  other)
 
     # but only include those vars specified (allows more flexibility for use with

--- a/gluon/html.py
+++ b/gluon/html.py
@@ -488,7 +488,7 @@ def verifyURL(request, hmac_key=None, hash_vars=True, salt=None, user_signature=
     if h_extension:
         h_extension = '.%s' % (h_extension)
         
-    h_args = '/%s/%s/%s.%s%s' % (request.application,
+    h_args = '/%s/%s/%s%s%s' % (request.application,
                                  request.controller,
                                  request.function,
                                  h_extension,

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -3930,7 +3930,7 @@ class Auth(AuthAPI):
             return self.has_permission(name, table_name, record_id)
         return self.requires(has_permission, otherwise=otherwise)
 
-    def requires_signature(self, otherwise=None, hash_vars=True):
+    def requires_signature(self, otherwise=None, hash_vars=True, hash_extension=True):
         """
         Decorator that prevents access to action if not logged in or
         if user logged in is not a member of group_id.
@@ -3938,7 +3938,7 @@ class Auth(AuthAPI):
         group_id is calculated.
         """
         def verify():
-            return URL.verify(current.request, user_signature=True, hash_vars=hash_vars)
+            return URL.verify(current.request, user_signature=True, hash_vars=hash_vars, hash_extension=True)
         return self.requires(verify, otherwise)
 
     def accessible_query(self, name, table, user_id=None):


### PR DESCRIPTION
Hi folks,

This update is to add functionality to decide whether the extension should be hashed as part of _signature creation/validation so that the extension can be ignored when comparing (similar to the hash_vars variable currently).

This would allow two identical URLs with varying extensions but an appropriate _signature to validate via the URL.verify function (example below):
- a/b/c.json?_signature=123456
- a/b/c.html?_signature=123456

My use case is that I am using both web2py and Vue.js together which means I can have multiple requests sent for any given route to fetch the data for a component template and the component template itself so both requests are using an identical _signature parameter however it is failing due to the hashing of the extension as part of the signature comparison.

My changes are backwards compatible as the optional function parameters all default to work as they do currently, so this should not break existing functionality.