### PR TITLE
Fix welcome app with web2py > 3.0.9

### DIFF
--- a/applications/welcome/models/db.py
+++ b/applications/welcome/models/db.py
@@ -7,14 +7,22 @@
 from gluon.contrib.appconfig import AppConfig
 from gluon.tools import Auth
 import os
+import re
+
+REQUIRED_WEB2PY_VERSION = "3.0.10"
 
 # -------------------------------------------------------------------------
 # This scaffolding model makes your app work on Google App Engine too
 # File is released under public domain and you can use without limitations
 # -------------------------------------------------------------------------
 
-if request.global_settings.web2py_version < "3.0.9":
-    raise HTTP(500, "Requires web2py 3.0.9 or newer")
+web2py_version_string = request.global_settings.web2py_version
+web2py_version = (web2py_version_string).split(".")
+web2py_version[2] = (re.match(r'\d+', (web2py_version[2]))).group()
+if web2py_version[0] <= REQUIRED_WEB2PY_VERSION.split(".")[0]:
+    if web2py_version[1] <= REQUIRED_WEB2PY_VERSION.split(".")[1]:
+        if web2py_version[2]  < REQUIRED_WEB2PY_VERSION.split(".")[2] :
+            raise HTTP(500, "Requires web2py " + REQUIRED_WEB2PY_VERSION + " or newer, not " + web2py_version_string)
 
 # -------------------------------------------------------------------------
 # if SSL/HTTPS is properly configured and you want all HTTP requests to

--- a/applications/welcome/models/db.py
+++ b/applications/welcome/models/db.py
@@ -21,8 +21,9 @@ web2py_version = (web2py_version_string).split(".")
 web2py_version[2] = (re.match(r'\d+', (web2py_version[2]))).group()
 if web2py_version[0] <= REQUIRED_WEB2PY_VERSION.split(".")[0]:
     if web2py_version[1] <= REQUIRED_WEB2PY_VERSION.split(".")[1]:
-        if web2py_version[2]  < REQUIRED_WEB2PY_VERSION.split(".")[2] :
-            raise HTTP(500, "Requires web2py " + REQUIRED_WEB2PY_VERSION + " or newer, not " + web2py_version_string)
+        if int(web2py_version[2]) < int(REQUIRED_WEB2PY_VERSION.split(".")[2]):
+            raise HTTP(500, "Requires web2py version " + REQUIRED_WEB2PY_VERSION \
+                + " or newer, not " + web2py_version_string)
 
 # -------------------------------------------------------------------------
 # if SSL/HTTPS is properly configured and you want all HTTP requests to


### PR DESCRIPTION
the current check for the needed web2py's version fails if version > 3.0.9

Surely there could be better ways to handle it, but not without additional dependency.