### PR TITLE
Change shebang on web2py.py to python3

### DIFF
--- a/web2py.py
+++ b/web2py.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import os


### PR DESCRIPTION
Using 'python' is a problem nowadays on Linux and Mac, while on Windows you cannot use shebang at all