### PR TITLE
Fix non-ASCII encoding for all Mail headers (closes #2561)

### DIFF
--- a/gluon/tests/test_tools.py
+++ b/gluon/tests/test_tools.py
@@ -251,6 +251,60 @@ class TestMail(unittest.TestCase):
         self.assertTrue("Content-Type: tra/lala" in message.payload)
         self.assertTrue("Content-Id: <trololo>" in message.payload)
 
+    def test_nonascii_subject(self):
+        mail = Mail()
+        mail.settings.server = "smtp.example.com:25"
+        mail.settings.sender = "you@example.com"
+        self.assertTrue(
+            mail.send(
+                to=["somebody@example.com"],
+                subject="Ünïcödé subject: äöü",
+                message="world",
+            )
+        )
+        message = TestMail.DummySMTP.inbox.pop()
+        # Must be RFC 2047 encoded, not a raw unicode string
+        self.assertIn("=?utf-8?", message.payload)
+        # Decoded subject must round-trip correctly
+        import email.header
+        parsed = message.parsed_payload
+        decoded = email.header.decode_header(parsed["Subject"])
+        subject = "".join(
+            part.decode(enc or "utf-8") if isinstance(part, bytes) else part
+            for part, enc in decoded
+        )
+        self.assertEqual(subject, "Ünïcödé subject: äöü")
+
+    def test_nonascii_from(self):
+        mail = Mail()
+        mail.settings.server = "smtp.example.com:25"
+        mail.settings.sender = "you@example.com"
+        self.assertTrue(
+            mail.send(
+                to=["somebody@example.com"],
+                subject="hello",
+                message="world",
+                from_address="Ünïcödé Sender <you@example.com>",
+            )
+        )
+        message = TestMail.DummySMTP.inbox.pop()
+        self.assertIn("=?utf-8?", message.payload)
+
+    def test_nonascii_custom_header(self):
+        mail = Mail()
+        mail.settings.server = "smtp.example.com:25"
+        mail.settings.sender = "you@example.com"
+        self.assertTrue(
+            mail.send(
+                to=["somebody@example.com"],
+                subject="hello",
+                message="world",
+                headers={"X-Custom": "Héllo"},
+            )
+        )
+        message = TestMail.DummySMTP.inbox.pop()
+        self.assertIn("=?utf-8?", message.payload)
+
 
 # TODO: class TestAuthJWT(unittest.TestCase):
 class TestAuthJWT(unittest.TestCase):

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -483,9 +483,8 @@ class Mail(object):
             else:
                 return key
 
-        # encoded or raw text
         def encoded_or_raw(text):
-            if raw:
+            if not raw:
                 text = encode_header(text)
             return text
 
@@ -817,23 +816,23 @@ class Mail(object):
             payload = payload_in
 
         if from_address:
-            payload["From"] = from_address
+            payload["From"] = encoded_or_raw(from_address)
         else:
-            payload["From"] = sender
+            payload["From"] = encoded_or_raw(sender)
         origTo = to[:]
         if to:
-            payload["To"] = ", ".join(to)
+            payload["To"] = encoded_or_raw(", ".join(to))
         if reply_to:
-            payload["Reply-To"] = ", ".join(reply_to)
+            payload["Reply-To"] = encoded_or_raw(", ".join(reply_to))
         if cc:
-            payload["Cc"] = ", ".join(cc)
+            payload["Cc"] = encoded_or_raw(", ".join(cc))
             to.extend(cc)
         if bcc:
             to.extend(bcc)
-        payload["Subject"] = subject
+        payload["Subject"] = encoded_or_raw(subject)
         payload["Date"] = email.utils.formatdate()
         for k, v in headers.items():
-            payload[k] = v
+            payload[k] = encoded_or_raw(v) if isinstance(v, str) else v
 
         dkim = dkim or self.settings.dkim
         list_unsubscribe = list_unsubscribe or self.settings.list_unsubscribe


### PR DESCRIPTION
The py3 migration (619c5887) stripped encoded_or_raw() calls from all header assignments, introducing UnicodeEncodeError for non-ASCII content in Subject, From, To, Reply-To, Cc and custom headers.

Additionally, encoded_or_raw() had an inverted condition since it was first introduced (44c7f576): it only encoded when raw=True, the opposite of the intended behavior.

- Fix encoded_or_raw(): 'if raw' -> 'if not raw'
- Apply encoded_or_raw() to all header string assignments
- Add tests for non-ASCII subject, from_address and custom headers

Supersedes #2563