### PR TITLE
callable auth.settings.auth_two_factor_enabled

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -2677,7 +2677,12 @@ class Auth(AuthAPI):
         # If auth.settings.auth_two_factor_enabled it will enable two factor
         # for all the app. Another way to anble two factor is that the user
         # must be part of a group that is called auth.settings.two_factor_authentication_group
-        if user and self.settings.auth_two_factor_enabled is True:
+        if user and (
+            self.settings.auth_two_factor_enabled(user)
+            if callable(self.settings.auth_two_factor_enabled)
+            else self.settings.auth_two_factor_enabled is True
+        ):
+
             session.auth_two_factor_enabled = True
         elif user and self.settings.two_factor_authentication_group:
             role = self.settings.two_factor_authentication_group


### PR DESCRIPTION
Allow the auth setting auth.settings.auth_two_factor_enabled to be a callable that passes the record of the user trying to login.

This allows the developer to inspect the user record before determining whether or not 2FA will be enforced.

I'm asking for this in order to be compatible with the way that py4web handles 2FA.

I know that we can use a group to specify users that are forced to use 2FA, but then there is a burden to maintain the list.  We want to be able to exclude certain users from 2FA.