### PR TITLE
Resolve logger warnings

### DIFF
--- a/gluon/languages.py
+++ b/gluon/languages.py
@@ -198,7 +198,7 @@ def read_possible_plural_rules():
                 plurals[lang] = (lang, nplurals, get_plural_id, construct_plural_form)
     except ImportError:
         e = sys.exc_info()[1]
-        logging.warn("Unable to import plural rules: %s" % e)
+        logging.warning("Unable to import plural rules: %s" % e)
     return plurals
 
 
@@ -792,7 +792,7 @@ class TranslatorFactory(object):
         ns=None,
     ):
         """
-        Gets cached translated markmin-message with inserted parametes
+        Gets cached translated markmin-message with inserted parameters
         if lazy==True lazyT object is returned
         """
         if lazy is None:
@@ -1073,7 +1073,7 @@ def findT(path, language=DEFAULT_LANGUAGE):
             try:
                 message = safe_eval(item)
             except:
-                continue  # silently ignore inproperly formatted strings
+                continue  # silently ignore improperly formatted strings
             add_message(message)
     gluon_msg = [Auth.default_messages, Crud.default_messages]
     for item in [x for m in gluon_msg for x in m.values() if x is not None]:

--- a/gluon/main.py
+++ b/gluon/main.py
@@ -645,7 +645,7 @@ def appfactory(
         raise BaseException("Deprecated API")
     if profiler_dir:
         profiler_dir = abspath(profiler_dir)
-        logger.warn("profiler is on. will use dir %s", profiler_dir)
+        logger.warning("profiler is on. will use dir %s", profiler_dir)
         if not os.path.isdir(profiler_dir):
             try:
                 os.makedirs(profiler_dir)

--- a/gluon/shell.py
+++ b/gluon/shell.py
@@ -251,13 +251,13 @@ def run(
         ):
             confirm = raw_input("application %s does not exist, create (y/N)?" % a)
         else:
-            logging.warn("application does not exist and will not be created")
+            logger.warning("application does not exist and will not be created")
             return
         if confirm.lower() in ("y", "yes"):
             os.mkdir(adir)
             fileutils.create_app(adir)
         else:
-            logging.warn(
+            logger.warning(
                 "application folder does not exist and has not been created as requested"
             )
             return

--- a/gluon/widget.py
+++ b/gluon/widget.py
@@ -680,12 +680,12 @@ def start():
             content = open(os.path.join("examples", "app.example.yaml"), "rb").read()
             open("app.yaml", "wb").write(content.replace("yourappname", name))
         else:
-            print("app.yaml alreday exists in the web2py folder")
+            print("app.yaml already exists in the web2py folder")
         if not os.path.exists("gaehandler.py"):
             content = open(os.path.join("handlers", "gaehandler.py"), "rb").read()
             open("gaehandler.py", "wb").write(content)
         else:
-            print("gaehandler.py alreday exists in the web2py folder")
+            print("gaehandler.py already exists in the web2py folder")
         return
 
     logger = logging.getLogger("web2py")
@@ -797,7 +797,7 @@ def start():
 
             root = tkinter.Tk()
         except (ImportError, OSError):
-            logger.warn("GUI not available because Tk library is not installed")
+            logger.warning("GUI not available because Tk library is not installed")
             options.no_gui = True
         except:
             logger.exception("cannot get Tk root window, GUI disabled")


### PR DESCRIPTION
## PR Summary
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```