### PR TITLE
fix AttributeError: 'Monitor' object has no attribute 'isAlive'

### DIFF
--- a/gluon/rocket.py
+++ b/gluon/rocket.py
@@ -26,7 +26,7 @@ THREAD_STOP_CHECK_INTERVAL = 1  # in secs, How often should threads check for a 
 if hasattr(sys, 'frozen'):
     # py2installer
     IS_JYTHON = False
-else:    
+else:
     IS_JYTHON = platform.system() == 'Java'  # Handle special cases for Jython
 IGNORE_ERRORS_ON_CLOSE = set([errno.ECONNABORTED, errno.ECONNRESET])
 DEFAULT_LISTEN_QUEUE_SIZE = 5
@@ -522,7 +522,7 @@ class Listener(Thread):
             self.err_log.warning('Listener started when not ready.')
             return
 
-        if self.thread is not None and self.thread.isAlive():
+        if self.thread is not None and self.thread.is_alive():
             self.err_log.warning('Listener already running.')
             return
 
@@ -530,11 +530,11 @@ class Listener(Thread):
 
         self.thread.start()
 
-    def isAlive(self):
+    def is_alive(self):
         if self.thread is None:
             return False
 
-        return self.thread.isAlive()
+        return self.thread.is_alive()
 
     def join(self):
         if self.thread is None:
@@ -713,14 +713,14 @@ class Rocket(object):
         if background:
             return
 
-        while self._monitor.isAlive():
+        while self._monitor.is_alive():
             try:
                 time.sleep(THREAD_STOP_CHECK_INTERVAL)
             except KeyboardInterrupt:
                 # Capture a keyboard interrupt when running from a console
                 break
             except:
-                if self._monitor.isAlive():
+                if self._monitor.is_alive():
                     log.error(traceback.format_exc())
                     continue
 
@@ -740,12 +740,12 @@ class Rocket(object):
             time.sleep(0.01)
 
             for l in self.listeners:
-                if l.isAlive():
+                if l.is_alive():
                     l.join()
 
             # Stop Monitor
             self._monitor.stop()
-            if self._monitor.isAlive():
+            if self._monitor.is_alive():
                 self._monitor.join()
 
             # Stop Worker threads
@@ -1055,14 +1055,14 @@ class ThreadPool:
             self.app_info['executor'].shutdown(wait=False)
 
         # Give them the gun
-        # active_threads = [t for t in self.threads if t.isAlive()]
+        # active_threads = [t for t in self.threads if t.is_alive()]
         # while active_threads:
         #     t = active_threads.pop()
         #     t.kill()
 
         # Wait until they pull the trigger
         for t in self.threads:
-            if t.isAlive():
+            if t.is_alive():
                 t.join()
 
         # Clean up the mess
@@ -1071,7 +1071,7 @@ class ThreadPool:
     def bring_out_your_dead(self):
         # Remove dead threads from the pool
 
-        dead_threads = [t for t in self.threads if not t.isAlive()]
+        dead_threads = [t for t in self.threads if not t.is_alive()]
         for t in dead_threads:
             if __debug__:
                 log.debug("Removing dead thread: %s." % t.getName())


### PR DESCRIPTION
Thread.isAlive is long deprecated. It is removed in Python 3.9. See https://bugs.python.org/issue37804

This fixes Issue #2354 