### PR TITLE
Fix: turning the id into an STR caused IS_NOT_IN_DB to fail because i…

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -1650,7 +1650,7 @@ class SQLFORM(FORM):
                         widget = SPAN(v, _id=field_id)
                         self.custom.dspval.id = str(v)
                         xfields.append((row_id, label, widget, comment))
-                    self.record_id = str(record[field.name])
+                    self.record_id = record[field.name]
                 self.custom.widget.id = widget
                 continue
 
@@ -1965,7 +1965,6 @@ class SQLFORM(FORM):
                 for item in requires
                 if hasattr(item, "set_self_id") and self.record_id
             ]
-
         # ## END
 
         fields = {}


### PR DESCRIPTION
…t would set_self_id with a str which it would then compare with a record.id which is an int