### PR TITLE
Fix path traversal in PDF image resolution for generic views

### DIFF
--- a/gluon/contrib/generics.py
+++ b/gluon/contrib/generics.py
@@ -8,13 +8,14 @@ from gluon.contrib.markmin.markmin2latex import markmin2latex
 from gluon.contrib.markmin.markmin2pdf import markmin2pdf
 from gluon.html import BODY, H1, HTML, TAG, UL, XML, markmin_serializer
 from gluon.sanitizer import sanitize
+from gluon.utils import safe_path_join
 
 
 def wrapper(f):
     def g(data):
         try:
             output = f(data)
-            return XML(ouput)
+            return XML(output)
         except (TypeError, ValueError) as e:
             raise HTTP(405, "%s serialization error" % e)
         except ImportError as e:
@@ -46,17 +47,26 @@ def pdflatex_from_html(html):
             return out
 
 
+def _resolve_pdf_image_path(path, request):
+    static_prefix = "/%s/static/" % request.application
+    if path.startswith(static_prefix):
+        relative_static_path = path[len(static_prefix):]
+        try:
+            return safe_path_join(request.folder, "static", relative_static_path)
+        except ValueError:
+            raise HTTP(403, "invalid static path")
+    return "http%s://%s%s" % (
+        request.is_https and "s" or "",
+        request.env.http_host,
+        path,
+    )
+
+
 def pyfpdf_from_html(html):
     request = current.request
 
     def image_map(path):
-        if path.startswith("/%s/static/" % request.application):
-            return os.path.join(request.folder, path.split("/", 2)[2])
-        return "http%s://%s%s" % (
-            request.is_https and "s" or "",
-            request.env.http_host,
-            path,
-        )
+        return _resolve_pdf_image_path(path, request)
 
     class MyFPDF(FPDF, HTMLMixin):
         pass

--- a/gluon/tests/test_contribs.py
+++ b/gluon/tests/test_contribs.py
@@ -6,6 +6,8 @@
 import os
 import unittest
 
+from gluon import HTTP
+from gluon.contrib.generics import _resolve_pdf_image_path
 from gluon.contrib import fpdf as fpdf
 from gluon.contrib import pyfpdf as pyfpdf
 from gluon.contrib.appconfig import AppConfig
@@ -63,3 +65,31 @@ class TestContribs(unittest.TestCase):
         self.assertEqual(myappconfig.take("config3.key2"), 2)
 
         current.request = {}
+
+    def test_pdf_image_map_allows_static_subpath(self):
+        request = Storage(
+            {
+                "application": "welcome",
+                "folder": os.path.join("applications", "welcome"),
+                "is_https": False,
+                "env": Storage({"http_host": "example.com"}),
+            }
+        )
+        result = _resolve_pdf_image_path("/welcome/static/img/logo.png", request)
+        expected_suffix = os.path.normpath(
+            os.path.join("applications", "welcome", "static", "img", "logo.png")
+        )
+        self.assertTrue(result.endswith(expected_suffix), result)
+
+    def test_pdf_image_map_rejects_static_traversal(self):
+        request = Storage(
+            {
+                "application": "welcome",
+                "folder": os.path.join("applications", "welcome"),
+                "is_https": False,
+                "env": Storage({"http_host": "example.com"}),
+            }
+        )
+        with self.assertRaises(HTTP) as ctx:
+            _resolve_pdf_image_path("/welcome/static/../../private/secret.txt", request)
+        self.assertEqual(ctx.exception.status, 403)


### PR DESCRIPTION
This patch fixes a path traversal vulnerability in PDF image resolution used by generic HTML-to-PDF rendering.

## Fix
- Introduced _resolve_pdf_image_path() to centralize path resolution
- Replaced unsafe os.path.join with safe_path_join
- Enforced restriction to the application’s /static/ directory
- Invalid or traversal paths now return HTTP 403
- Preserved behavior for non-static paths