### PR TITLE
Fix host-header based trust bypass in appadmin local access control

### DIFF
--- a/applications/admin/controllers/appadmin.py
+++ b/applications/admin/controllers/appadmin.py
@@ -17,19 +17,12 @@ is_gae = request.env.web2py_runtime_gae or False
 global_env = copy.copy(globals())
 global_env['datetime'] = datetime
 
-remote_addr = request.env.remote_addr
-
-
-def is_loopback_address(ip_address):
-    return ip_address in ('::1', '127.0.0.1', '::ffff:127.0.0.1')
-
 if request.is_https:
     session.secure()
 elif request.env.trusted_lan_prefix and \
-     remote_addr.startswith(request.env.trusted_lan_prefix):
+     request.env.remote_addr.startswith(request.env.trusted_lan_prefix):
     request.is_local = True
-elif (not is_loopback_address(remote_addr)) and \
-    (request.function != 'manage'):
+elif not request.is_local and request.function != 'manage':
     raise HTTP(200, T('appadmin is disabled because insecure channel'))
 
 if request.function == 'manage':

--- a/applications/admin/controllers/appadmin.py
+++ b/applications/admin/controllers/appadmin.py
@@ -5,7 +5,6 @@
 # ###########################################################
 
 import os
-import socket
 import datetime
 import copy
 import gluon.contenttype
@@ -18,21 +17,18 @@ is_gae = request.env.web2py_runtime_gae or False
 global_env = copy.copy(globals())
 global_env['datetime'] = datetime
 
-http_host = request.env.http_host.split(':')[0]
 remote_addr = request.env.remote_addr
-try:
-    hosts = (http_host, socket.gethostname(),
-             socket.gethostbyname(http_host),
-             '::1', '127.0.0.1', '::ffff:127.0.0.1')
-except:
-    hosts = (http_host, )
+
+
+def is_loopback_address(ip_address):
+    return ip_address in ('::1', '127.0.0.1', '::ffff:127.0.0.1')
 
 if request.is_https:
     session.secure()
 elif request.env.trusted_lan_prefix and \
      remote_addr.startswith(request.env.trusted_lan_prefix):
     request.is_local = True
-elif (remote_addr not in hosts) and (remote_addr != '127.0.0.1') and \
+elif (not is_loopback_address(remote_addr)) and \
     (request.function != 'manage'):
     raise HTTP(200, T('appadmin is disabled because insecure channel'))
 

--- a/applications/examples/controllers/appadmin.py
+++ b/applications/examples/controllers/appadmin.py
@@ -17,19 +17,12 @@ is_gae = request.env.web2py_runtime_gae or False
 global_env = copy.copy(globals())
 global_env['datetime'] = datetime
 
-remote_addr = request.env.remote_addr
-
-
-def is_loopback_address(ip_address):
-    return ip_address in ('::1', '127.0.0.1', '::ffff:127.0.0.1')
-
 if request.is_https:
     session.secure()
 elif request.env.trusted_lan_prefix and \
-     remote_addr.startswith(request.env.trusted_lan_prefix):
+     request.env.remote_addr.startswith(request.env.trusted_lan_prefix):
     request.is_local = True
-elif (not is_loopback_address(remote_addr)) and \
-    (request.function != 'manage'):
+elif not request.is_local and request.function != 'manage':
     raise HTTP(200, T('appadmin is disabled because insecure channel'))
 
 if request.function == 'manage':

--- a/applications/examples/controllers/appadmin.py
+++ b/applications/examples/controllers/appadmin.py
@@ -5,7 +5,6 @@
 # ###########################################################
 
 import os
-import socket
 import datetime
 import copy
 import gluon.contenttype
@@ -18,21 +17,18 @@ is_gae = request.env.web2py_runtime_gae or False
 global_env = copy.copy(globals())
 global_env['datetime'] = datetime
 
-http_host = request.env.http_host.split(':')[0]
 remote_addr = request.env.remote_addr
-try:
-    hosts = (http_host, socket.gethostname(),
-             socket.gethostbyname(http_host),
-             '::1', '127.0.0.1', '::ffff:127.0.0.1')
-except:
-    hosts = (http_host, )
+
+
+def is_loopback_address(ip_address):
+    return ip_address in ('::1', '127.0.0.1', '::ffff:127.0.0.1')
 
 if request.is_https:
     session.secure()
 elif request.env.trusted_lan_prefix and \
      remote_addr.startswith(request.env.trusted_lan_prefix):
     request.is_local = True
-elif (remote_addr not in hosts) and (remote_addr != '127.0.0.1') and \
+elif (not is_loopback_address(remote_addr)) and \
     (request.function != 'manage'):
     raise HTTP(200, T('appadmin is disabled because insecure channel'))
 

--- a/applications/welcome/controllers/appadmin.py
+++ b/applications/welcome/controllers/appadmin.py
@@ -17,19 +17,12 @@ is_gae = request.env.web2py_runtime_gae or False
 global_env = copy.copy(globals())
 global_env['datetime'] = datetime
 
-remote_addr = request.env.remote_addr
-
-
-def is_loopback_address(ip_address):
-    return ip_address in ('::1', '127.0.0.1', '::ffff:127.0.0.1')
-
 if request.is_https:
     session.secure()
 elif request.env.trusted_lan_prefix and \
-     remote_addr.startswith(request.env.trusted_lan_prefix):
+     request.env.remote_addr.startswith(request.env.trusted_lan_prefix):
     request.is_local = True
-elif (not is_loopback_address(remote_addr)) and \
-    (request.function != 'manage'):
+elif not request.is_local and request.function != 'manage':
     raise HTTP(200, T('appadmin is disabled because insecure channel'))
 
 if request.function == 'manage':

--- a/applications/welcome/controllers/appadmin.py
+++ b/applications/welcome/controllers/appadmin.py
@@ -5,7 +5,6 @@
 # ###########################################################
 
 import os
-import socket
 import datetime
 import copy
 import gluon.contenttype
@@ -18,21 +17,18 @@ is_gae = request.env.web2py_runtime_gae or False
 global_env = copy.copy(globals())
 global_env['datetime'] = datetime
 
-http_host = request.env.http_host.split(':')[0]
 remote_addr = request.env.remote_addr
-try:
-    hosts = (http_host, socket.gethostname(),
-             socket.gethostbyname(http_host),
-             '::1', '127.0.0.1', '::ffff:127.0.0.1')
-except:
-    hosts = (http_host, )
+
+
+def is_loopback_address(ip_address):
+    return ip_address in ('::1', '127.0.0.1', '::ffff:127.0.0.1')
 
 if request.is_https:
     session.secure()
 elif request.env.trusted_lan_prefix and \
      remote_addr.startswith(request.env.trusted_lan_prefix):
     request.is_local = True
-elif (remote_addr not in hosts) and (remote_addr != '127.0.0.1') and \
+elif (not is_loopback_address(remote_addr)) and \
     (request.function != 'manage'):
     raise HTTP(200, T('appadmin is disabled because insecure channel'))
 

--- a/gluon/tests/test_appadmin.py
+++ b/gluon/tests/test_appadmin.py
@@ -47,6 +47,8 @@ class TestAppAdmin(unittest.TestCase):
         request.folder = "applications/welcome"
         request.env.http_host = "127.0.0.1:8000"
         request.env.remote_addr = "127.0.0.1"
+        request.client = request.env.remote_addr
+        request.is_local = True
         response = Response()
         session = Session()
         T = TranslatorFactory("", "en")
@@ -107,6 +109,8 @@ class TestAppAdmin(unittest.TestCase):
         request = self.env["request"]
         request.env.http_host = "127.0.0.1:8000"
         request.env.remote_addr = "203.0.113.10"
+        request.client = request.env.remote_addr
+        request.is_local = False
         request.is_https = False
         request.env.trusted_lan_prefix = None
         with self.assertRaises(HTTP) as ctx:

--- a/gluon/tests/test_appadmin.py
+++ b/gluon/tests/test_appadmin.py
@@ -103,6 +103,18 @@ class TestAppAdmin(unittest.TestCase):
     def test_index(self):
         self._test_index()
 
+    def test_index_rejects_host_header_spoofing(self):
+        request = self.env["request"]
+        request.env.http_host = "127.0.0.1:8000"
+        request.env.remote_addr = "203.0.113.10"
+        request.is_https = False
+        request.env.trusted_lan_prefix = None
+        with self.assertRaises(HTTP) as ctx:
+            self.run_function()
+        error = ctx.exception
+        self.assertEqual(error.status, 200)
+        self.assertIn("appadmin is disabled because insecure channel", str(error.body))
+
     def test_index_compiled(self):
         appname_path = os.path.join(os.getcwd(), "applications", "welcome")
         compile_application(appname_path)


### PR DESCRIPTION
appadmin currently determines whether a request is "local" by relying in part on the HTTP Host header and DNS resolution.

This is unsafe because the Host header is user-controlled and can be manipulated to bypass local-only access restrictions.

An attacker can send a request with a forged Host header that resolves to a loopback address causing the server to incorrectly treat the request as local and grant access to appadmin endpoints.

This patch removes Host-header and DNS-based trust from the access control logic and instead enforces locality strictly based on the actual client source address.

### Changes
- Removed Host header and DNS-based locality checks
- Introduced strict validation based on client source IP (loopback or configured trusted LAN prefix)
- Eliminated dependency on socket-based resolution for access control decisions
- Applied consistently across all appadmin controller variants (welcome, admin, examples)
