### PR TITLE
fix reduce import error on admin/todolist.load

### DIFF
--- a/applications/admin/views/default/todolist.load
+++ b/applications/admin/views/default/todolist.load
@@ -1,6 +1,6 @@
 <div>
 <!--div class="page-header"-->
-    {{n_todo=reduce(lambda x,y: x + len(y['matches']), todo, 0)}}
+    {{n_todo = sum(len(file['matches']) for file in todo)}}
     <h4>{{="%s TODO in %s" % (n_todo, app)}}</h4>
 <!--/div-->
 <ul class="nav nav-list cm-s-web2py">


### PR DESCRIPTION
in py3 reduce is not a built-in function anymore and must be imported from the functools module. However I've preferred to change its usage with a more pythonic  code snippet