### PR TITLE
Fix some SyntaxWarnings when comparing string

### DIFF
--- a/applications/admin/views/wizard/step.html
+++ b/applications/admin/views/wizard/step.html
@@ -65,7 +65,7 @@
 		<div class="form row-fluid">
 			{{=form.custom.begin}}
 				{{ for fieldname in form.table.fields: }}
-					{{if fieldname is not 'id':}}
+					{{if fieldname != 'id':}}
 						<label>{{=form.custom.label[fieldname]}}:</label>
 						{{=form.custom.widget[fieldname]}}
 						{{if fieldname=='layout_theme':}}
@@ -95,7 +95,7 @@
 		<div class="form row-fluid">
 			{{=form.custom.begin}}
 				{{ for fieldname in form.table.fields: }} 
-					{{if fieldname is not 'id':}}
+					{{if fieldname != 'id':}}
 						<div class="control-group">
 							<label class="control-label">{{=form.custom.label[fieldname]}}:</label>
 							<div class="controls">


### PR DESCRIPTION
Fix some SyntaxWarnings of python3 when comparing string in admin/views/wizard/step.html