### PR TITLE
make simplejsonrpc compatible with python3.8+

### DIFF
--- a/gluon/contrib/simplejsonrpc.py
+++ b/gluon/contrib/simplejsonrpc.py
@@ -18,12 +18,17 @@ __license__ = "LGPL 3.0"
 __version__ = "0.05"
 
 import sys
-from urllib import parse
-from xmlrpc.client import Transport, SafeTransport
-from io import StringIO
+PY2 = sys.version_info[0] == 2
+
+if PY2:
+    from xmlrpclib import Transport, SafeTransport
+    from cStringIO import StringIO
+else:
+    from xmlrpc.client import Transport, SafeTransport
+    from io import StringIO
 import random
 import json
-from gluon._compat import basestring
+from gluon._compat import basestring, urlparse
 
 class JSONRPCError(RuntimeError):
     "Error object for remote procedure call fail"
@@ -86,7 +91,7 @@ class ServerProxy(object):
         self.version = version          # '2.0' for jsonrpc2
         self.json_encoder = json_encoder  # Allow for a custom JSON encoding class
 
-        parsed = parse.urlparse(uri)
+        parsed = urlparse.urlparse(uri)
         type = parsed.scheme
         if type not in ("http", "https"):
             raise IOError("unsupported JSON-RPC protocol")

--- a/gluon/contrib/simplejsonrpc.py
+++ b/gluon/contrib/simplejsonrpc.py
@@ -18,16 +18,9 @@ __license__ = "LGPL 3.0"
 __version__ = "0.05"
 
 import sys
-PY2 = sys.version_info[0] == 2
-
-if PY2:
-    import urllib
-    from xmlrpclib import Transport, SafeTransport
-    from cStringIO import StringIO
-else:
-    import urllib.request as urllib
-    from xmlrpc.client import Transport, SafeTransport
-    from io import StringIO
+from urllib import parse
+from xmlrpc.client import Transport, SafeTransport
+from io import StringIO
 import random
 import json
 from gluon._compat import basestring
@@ -93,10 +86,12 @@ class ServerProxy(object):
         self.version = version          # '2.0' for jsonrpc2
         self.json_encoder = json_encoder  # Allow for a custom JSON encoding class
 
-        type, uri = urllib.splittype(uri)
+        parsed = parse.urlparse(uri)
+        type = parsed.scheme
         if type not in ("http", "https"):
             raise IOError("unsupported JSON-RPC protocol")
-        self.__host, self.__handler = urllib.splithost(uri)
+        self.__host = parsed.netloc
+        self.__handler = parsed.path
 
         if transport is None:
             if type == "https":


### PR DESCRIPTION
urllib's splittype and splithost were deprecated in 3.8

This also removes support for python2 in this contrib module (if required, it can be reintroduced, as urlparse was available as part of the urlparse module before integration into urllib.parse)

Fixes https://github.com/web2py/web2py/issues/2346