### PR TITLE
Harden ticket deserialization by replacing unsafe pickle usage

### DIFF
--- a/applications/admin/controllers/default.py
+++ b/applications/admin/controllers/default.py
@@ -16,6 +16,7 @@ import importlib
 
 from gluon.admin import *
 from gluon.fileutils import abspath, read_file, write_file
+from gluon.restricted import safe_load, safe_loads
 from gluon.utils import web2py_uuid
 from gluon.tools import Config, prevent_open_redirect
 from gluon.compileapp import find_exposed_functions
@@ -1638,12 +1639,10 @@ def errors():
             try:
                 fullpath_file = safe_open(fullpath, 'rb')
                 try:
-                    error = pickle.load(fullpath_file)
+                    error = safe_load(fullpath_file)
                 finally:
                     fullpath_file.close()
-            except IOError:
-                continue
-            except EOFError:
+            except (IOError, pickle.UnpicklingError, EOFError):
                 continue
 
             hash = hashlib.md5(error['traceback'].encode("utf8")).hexdigest()
@@ -1680,7 +1679,7 @@ def errors():
 
         for fn in tk_db(tk_table.id > 0).select():
             try:
-                error = pickle.loads(fn.ticket_data)
+                error = safe_loads(fn.ticket_data)
                 hash = hashlib.md5(error['traceback']).hexdigest()
 
                 if hash in delete_hashes:
@@ -1697,7 +1696,7 @@ def errors():
                                                 pickel=error, causer=error_causer,
                                                 last_line=last_line, hash=hash,
                                                 ticket=fn.ticket_id)
-            except AttributeError as e:
+            except (AttributeError, pickle.UnpicklingError, EOFError):
                 tk_db(tk_table.id == fn.id).delete()
                 tk_db.commit()
 

--- a/gluon/restricted.py
+++ b/gluon/restricted.py
@@ -9,6 +9,8 @@ Restricted environment to execute application's code
 -----------------------------------------------------
 """
 
+import builtins
+import io
 import logging
 import os
 import pickle
@@ -23,7 +25,52 @@ from gluon.storage import Storage
 
 logger = logging.getLogger("web2py")
 
-__all__ = ["RestrictedError", "restricted", "TicketStorage", "compile2"]
+__all__ = [
+    "RestrictedError",
+    "restricted",
+    "TicketStorage",
+    "compile2",
+    "SafeUnpickler",
+    "safe_load",
+    "safe_loads",
+]
+
+
+class SafeUnpickler(pickle.Unpickler):
+    """
+    Restricted unpickler that only allows a small set of safe builtins.
+    """
+
+    safe_builtins = {
+        "dict",
+        "list",
+        "tuple",
+        "set",
+        "frozenset",
+        "str",
+        "bytes",
+        "bytearray",
+        "int",
+        "float",
+        "complex",
+        "bool",
+        "NoneType",
+    }
+
+    def find_class(self, module, name):
+        if module == "builtins" and name in self.safe_builtins:
+            return getattr(builtins, name)
+        raise pickle.UnpicklingError("global '%s.%s' is forbidden" % (module, name))
+
+
+def safe_load(file_obj):
+    return SafeUnpickler(file_obj).load()
+
+
+def safe_loads(data):
+    if isinstance(data, str):
+        data = data.encode("latin-1")
+    return SafeUnpickler(io.BytesIO(data)).load()
 
 
 class TicketStorage(Storage):
@@ -102,13 +149,20 @@ class TicketStorage(Storage):
             except IOError:
                 return {}
             try:
-                return pickle.load(ef)
+                return safe_load(ef)
+            except (pickle.UnpicklingError, EOFError):
+                return {}
             finally:
                 ef.close()
         else:
             table = self._get_table(self.db, self.tablename, app)
             rows = self.db(table.ticket_id == ticket_id).select()
-            return pickle.loads(rows[0].ticket_data) if rows else {}
+            if not rows:
+                return {}
+            try:
+                return safe_loads(rows[0].ticket_data)
+            except (pickle.UnpicklingError, EOFError):
+                return {}
 
 
 class RestrictedError(Exception):

--- a/gluon/tests/test_restricted.py
+++ b/gluon/tests/test_restricted.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import io
+import pickle
+import subprocess
+import unittest
+
+from gluon.restricted import safe_load, safe_loads
+
+
+class TestRestrictedPickle(unittest.TestCase):
+    def test_safe_unpickler_loads_basic_types(self):
+        payload = {"traceback": "test error", "layer": "test"}
+        pickled = pickle.dumps(payload, pickle.HIGHEST_PROTOCOL)
+
+        self.assertEqual(safe_loads(pickled), payload)
+        self.assertEqual(safe_load(io.BytesIO(pickled)), payload)
+
+    def test_safe_unpickler_rejects_unsafe_classes(self):
+        pickled = pickle.dumps({"bad": subprocess.Popen}, pickle.HIGHEST_PROTOCOL)
+        with self.assertRaises(pickle.UnpicklingError):
+            safe_loads(pickled)

--- a/gluon/tests/test_restricted.py
+++ b/gluon/tests/test_restricted.py
@@ -2,11 +2,13 @@
 # -*- coding: utf-8 -*-
 
 import io
+import os
 import pickle
 import subprocess
+import tempfile
 import unittest
 
-from gluon.restricted import safe_load, safe_loads
+from gluon.restricted import TicketStorage, safe_load, safe_loads
 
 
 class TestRestrictedPickle(unittest.TestCase):
@@ -21,3 +23,102 @@ class TestRestrictedPickle(unittest.TestCase):
         pickled = pickle.dumps({"bad": subprocess.Popen}, pickle.HIGHEST_PROTOCOL)
         with self.assertRaises(pickle.UnpicklingError):
             safe_loads(pickled)
+
+    def test_safe_unpickler_loads_full_ticket_structure(self):
+        """Verify SafeUnpickler handles realistic ticket dicts with nested types."""
+        payload = {
+            "layer": "model",
+            "code": "x = 1/0",
+            "output": "",
+            "traceback": "Traceback (most recent call last):\n  ...\nZeroDivisionError",
+            "snapshot": {
+                "pyver": "Python 3.10",
+                "date": "Thu Apr 24 00:00:00 2026",
+                "frames": [
+                    {
+                        "file": "/app/models/db.py",
+                        "func": "<module>",
+                        "call": "",
+                        "lines": {1: "x = 1/0"},
+                        "lnum": 1,
+                        "dump": {"x": "undefined"},
+                    }
+                ],
+                "etype": "ZeroDivisionError",
+                "evalue": "division by zero",
+                "exception": {"args": "('division by zero',)"},
+                "locals": {"x": "undefined"},
+            },
+        }
+        pickled = pickle.dumps(payload, pickle.HIGHEST_PROTOCOL)
+        self.assertEqual(safe_loads(pickled), payload)
+        self.assertEqual(safe_load(io.BytesIO(pickled)), payload)
+
+    def test_safe_unpickler_rejects_malicious_file_payload(self):
+        """safe_load must reject a pickle stream containing an unsafe global."""
+        malicious = pickle.dumps({"bad": subprocess.Popen}, pickle.HIGHEST_PROTOCOL)
+        with self.assertRaises(pickle.UnpicklingError):
+            safe_load(io.BytesIO(malicious))
+
+    def test_safe_unpickler_handles_eof(self):
+        """safe_load must raise EOFError on empty/truncated data."""
+        with self.assertRaises(EOFError):
+            safe_load(io.BytesIO(b""))
+        with self.assertRaises(Exception):
+            safe_loads(b"")
+
+
+class TestTicketStorageFilePath(unittest.TestCase):
+    def setUp(self):
+        from gluon.globals import Request
+        import shutil
+
+        # _error_file computes: request.folder/../app/errors/
+        # So with folder=tmpdir/welcome and app="welcome":
+        # root = tmpdir/welcome/../welcome = tmpdir/welcome
+        # errors_folder = tmpdir/welcome/errors
+        self.tmpdir = tempfile.mkdtemp()
+        self.app_dir = os.path.join(self.tmpdir, "welcome")
+        self.errors_dir = os.path.join(self.app_dir, "errors")
+        os.makedirs(self.errors_dir)
+
+        self.request = Request(env={})
+        self.request.folder = self.app_dir
+        self.storage = TicketStorage()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write_ticket(self, ticket_id, data):
+        path = os.path.join(self.errors_dir, ticket_id)
+        with open(path, "wb") as f:
+            pickle.dump(data, f, pickle.HIGHEST_PROTOCOL)
+
+    def _write_raw_ticket(self, ticket_id, raw_bytes):
+        path = os.path.join(self.errors_dir, ticket_id)
+        with open(path, "wb") as f:
+            f.write(raw_bytes)
+
+    def test_load_valid_ticket_from_file(self):
+        payload = {"traceback": "some error", "layer": "model", "snapshot": {}}
+        self._write_ticket("abc123", payload)
+        result = self.storage.load(self.request, "welcome", "abc123")
+        self.assertEqual(result, payload)
+
+    def test_load_missing_ticket_returns_empty(self):
+        result = self.storage.load(self.request, "welcome", "nonexistent")
+        self.assertEqual(result, {})
+
+    def test_load_malicious_ticket_returns_empty(self):
+        """A pickle with an unsafe global must be rejected silently."""
+        malicious = pickle.dumps({"bad": subprocess.Popen}, pickle.HIGHEST_PROTOCOL)
+        self._write_raw_ticket("evil123", malicious)
+        result = self.storage.load(self.request, "welcome", "evil123")
+        self.assertEqual(result, {})
+
+    def test_load_truncated_ticket_returns_empty(self):
+        """A truncated/corrupt pickle file must be handled gracefully."""
+        self._write_raw_ticket("truncated", b"\x80\x05\x95")
+        result = self.storage.load(self.request, "welcome", "truncated")
+        self.assertEqual(result, {})


### PR DESCRIPTION
This patch hardens ticket and error deserialization by replacing direct usage of`pickle.load()` and `pickle.loads()` with a restricted unpickler.

Changes:
- Introduced SafeUnpickler with an allowlist of safe built-in types
- Added helper functions: `safe_load()` and `safe_loads()`
- Updated TicketStorage to use safe deserialization for both file and DB paths
- Updated admin error viewer to avoid unsafe pickle usage
- Added handling for malformed or unsafe serialized data (UnpicklingError, EOFError)