### PR TITLE
Fix crash running update_languages.py on macOS

### DIFF
--- a/scripts/update_languages.py
+++ b/scripts/update_languages.py
@@ -54,6 +54,7 @@ def update_languages(cwd, default_lang):
 	default = read_dict(defaultfp)
 
 	for lang in os.listdir(os.path.join(cwd, "languages")):
+		if '.DS_Store' in lang: continue
 		if lang == default_lang+".py" or lang.startswith("plural-"): continue
 		
 		i18n = read_dict(os.path.join(cwd, "languages", lang))


### PR DESCRIPTION
This PR fixes a fatal bug when running the `update_languages.py` on macOS, due to the invisible `.DS_Store`.  Considering I use a MacBook all the time, I'm kind of surprised it took this long before an issue popped up...