### PR TITLE
Fix fail-open behavior by rejecting oversized Authorization tokens

### DIFF
--- a/gluon/tests/test_tools.py
+++ b/gluon/tests/test_tools.py
@@ -263,8 +263,15 @@ class TestAuthJWT(unittest.TestCase):
         self.request.controller = "c"
         self.request.function = "f"
         self.request.folder = "applications/admin"
+        self.response = Response()
+        self.session = Session()
+        self.T = TranslatorFactory("", "en")
+        self.session.connect(self.request, self.response)
         self.current = current
         self.current.request = self.request
+        self.current.response = self.response
+        self.current.session = self.session
+        self.current.T = self.T
 
         self.db = DAL(DEFAULT_URI, check_reserved=["all"])
         self.auth = Auth(self.db)
@@ -310,6 +317,32 @@ class TestAuthJWT(unittest.TestCase):
             self.assertEqual(self.user_data["username"], self.auth.user.username)
 
         optional_auth()
+
+    def test_allows_jwt_rejects_oversized_token_required(self):
+        self.request.env.http_authorization = "Bearer " + (
+            "x" * self.jwtauth.max_header_length
+        )
+
+        @self.jwtauth.allows_jwt(required=True)
+        def protected_action():
+            return "ok"
+
+        with self.assertRaises(HTTP) as err:
+            protected_action()
+        self.assertEqual(err.exception.status, 400)
+
+    def test_allows_jwt_rejects_oversized_token_optional(self):
+        self.request.env.http_authorization = "Bearer " + (
+            "x" * self.jwtauth.max_header_length
+        )
+
+        @self.jwtauth.allows_jwt(required=False)
+        def optional_action():
+            return "ok"
+
+        with self.assertRaises(HTTP) as err:
+            optional_action()
+        self.assertEqual(err.exception.status, 400)
 
 
 @unittest.skipIf(IS_IMAP, "TODO: Imap raises 'Connection refused'")

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -1554,7 +1554,9 @@ class AuthJWT(object):
                     if required:
                         raise e
                     token = None
-                if token and len(token) < self.max_header_length:
+                if token and len(token) >= self.max_header_length:
+                    raise HTTP(400, "Invalid JWT header, token too long")
+                if token:
                     old_verify_expiration = self.verify_expiration
                     try:
                         self.verify_expiration = verify_expiration


### PR DESCRIPTION
This patch fixes a fail-open condition in AuthJWT where oversized Authorization header tokens were silently ignored instead of being rejected.

### Fix
- Enforce fail-closed behavior by rejecting tokens whose length is greater than
  or equal to `max_header_length`
- Return HTTP 400 for oversized tokens before any authentication logic proceeds

### Tests
- Added regression tests to ensure oversized tokens are rejected:
  - Required JWT endpoints (`required=True`)
  - Optional JWT endpoints (`required=False`)
- Stabilized test setup by initializing request/response/session context
