### PR TITLE
utils-compare fail safe

### DIFF
--- a/gluon/tests/test_utils.py
+++ b/gluon/tests/test_utils.py
@@ -29,6 +29,14 @@ class TestUtils(unittest.TestCase):
         compare_result_false = compare(a, b)
         self.assertFalse(compare_result_false)
 
+        a, b = 'test123', ['test123', 'test123']
+        compare_result_false = compare(a, b)
+        self.assertFalse(compare_result_false)
+
+        a, b = '123', 123
+        compare_result_false = compare(a, b)
+        self.assertFalse(compare_result_false)
+
     def test_md5_hash(self):
         """ Tests the md5_hash function """
 

--- a/gluon/utils.py
+++ b/gluon/utils.py
@@ -79,12 +79,15 @@ def AES_dec(cipher, data):
 
 def compare(a, b):
     """ Compares two strings and not vulnerable to timing attacks """
-    if HAVE_COMPARE_DIGEST:
-        return hmac.compare_digest(a, b)
-    result = len(a) ^ len(b)
-    for i in xrange(len(b)):
-        result |= ord(a[i % len(a)]) ^ ord(b[i])
-    return result == 0
+    try:
+        if HAVE_COMPARE_DIGEST:
+            return hmac.compare_digest(a, b)
+        result = len(a) ^ len(b)
+        for i in xrange(len(b)):
+            result |= ord(a[i % len(a)]) ^ ord(b[i])
+        return result == 0
+    except:
+        return False
 
 
 def md5_hash(text):


### PR DESCRIPTION
compare function in utils.py assumes a and b are the same types, if not, it fails and throws an exception. Instead of throwing an exception, I recommend to fail safely and return False. 