### PR TITLE
Fix: appadmin when is_shell such as in force_migrate was throwing errors

### DIFF
--- a/applications/admin/controllers/appadmin.py
+++ b/applications/admin/controllers/appadmin.py
@@ -22,7 +22,7 @@ if request.is_https:
 elif request.env.trusted_lan_prefix and \
      request.env.remote_addr.startswith(request.env.trusted_lan_prefix):
     request.is_local = True
-elif not request.is_local and request.function != 'manage':
+elif not request.is_local and not request.is_shell and request.function != 'manage':
     raise HTTP(200, T('appadmin is disabled because insecure channel'))
 
 if request.function == 'manage':

--- a/applications/examples/controllers/appadmin.py
+++ b/applications/examples/controllers/appadmin.py
@@ -22,7 +22,7 @@ if request.is_https:
 elif request.env.trusted_lan_prefix and \
      request.env.remote_addr.startswith(request.env.trusted_lan_prefix):
     request.is_local = True
-elif not request.is_local and request.function != 'manage':
+elif not request.is_local and not request.is_shell and request.function != 'manage':
     raise HTTP(200, T('appadmin is disabled because insecure channel'))
 
 if request.function == 'manage':

--- a/applications/welcome/controllers/appadmin.py
+++ b/applications/welcome/controllers/appadmin.py
@@ -22,7 +22,7 @@ if request.is_https:
 elif request.env.trusted_lan_prefix and \
      request.env.remote_addr.startswith(request.env.trusted_lan_prefix):
     request.is_local = True
-elif not request.is_local and request.function != 'manage':
+elif not request.is_local and not request.is_shell and request.function != 'manage':
     raise HTTP(200, T('appadmin is disabled because insecure channel'))
 
 if request.function == 'manage':

--- a/gluon/tests/test_appadmin.py
+++ b/gluon/tests/test_appadmin.py
@@ -119,6 +119,18 @@ class TestAppAdmin(unittest.TestCase):
         self.assertEqual(error.status, 200)
         self.assertIn("appadmin is disabled because insecure channel", str(error.body))
 
+    def test_index_allows_shell(self):
+        request = self.env["request"]
+        request.env.remote_addr = "203.0.113.10"
+        request.client = request.env.remote_addr
+        request.is_local = False
+        request.is_https = False
+        request.is_shell = True
+        request.env.trusted_lan_prefix = None
+        # should not raise HTTP — shell execution must bypass the channel check
+        result = self.run_function()
+        self.assertIn("db", result["databases"])
+
     def test_index_compiled(self):
         appname_path = os.path.join(os.getcwd(), "applications", "welcome")
         compile_application(appname_path)


### PR DESCRIPTION
Caused by #2557