### PR TITLE
Add DKIM support to emails

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -282,6 +282,8 @@ class Mail(object):
         settings.timeout = 5  # seconds
         settings.hostname = None
         settings.ssl = False
+        settings.dkim = None
+        settings.list_unsubscribe = None
         settings.cipher_type = None
         settings.gpg_home = None
         settings.sign = True
@@ -767,6 +769,9 @@ class Mail(object):
         payload['Date'] = email.utils.formatdate()
         for k, v in iteritems(headers):
             payload[k] = encoded_or_raw(to_unicode(v, encoding))
+
+        dkim = dkim or self.settings.dkim
+        list_unsubscribe = list_unsubscribe or self.settings.list_unsubscribe
 
         if list_unsubscribe:
             payload['List-Unsubscribe'] = "<mailto:%s>" % list_unsubscribe

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -310,6 +310,8 @@ class Mail(object):
              raw=False,
              headers={},
              from_address=None,
+             dkim=None,
+             list_unsubscribe=None,
              cipher_type=None,
              sign=None,
              sign_passphrase=None,
@@ -765,6 +767,12 @@ class Mail(object):
         payload['Date'] = email.utils.formatdate()
         for k, v in iteritems(headers):
             payload[k] = encoded_or_raw(to_unicode(v, encoding))
+
+        if list_unsubscribe:
+            payload['List-Unsubscribe'] = "<mailto:%s>" % list_unsubscribe
+        if dkim:
+            payload['DKIM-Signature'] = dkim_sign(payload, dkim.key, dkim.selector)
+
         result = {}
         try:
             if self.settings.server == 'logging':


### PR DESCRIPTION
add support to `Mail.send()` for the following spam-filters facilitating mail content:

- DKIM (requires install of `dkimpy`)
- List-Unsubscribe

example usage (global configuration e.g. via `models/db.py`):
```
dkim_key_path = myconf.get("dkim.key", default=default_dkim_key_path)
if path.exists(dkim_key_path):
    class dkim:
        key = open(dkim_key_path).read()
        selector = myconf.get("dkim.selector", default="s1024")

    mail.settings.dkim = dkim


list_unsubscribe = myconf.get("contact.email")
if list_unsubscribe:
    mail.settings.list_unsubscribe = list_unsubscribe
```