### PR TITLE
Fixes to redis session, scheduler and json post variables

### DIFF
--- a/gluon/contrib/redis_scheduler.py
+++ b/gluon/contrib/redis_scheduler.py
@@ -762,8 +762,8 @@ class RScheduler(Scheduler):
             except:
                 pass
         rtn = self.db.scheduler_task.validate_and_insert(**kwargs)
-        if not rtn.errors:
-            rtn.uuid = tuuid
+        if not rtn.get('errors'):
+            rtn['uuid'] = tuuid
             if immediate:
                 r_server = self.r_server
                 ticker = self.get_workers(only_ticker=True)
@@ -781,7 +781,7 @@ class RScheduler(Scheduler):
                                 time.sleep(0.1)
                                 continue
         else:
-            rtn.uuid = None
+            rtn['uuid'] = None
         return rtn
 
     def stop_task(self, ref):

--- a/gluon/contrib/redis_session.py
+++ b/gluon/contrib/redis_session.py
@@ -231,11 +231,11 @@ class MockQuery(object):
             key = self.keyprefix + ":" + str(self.value)
             if self.with_lock:
                 acquire_lock(self.db.r_server, key + ":lock", self.value, 2)
-            rtn = {str(k): v for k, v in self.db.r_server.hgetall(key).items()}
+            rtn = {k.decode(): v for k, v in self.db.r_server.hgetall(key).items()}
             if rtn:
                 if self.unique_key:
                     # make sure the id and unique_key are correct
-                    if rtn["unique_key"] == self.unique_key:
+                    if rtn["unique_key"].decode() == self.unique_key:
                         rtn["update_record"] = self.update  # update record support
                     else:
                         rtn = None

--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -235,7 +235,7 @@ class Request(Storage):
 
         if is_json:
             try:
-                json_vars = json_parser.loads(body)
+                json_vars = json_parser.load(body)
             except:
                 # incoherent request bodies can still be parsed "ad-hoc"
                 json_vars = {}


### PR DESCRIPTION
Tested scheduler, redis session with success
json post variables were being escaped, seems like an old fix was reverted