### PR TITLE
Add .msg to CONTENT_TYPE

### DIFF
--- a/gluon/contenttype.py
+++ b/gluon/contenttype.py
@@ -412,6 +412,7 @@ CONTENT_TYPE = {
     '.mrml': 'text/x-mrml',
     '.mrw': 'image/x-minolta-mrw',
     '.ms': 'text/x-troff-ms',
+    '.msg': 'application/vnd.ms-outlook',
     '.msi': 'application/x-msi',
     '.msod': 'image/x-msod',
     '.msx': 'application/x-msx-rom',


### PR DESCRIPTION
Useful for outlook messages in attachments