### PR TITLE
Apply safe deserialization to globals and utils (follow-up to #2562)

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -71,6 +71,7 @@ import gluon.settings as settings
 from gluon import recfile
 from gluon.cache import CacheInRam
 from gluon.contenttype import contenttype
+from gluon.restricted import safe_load, safe_loads
 from gluon.contrib.multipart import MultipartParser, ParserError, parse_options_header
 from gluon.fileutils import up
 from gluon.html import PRE, TABLE, TR, URL, xmlescape
@@ -1117,7 +1118,7 @@ class Session(Storage):
                         )
                         portalocker.lock(response.session_file, portalocker.LOCK_EX)
                         response.session_locked = True
-                        self.update(pickle.load(response.session_file))
+                        self.update(safe_load(response.session_file))
                         response.session_file.seek(0)
                         oc = response.session_filename.split("/")[-1].split("-")[0]
                         if check_client and response.session_client != oc:
@@ -1182,10 +1183,10 @@ class Session(Storage):
                         # rows[0].update_record(locked=True)
                         # Unpickle the data
                         try:
-                            session_data = pickle.loads(row["session_data"])
+                            session_data = safe_loads(row["session_data"])
                             self.update(session_data)
                             response.session_new = False
-                        except:
+                        except (pickle.UnpicklingError, EOFError, ValueError):
                             record_id = None
                     else:
                         record_id = None

--- a/gluon/tests/test_restricted.py
+++ b/gluon/tests/test_restricted.py
@@ -67,6 +67,57 @@ class TestRestrictedPickle(unittest.TestCase):
         with self.assertRaises(Exception):
             safe_loads(b"")
 
+    def test_session_file_blocks_rce_payload(self):
+        """Session file loading must not execute malicious pickle."""
+        from gluon.globals import Request, Session, Response
+
+        class Exploit:
+            def __reduce__(self):
+                import os
+                return (os.system, ("echo hacked_session > /tmp/web2py_session",))
+
+        tmpdir = tempfile.mkdtemp()
+        app_dir = os.path.join(tmpdir, "welcome")
+        sessions_dir = os.path.join(app_dir, "sessions")
+        os.makedirs(sessions_dir)
+
+        request = Request(env={})
+        request.folder = app_dir
+        request.application = "welcome"
+
+        session_file = os.path.join(sessions_dir, "testsession")
+
+        with open(session_file, "wb") as f:
+            pickle.dump(Exploit(), f, pickle.HIGHEST_PROTOCOL)
+
+        if os.path.exists("/tmp/web2py_session"):
+            os.remove("/tmp/web2py_session")
+
+        s = Session()
+        response = Response()
+        s.connect(request, response)
+
+        self.assertFalse(os.path.exists("/tmp/web2py_session"))
+
+    def test_secure_loads_blocks_rce_payload(self):
+        """secure_loads must not execute malicious pickle after decryption."""
+        from gluon.utils import secure_loads
+
+        class Exploit:
+            def __reduce__(self):
+                import os
+                return (os.system, ("echo hacked_utils > /tmp/web2py_utils",))
+
+        payload = pickle.dumps(Exploit(), pickle.HIGHEST_PROTOCOL)
+
+        if os.path.exists("/tmp/web2py_utils"):
+         os.remove("/tmp/web2py_utils")
+
+        result = secure_loads(payload, encryption_key=None)
+
+        self.assertIsNone(result)
+        self.assertFalse(os.path.exists("/tmp/web2py_utils"))
+
 
 class TestTicketStorageFilePath(unittest.TestCase):
     def setUp(self):

--- a/gluon/utils.py
+++ b/gluon/utils.py
@@ -171,7 +171,9 @@ def secure_loads(data, encryption_key, hash_key=None, compression_level=None):
         data = unpad(AES_dec(cipher, encrypted_data))
         if compression_level:
             data = zlib.decompress(data)
-        return pickle.loads(data)
+        # Use safe_loads to prevent arbitrary code execution during unpickling
+        from gluon.restricted import safe_loads as safe_loads_restricted
+        return safe_loads_restricted(data)
     except Exception:
         return None
 


### PR DESCRIPTION
Follow-up to #2562.

This PR extends the previously introduced safe deserialization approach to remaining unsafe pickle usages in gluon.globals `session handling` and gluon.utils `secure_loads` ensuring consistent protection against arbitrary code execution across all deserialization paths.