### PR TITLE
Fix hanging issue when cache file is corrupt

### DIFF
--- a/gluon/cache.py
+++ b/gluon/cache.py
@@ -450,7 +450,13 @@ class CacheOnDisk(CacheAbstract):
         dt = time_expire
         self.storage.acquire(key)
         self.storage.acquire(CacheAbstract.cache_stats_name)
-        item = self.storage.get(key)
+
+        try:
+            item = self.storage.get(key)
+        except:
+            del self.storage[key]
+            item = self.storage.get(key)
+
         self.storage.safe_apply(CacheAbstract.cache_stats_name, inc_hit_total,
                                 default_value={'hit_total': 0, 'misses': 0})
 

--- a/gluon/tests/test_cache.py
+++ b/gluon/tests/test_cache.py
@@ -10,6 +10,7 @@ import unittest
 from gluon.storage import Storage
 from gluon.cache import CacheInRam, CacheOnDisk, Cache
 from gluon.dal import DAL, Field
+from gluon import recfile
 
 oldcwd = None
 
@@ -92,6 +93,19 @@ class TestCache(unittest.TestCase):
         self.assertEqual(cache('a', lambda: 1, 100), 6)
         cache.increment('b')
         self.assertEqual(cache('b', lambda: 'x', 100), 1)
+    
+    def test_corrupt_CacheOnDsk(self):
+        s = Storage({'application': 'admin',
+                     'folder': 'applications/admin'})
+        cache = CacheOnDisk(s)
+        self.assertEqual(cache('a', lambda: 1, 100), 1)
+
+        # empty cache file
+        folder = os.path.join(s.folder, 'cache') 
+        val_file = recfile.open('a', mode='r+b', path=folder)
+        val_file.truncate()
+
+        self.assertEqual(cache('a', lambda: 2, 0), 2)
 
     # TODO: def test_CacheAction(self):
 


### PR DESCRIPTION
If someone edits cache file or if web2py fails to save value to cache file successfully, then error would be thrown when web2py tries to get cache value from filesystem.   
Error would be thrown here https://github.com/web2py/web2py/blob/master/gluon/cache.py#L359, https://github.com/web2py/web2py/blob/master/gluon/cache.py#L453
And that error causes the application to hang because the storage would never be released https://github.com/web2py/web2py/blob/master/gluon/cache.py#L480

And sometimes I notice empty cache files, and that would raise error when `pickle.load(val_file)` is called. I think this is because when web2py tries to save a value in a file, it first empties out the file here https://github.com/web2py/web2py/blob/master/gluon/cache.py#L346 and then the rest of the process fails. It could be because UWSGI kills workers at that time or somehow how the process gets killed in the web server

My solution to delete cache file when `item = self.storage.get(key)` raises exception, so that web2py can generate a new one 




