### PR TITLE
encode non-ASCII characters in Subject header Fixes #2561

### DIFF
--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -830,7 +830,7 @@ class Mail(object):
             to.extend(cc)
         if bcc:
             to.extend(bcc)
-        payload["Subject"] = subject
+        payload["Subject"] = encode_header(subject)
         payload["Date"] = email.utils.formatdate()
         for k, v in headers.items():
             payload[k] = v


### PR DESCRIPTION
Mail.send() fails with a UnicodeEncodeError when the subject parameter contains non-ASCII characters (e.g. German umlauts like ü, ö, ä).

Fixes #2561 