### PR TITLE
Fix problem with gmail attachments

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -246,15 +246,13 @@ class Mail(object):
                 if filename is None:
                     raise Exception('Missing attachment name')
                 payload = payload.read()
-            # FIXME PY3 can be used to_native?
-            filename = filename.encode(encoding)
             if content_type is None:
                 content_type = contenttype(filename)
             self.my_filename = filename
             self.my_payload = payload
             MIMEBase.__init__(self, *content_type.split('/', 1))
             self.set_payload(payload)
-            self['Content-Disposition'] = Header('attachment; filename="%s"' % to_native(filename, encoding), 'utf-8')
+            self.add_header('Content-Disposition', 'attachment', filename=filename)
             if content_id is not None:
                 self['Content-Id'] = '<%s>' % to_native(content_id, encoding)
             Encoders.encode_base64(self)


### PR DESCRIPTION
Problem was introduced by my here 35264660bf60cb59b7ebfb83718b7d03c6024029 while fixing accents in filenames, this fix keeps accents working as well