### PR TITLE
Fix calls to mailer.send() to use strings

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -4136,7 +4136,7 @@ class Auth(AuthAPI):
         if self.settings.mailer and self.settings.mailer.send(
             to=user.email,
             subject=self.messages.reset_password_subject,
-            message=self.messages.reset_password % d,
+            message=str(self.messages.reset_password % d),
         ):
             user.update_record(reset_password_key=reset_password_key)
             return True

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -3630,7 +3630,7 @@ class Auth(AuthAPI):
             self.settings.mailer.send(
                 to=form.vars.email,
                 subject=self.messages.retrieve_username_subject,
-                message=self.messages.retrieve_username % dict(username=username),
+                message=str(self.messages.retrieve_username % dict(username=username)),
             )
             session.flash = self.messages.email_sent
             for user in users:
@@ -3727,7 +3727,7 @@ class Auth(AuthAPI):
             if self.settings.mailer and self.settings.mailer.send(
                 to=form.vars.email,
                 subject=self.messages.retrieve_password_subject,
-                message=self.messages.retrieve_password % dict(password=password),
+                message=str(self.messages.retrieve_password % dict(password=password)),
             ):
                 session.flash = self.messages.email_sent
             else:

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -3844,7 +3844,7 @@ class Auth(AuthAPI):
             dict(key=reset_password_key, link=link, site=current.request.env.http_host)
         )
         if self.settings.mailer and self.settings.mailer.send(
-            to=user.email, subject=subject % d, message=body % d
+            to=user.email, subject=subject % d, message=str(body % d)
         ):
             user.update_record(reset_password_key=reset_password_key)
             return True


### PR DESCRIPTION
The first commit fixes a plain internal error crash on our prod.

The other 2 commits are "blind fixes", untested but very likely required, if only for symmetry.