### PR TITLE
fix circular import #2475

### DIFF
--- a/gluon/__init__.py
+++ b/gluon/__init__.py
@@ -144,9 +144,9 @@ def import_packages():
 
 import_packages()
 
+from .globals import current
 from .compileapp import LOAD
 from .dal import DAL, Field
-from .globals import current
 from .html import *
 from .http import HTTP, redirect
 from .sqlhtml import SQLFORM, SQLTABLE


### PR DESCRIPTION
fix for #2475, just rearranges the order of the imports for gluon so that a circular import wont happen