### PR TITLE
Fix markmin2latex regex, repl & plain strings to use r-strings

### DIFF
--- a/gluon/contrib/markmin/markmin2latex.py
+++ b/gluon/contrib/markmin/markmin2latex.py
@@ -16,26 +16,26 @@ regex_code = re.compile(r"(" + META + r")|(``(?P<t>.*?)``(:(?P<c>\w+))?)", re.S)
 regex_title = re.compile(r"^#{1} (?P<t>[^\n]+)", re.M)
 regex_maps = [
     (re.compile(r"[ \t\r]+\n"), "\n"),
-    (re.compile(r"\*\*(?P<t>[^\s\*]+( +[^\s\*]+)*)\*\*"), "{\\\\bf \g<t>}"),
-    (re.compile(r"''(?P<t>[^\s']+( +[^\s']+)*)''"), "{\\\it \g<t>}"),
-    (re.compile(r"^#{5,6}\s*(?P<t>[^\n]+)", re.M), "\n\n{\\\\bf \g<t>}\n"),
+    (re.compile(r"\*\*(?P<t>[^\s\*]+( +[^\s\*]+)*)\*\*"), r"{\\bf \g<t>}"),
+    (re.compile(r"''(?P<t>[^\s']+( +[^\s']+)*)''"), r"{\\it \g<t>}"),
+    (re.compile(r"^#{5,6}\s*(?P<t>[^\n]+)", re.M), r"\n\n{\\bf \g<t>}\n"),
     (
         re.compile(r"^#{4}\s*(?P<t>[^\n]+)", re.M),
-        "\n\n\\\\goodbreak\\\subsubsection{\g<t>}\n",
+        r"\n\n\\goodbreak\\subsubsection{\g<t>}\n",
     ),
     (
         re.compile(r"^#{3}\s*(?P<t>[^\n]+)", re.M),
-        "\n\n\\\\goodbreak\\\subsection{\g<t>}\n",
+        r"\n\n\\goodbreak\\subsection{\g<t>}\n",
     ),
-    (re.compile(r"^#{2}\s*(?P<t>[^\n]+)", re.M), "\n\n\\\\goodbreak\\\section{\g<t>}\n"),
+    (re.compile(r"^#{2}\s*(?P<t>[^\n]+)", re.M), r"\n\n\\goodbreak\\section{\g<t>}\n"),
     (re.compile(r"^#{1}\s*(?P<t>[^\n]+)", re.M), ""),
     (
         re.compile(r"^\- +(?P<t>.*)", re.M),
-        "\\\\begin{itemize}\n\\\item \g<t>\n\\\end{itemize}",
+        r"\\begin{itemize}\n\\item \g<t>\n\\end{itemize}",
     ),
     (
         re.compile(r"^\+ +(?P<t>.*)", re.M),
-        "\\\\begin{itemize}\n\\\item \g<t>\n\\\end{itemize}",
+        r"\\begin{itemize}\n\\item \g<t>\n\\end{itemize}",
     ),
     (re.compile(r"\\\\end\{itemize\}\s+\\\\begin\{itemize\}"), "\n"),
     (re.compile(r"\n\s+\n"), "\n\n"),
@@ -79,7 +79,7 @@ def render(
     #############################################################
     text = str(text or "")
     segments, i = [], 0
-    text = regex_dd.sub("``\g<latex>``:latex ", text)
+    text = regex_dd.sub(r"``\g<latex>``:latex ", text)
     text = regex_newlines.sub("\n", text)
     while True:
         item = regex_code.search(text, i)
@@ -110,10 +110,10 @@ def render(
     text = latex_escape(text, pound=False)
 
     texts = text.split("## References", 1)
-    text = regex_anchor.sub("\\\label{\g<t>}", texts[0])
+    text = regex_anchor.sub(r"\\label{\g<t>}", texts[0])
     if len(texts) == 2:
         text += "\n\\begin{thebibliography}{999}\n"
-        text += regex_bibitem.sub("\n\\\\bibitem{\g<t>}", texts[1])
+        text += regex_bibitem.sub(r"\n\\bibitem{\g<t>}", texts[1])
         text += "\n\\end{thebibliography}\n"
 
     text = "\n".join(t.strip() for t in text.split("\n"))
@@ -172,9 +172,9 @@ def render(
     text = regex_image_width.sub(sub, text)
     text = regex_image.sub(sub, text)
 
-    text = regex_link.sub("{\\\\footnotesize\\\href{\g<k>}{\g<t>}}", text)
-    text = regex_commas.sub("\g<t>", text)
-    text = regex_noindent.sub("\n\\\\noindent \g<t>", text)
+    text = regex_link.sub(r"{\\footnotesize\\href{\g<k>}{\g<t>}}", text)
+    text = regex_commas.sub(r"\g<t>", text)
+    text = regex_noindent.sub(r"\n\\noindent \g<t>", text)
 
     # ## fix paths in images
     regex = re.compile(r"\\\\_\w*\.(eps|png|jpg|gif)")

--- a/gluon/contrib/markmin/markmin2latex.py
+++ b/gluon/contrib/markmin/markmin2latex.py
@@ -12,7 +12,7 @@ __all__ = ["render", "markmin2latex"]
 META = "META"
 regex_newlines = re.compile(r"(\n\r)|(\r\n)")
 regex_dd = re.compile(r"\$\$(?P<latex>.*?)\$\$")
-regex_code = re.compile(r"(" + META + ")|(``(?P<t>.*?)``(:(?P<c>\w+))?)", re.S)
+regex_code = re.compile(r"(" + META + r")|(``(?P<t>.*?)``(:(?P<c>\w+))?)", re.S)
 regex_title = re.compile(r"^#{1} (?P<t>[^\n]+)", re.M)
 regex_maps = [
     (re.compile(r"[ \t\r]+\n"), "\n"),
@@ -45,7 +45,7 @@ regex_table = re.compile(r"^\-{4,}\n(?P<t>.*?)\n\-{4,}(:(?P<c>\w+))?\n", re.M | 
 regex_anchor = re.compile(r"\[\[(?P<t>\S+)\]\]")
 regex_bibitem = re.compile(r"\-\s*\[\[(?P<t>\S+)\]\]")
 regex_image_width = re.compile(
-    "\[\[(?P<t>[^\]]*?) +(?P<k>\S+) +(?P<p>left|right|center) +(?P<w>\d+px)\]\]"
+    r"\[\[(?P<t>[^\]]*?) +(?P<k>\S+) +(?P<p>left|right|center) +(?P<w>\d+px)\]\]"
 )
 regex_image = re.compile(r"\[\[(?P<t>[^\]]*?) +(?P<k>\S+) +(?P<p>left|right|center)\]\]")
 # regex_video = re.compile(r'\[\[(?P<t>[^\]]*?) +(?P<k>\S+) +video\]\]')

--- a/gluon/contrib/markmin/markmin2latex.py
+++ b/gluon/contrib/markmin/markmin2latex.py
@@ -208,11 +208,11 @@ def render(
                 authors.append(author)
                 html = ""
             elif b == "inxx":
-                html = "\inxx{%s}" % latex_escape(code)
+                html = r"\inxx{%s}" % latex_escape(code)
             elif b == "cite":
-                html = "~\cite{%s}" % latex_escape(code.strip())
+                html = r"~\cite{%s}" % latex_escape(code.strip())
             elif b == "ref":
-                html = "~\ref{%s}" % latex_escape(code.strip())
+                html = r"~\ref{%s}" % latex_escape(code.strip())
             elif b == "latex":
                 if "\n" in code:
                     html = "\n\\begin{equation}\n%s\n\\end{equation}\n" % code.strip()


### PR DESCRIPTION
This fixes `SyntaxWarning: invalid escape sequence '\...'` warnings.