### PR TITLE
Fix get app info + set python3 on shebang

### DIFF
--- a/applications/admin/controllers/default.py
+++ b/applications/admin/controllers/default.py
@@ -1087,10 +1087,13 @@ def about():
     """ Read about info """
     app = get_app()
     # ## check if file is not there
-    about = safe_read(apath('%s/ABOUT.web2py.txt' % app, r=request))
-    license = safe_read(apath('%s/LICENSE.web2py.txt' % app, r=request))
+    try:
+        about = safe_read(apath('%s/ABOUT.web2py.txt' % app, r=request))
+        license = safe_read(apath('%s/LICENSE.web2py.txt' % app, r=request))
+    except FileNotFoundError:
+        about = safe_read(apath('%s/ABOUT' % app, r=request))
+        license = safe_read(apath('%s/LICENSE' % app, r=request))
     return dict(app=app, about=MARKMIN(about), license=MARKMIN(license), progress=report_progress(app))
-
 
 def design():
     """ Application design handler """

--- a/web2py.py
+++ b/web2py.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import os


### PR DESCRIPTION
With the current admin app you cannot get info about the provided apps (the related files was renamed).

Also I think 'python3' on shebang is better than 'python', because on Windows you can't use it and on Linux/Mac that's the preferred choice.