### PR TITLE
remove saml2 flash error message

### DIFF
--- a/gluon/contrib/login_methods/saml2_auth.py
+++ b/gluon/contrib/login_methods/saml2_auth.py
@@ -164,7 +164,6 @@ class Saml2Auth(object):
         if 'url' in d:
             redirect(d['url'])
         elif 'error' in d:
-            current.session.flash = d['error']
             redirect(URL('default','index'))
         elif 'response' in d:            
             # a['assertions'][0]['attribute_statement'][0]['attribute']


### PR DESCRIPTION
login method should not be sending tracebacks directly to session.flash.  should use a logger instead