### PR TITLE
Fix compatibility issues in safe_unpickle session handling

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -71,6 +71,7 @@ import gluon.settings as settings
 from gluon import recfile
 from gluon.cache import CacheInRam
 from gluon.contenttype import contenttype
+from gluon.restricted import safe_load, safe_loads
 from gluon.contrib.multipart import MultipartParser, ParserError, parse_options_header
 from gluon.fileutils import up
 from gluon.html import PRE, TABLE, TR, URL, xmlescape
@@ -1021,6 +1022,8 @@ class Session(Storage):
         cookie_key=None,
         cookie_expires=None,
         compression_level=None,
+        safe_unpickle=False,
+        pickle_allowed_classes=None,
     ):
         """
         Used in models, allows to customize Session handling
@@ -1043,6 +1046,11 @@ class Session(Storage):
             cookie_expires: sets the expiration of the cookie
             compression_level(int): 0-9, sets zlib compression on the data
                 before the encryption
+            safe_unpickle(bool): if True, session data is loaded through a
+                restricted safe unpickler. When False, legacy pickle loading
+                is used for compatibility.
+            pickle_allowed_classes(dict): allowed classes for restricted
+                unpickling when safe_unpickle=True.
         """
         request = request or current.request
         response = response or current.response
@@ -1089,9 +1097,20 @@ class Session(Storage):
             else:
                 session_cookie_data = None
             if session_cookie_data:
-                data = secure_loads(
-                    session_cookie_data, cookie_key, compression_level=compression_level
-                )
+                if safe_unpickle:
+                    data = secure_loads(
+                        session_cookie_data,
+                        cookie_key,
+                        compression_level=compression_level,
+                        allowed_classes=pickle_allowed_classes,
+                    )
+                else:
+                    data = secure_loads(
+                        session_cookie_data,
+                        cookie_key,
+                        compression_level=compression_level,
+                        safe_unpickle=False,
+                    )
                 if data:
                     self.update(data)
             response.session_id = True
@@ -1117,7 +1136,15 @@ class Session(Storage):
                         )
                         portalocker.lock(response.session_file, portalocker.LOCK_EX)
                         response.session_locked = True
-                        self.update(pickle.load(response.session_file))
+                        session_data = (
+                            safe_load(
+                                response.session_file,
+                                allowed_classes=pickle_allowed_classes,
+                            )
+                            if safe_unpickle
+                            else pickle.load(response.session_file)
+                        )
+                        self.update(session_data)
                         response.session_file.seek(0)
                         oc = response.session_filename.split("/")[-1].split("-")[0]
                         if check_client and response.session_client != oc:
@@ -1182,10 +1209,22 @@ class Session(Storage):
                         # rows[0].update_record(locked=True)
                         # Unpickle the data
                         try:
-                            session_data = pickle.loads(row["session_data"])
+                            if safe_unpickle:
+                                session_data = safe_loads(
+                                    row["session_data"],
+                                    allowed_classes=pickle_allowed_classes,
+                                )
+                            else:
+                                session_data = pickle.loads(row["session_data"])
                             self.update(session_data)
                             response.session_new = False
-                        except:
+                        except (
+                            pickle.UnpicklingError,
+                            EOFError,
+                            ValueError,
+                            AttributeError,
+                            ImportError,
+                        ):
                             record_id = None
                     else:
                         record_id = None

--- a/gluon/restricted.py
+++ b/gluon/restricted.py
@@ -10,6 +10,7 @@ Restricted environment to execute application's code
 """
 
 import builtins
+import importlib
 import io
 import logging
 import os
@@ -35,10 +36,18 @@ __all__ = [
     "safe_loads",
 ]
 
+DEFAULT_SAFE_GLOBALS = {
+    "decimal": {"Decimal"},
+    "datetime": {"date", "datetime", "time", "timedelta"},
+    "uuid": {"UUID"},
+    "pydal.objects": {"Row", "Rows"},
+}
+
 
 class SafeUnpickler(pickle.Unpickler):
     """
-    Restricted unpickler that only allows a small set of safe builtins.
+    Restricted unpickler that only allows a small set of safe builtins
+    and a small set of safe globals.
     """
 
     safe_builtins = {
@@ -57,20 +66,52 @@ class SafeUnpickler(pickle.Unpickler):
         "NoneType",
     }
 
+    def __init__(self, file_obj, allowed_classes=None):
+        super(SafeUnpickler, self).__init__(file_obj)
+        self.allowed_classes = self._normalize_allowed_classes(allowed_classes)
+
+    @staticmethod
+    def _normalize_allowed_classes(allowed_classes):
+        if not allowed_classes:
+            return {}
+        normalized = {}
+        for module, names in allowed_classes.items():
+            if isinstance(names, str):
+                normalized[module] = {names}
+            else:
+                normalized[module] = set(names)
+        return normalized
+
     def find_class(self, module, name):
         if module == "builtins" and name in self.safe_builtins:
             return getattr(builtins, name)
+        if module in DEFAULT_SAFE_GLOBALS and name in DEFAULT_SAFE_GLOBALS[module]:
+            try:
+                mod = importlib.import_module(module)
+            except ImportError:
+                raise pickle.UnpicklingError(
+                    "global '%s.%s' is forbidden" % (module, name)
+                )
+            return getattr(mod, name)
+        if module in self.allowed_classes and name in self.allowed_classes[module]:
+            try:
+                mod = importlib.import_module(module)
+            except ImportError:
+                raise pickle.UnpicklingError(
+                    "global '%s.%s' is forbidden" % (module, name)
+                )
+            return getattr(mod, name)
         raise pickle.UnpicklingError("global '%s.%s' is forbidden" % (module, name))
 
 
-def safe_load(file_obj):
-    return SafeUnpickler(file_obj).load()
+def safe_load(file_obj, allowed_classes=None):
+    return SafeUnpickler(file_obj, allowed_classes=allowed_classes).load()
 
 
-def safe_loads(data):
+def safe_loads(data, allowed_classes=None):
     if isinstance(data, str):
         data = data.encode("latin-1")
-    return SafeUnpickler(io.BytesIO(data)).load()
+    return SafeUnpickler(io.BytesIO(data), allowed_classes=allowed_classes).load()
 
 
 class TicketStorage(Storage):

--- a/gluon/tests/test_restricted.py
+++ b/gluon/tests/test_restricted.py
@@ -117,33 +117,44 @@ class CustomClass(object):
         """Session file loading must not execute malicious pickle."""
         from gluon.globals import Request, Session, Response
 
+        sentinel_fd, sentinel_path = tempfile.mkstemp(prefix="web2py_session_rce_")
+        os.close(sentinel_fd)
+        os.remove(sentinel_path)
+
         class Exploit:
             def __reduce__(self):
-                import os
-                return (os.system, ("echo hacked_session > /tmp/web2py_session",))
+                return (open, (sentinel_path, "w"))
 
         tmpdir = tempfile.mkdtemp()
-        app_dir = os.path.join(tmpdir, "welcome")
-        sessions_dir = os.path.join(app_dir, "sessions")
-        os.makedirs(sessions_dir)
+        try:
+            app_dir = os.path.join(tmpdir, "welcome")
+            sessions_dir = os.path.join(app_dir, "sessions")
+            os.makedirs(sessions_dir)
 
-        request = Request(env={})
-        request.folder = app_dir
-        request.application = "welcome"
+            request = Request(env={})
+            request.folder = app_dir
+            request.application = "welcome"
+            request.client = "127.0.0.1"
+            session_id = "127.0.0.1-evil"
+            cookie = type("Cookie", (), {"value": session_id})()
+            request.cookies = {"session_id_welcome": cookie}
 
-        session_file = os.path.join(sessions_dir, "testsession")
+            session_file = os.path.join(sessions_dir, session_id)
+            with open(session_file, "wb") as f:
+                pickle.dump(Exploit(), f, pickle.HIGHEST_PROTOCOL)
 
-        with open(session_file, "wb") as f:
-            pickle.dump(Exploit(), f, pickle.HIGHEST_PROTOCOL)
+            s = Session()
+            response = Response()
+            s.connect(request, response, safe_unpickle=True)
+            if getattr(response, "session_file", None):
+                response.session_file.close()
 
-        if os.path.exists("/tmp/web2py_session"):
-            os.remove("/tmp/web2py_session")
-
-        s = Session()
-        response = Response()
-        s.connect(request, response, safe_unpickle=True)
-
-        self.assertFalse(os.path.exists("/tmp/web2py_session"))
+            self.assertFalse(os.path.exists(sentinel_path))
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir, ignore_errors=True)
+            if os.path.exists(sentinel_path):
+                os.remove(sentinel_path)
 
     def test_session_connect_legacy_unpickle_allows_custom_objects(self):
         import sys
@@ -195,22 +206,29 @@ class CustomClass(object):
 
     def test_secure_loads_blocks_rce_payload(self):
         """secure_loads must not execute malicious pickle after decryption."""
-        from gluon.utils import secure_loads
+        from gluon.utils import secure_loads, secure_dumps
+
+        sentinel_fd, sentinel_path = tempfile.mkstemp(prefix="web2py_utils_rce_")
+        os.close(sentinel_fd)
+        os.remove(sentinel_path)
 
         class Exploit:
             def __reduce__(self):
-                import os
-                return (os.system, ("echo hacked_utils > /tmp/web2py_utils",))
+                return (open, (sentinel_path, "w"))
 
-        payload = pickle.dumps(Exploit(), pickle.HIGHEST_PROTOCOL)
+        # Use secure_dumps so the data passes HMAC/signature checks and
+        # actually reaches pickle.loads — that's the code path safe_unpickle protects.
+        encryption_key = "test-key"
+        encrypted = secure_dumps(Exploit(), encryption_key)
 
-        if os.path.exists("/tmp/web2py_utils"):
-         os.remove("/tmp/web2py_utils")
+        try:
+            result = secure_loads(encrypted, encryption_key, safe_unpickle=True)
 
-        result = secure_loads(payload, encryption_key=None)
-
-        self.assertIsNone(result)
-        self.assertFalse(os.path.exists("/tmp/web2py_utils"))
+            self.assertIsNone(result)
+            self.assertFalse(os.path.exists(sentinel_path))
+        finally:
+            if os.path.exists(sentinel_path):
+                os.remove(sentinel_path)
 
 
 class TestTicketStorageFilePath(unittest.TestCase):

--- a/gluon/tests/test_restricted.py
+++ b/gluon/tests/test_restricted.py
@@ -54,6 +54,52 @@ class TestRestrictedPickle(unittest.TestCase):
         self.assertEqual(safe_loads(pickled), payload)
         self.assertEqual(safe_load(io.BytesIO(pickled)), payload)
 
+    def test_safe_unpickler_loads_safe_standard_types(self):
+        import datetime
+        import decimal
+        import uuid
+
+        payload = {
+            "date": datetime.date(2026, 4, 24),
+            "datetime": datetime.datetime(2026, 4, 24, 12, 34, 56),
+            "time": datetime.time(12, 34, 56),
+            "timedelta": datetime.timedelta(days=1, seconds=5),
+            "uuid": uuid.UUID("12345678123456781234567812345678"),
+            "decimal": decimal.Decimal("1.23"),
+        }
+        pickled = pickle.dumps(payload, pickle.HIGHEST_PROTOCOL)
+        self.assertEqual(safe_loads(pickled), payload)
+        self.assertEqual(safe_load(io.BytesIO(pickled)), payload)
+
+    def test_safe_unpickler_allows_custom_allowed_class(self):
+        import sys
+        import types
+
+        module_name = "safe_unpickler_custom_module"
+        module = types.ModuleType(module_name)
+        exec(
+            """
+class CustomClass(object):
+    def __init__(self, value):
+        self.value = value
+
+    def __eq__(self, other):
+        return isinstance(other, CustomClass) and self.value == other.value
+""",
+            module.__dict__,
+        )
+        sys.modules[module_name] = module
+        try:
+            payload = module.CustomClass(42)
+            pickled = pickle.dumps(payload, pickle.HIGHEST_PROTOCOL)
+            result = safe_loads(
+                pickled,
+                allowed_classes={module_name: {"CustomClass"}},
+            )
+            self.assertEqual(result, payload)
+        finally:
+            del sys.modules[module_name]
+
     def test_safe_unpickler_rejects_malicious_file_payload(self):
         """safe_load must reject a pickle stream containing an unsafe global."""
         malicious = pickle.dumps({"bad": subprocess.Popen}, pickle.HIGHEST_PROTOCOL)
@@ -66,6 +112,105 @@ class TestRestrictedPickle(unittest.TestCase):
             safe_load(io.BytesIO(b""))
         with self.assertRaises(Exception):
             safe_loads(b"")
+
+    def test_session_file_blocks_rce_payload(self):
+        """Session file loading must not execute malicious pickle."""
+        from gluon.globals import Request, Session, Response
+
+        class Exploit:
+            def __reduce__(self):
+                import os
+                return (os.system, ("echo hacked_session > /tmp/web2py_session",))
+
+        tmpdir = tempfile.mkdtemp()
+        app_dir = os.path.join(tmpdir, "welcome")
+        sessions_dir = os.path.join(app_dir, "sessions")
+        os.makedirs(sessions_dir)
+
+        request = Request(env={})
+        request.folder = app_dir
+        request.application = "welcome"
+
+        session_file = os.path.join(sessions_dir, "testsession")
+
+        with open(session_file, "wb") as f:
+            pickle.dump(Exploit(), f, pickle.HIGHEST_PROTOCOL)
+
+        if os.path.exists("/tmp/web2py_session"):
+            os.remove("/tmp/web2py_session")
+
+        s = Session()
+        response = Response()
+        s.connect(request, response, safe_unpickle=True)
+
+        self.assertFalse(os.path.exists("/tmp/web2py_session"))
+
+    def test_session_connect_legacy_unpickle_allows_custom_objects(self):
+        import sys
+        import types
+
+        from gluon.globals import Request, Session, Response
+
+        module_name = "legacy_unpickle_custom_module"
+        module = types.ModuleType(module_name)
+        exec(
+            """
+class CustomClass(object):
+    def __init__(self, value):
+        self.value = value
+
+    def __eq__(self, other):
+        return isinstance(other, CustomClass) and self.value == other.value
+""",
+            module.__dict__,
+        )
+        sys.modules[module_name] = module
+        try:
+            tmpdir = tempfile.mkdtemp()
+            app_dir = os.path.join(tmpdir, "welcome")
+            sessions_dir = os.path.join(app_dir, "sessions")
+            os.makedirs(sessions_dir)
+
+            request = Request(env={})
+            request.folder = app_dir
+            request.application = "welcome"
+            request.client = "127.0.0.1"
+            session_id = "127.0.0.1-1234"
+            cookie = type("Cookie", (), {"value": session_id})()
+            request.cookies = {"session_id_welcome": cookie}
+
+            session_file = os.path.join(sessions_dir, session_id)
+            with open(session_file, "wb") as f:
+                pickle.dump({"data": module.CustomClass(123)}, f, pickle.HIGHEST_PROTOCOL)
+
+            s = Session()
+            response = Response()
+            s.connect(request, response, safe_unpickle=False)
+            if getattr(response, "session_file", None):
+                response.session_file.close()
+
+            self.assertEqual(s["data"], module.CustomClass(123))
+        finally:
+            del sys.modules[module_name]
+
+    def test_secure_loads_blocks_rce_payload(self):
+        """secure_loads must not execute malicious pickle after decryption."""
+        from gluon.utils import secure_loads
+
+        class Exploit:
+            def __reduce__(self):
+                import os
+                return (os.system, ("echo hacked_utils > /tmp/web2py_utils",))
+
+        payload = pickle.dumps(Exploit(), pickle.HIGHEST_PROTOCOL)
+
+        if os.path.exists("/tmp/web2py_utils"):
+         os.remove("/tmp/web2py_utils")
+
+        result = secure_loads(payload, encryption_key=None)
+
+        self.assertIsNone(result)
+        self.assertFalse(os.path.exists("/tmp/web2py_utils"))
 
 
 class TestTicketStorageFilePath(unittest.TestCase):

--- a/gluon/utils.py
+++ b/gluon/utils.py
@@ -144,7 +144,14 @@ def secure_dumps(data, encryption_key, hash_key=None, compression_level=None):
     return b"hmac256:" + signature + b":" + encrypted_data
 
 
-def secure_loads(data, encryption_key, hash_key=None, compression_level=None):
+def secure_loads(
+    data,
+    encryption_key,
+    hash_key=None,
+    compression_level=None,
+    safe_unpickle=True,
+    allowed_classes=None,
+):
     """loads a signed data dump"""
     components = data.count(b":")
     if components == 1:
@@ -171,6 +178,10 @@ def secure_loads(data, encryption_key, hash_key=None, compression_level=None):
         data = unpad(AES_dec(cipher, encrypted_data))
         if compression_level:
             data = zlib.decompress(data)
+        if safe_unpickle:
+            from gluon.restricted import safe_loads as safe_loads_restricted
+
+            return safe_loads_restricted(data, allowed_classes=allowed_classes)
         return pickle.loads(data)
     except Exception:
         return None


### PR DESCRIPTION
Follow-up to #2567.

This PR fixes compatibility issues introduced in #2567 by ensuring that safe unpickling remains opt-in and existing session behavior is preserved.

Changes:

* Keeps `safe_unpickle=False` as default (no breaking change)
* Restores compatibility with existing pickled sessions
* Adds support for common types (datetime, decimal, uuid, pydal Row/Rows)
* Allows opt-in safe deserialization via `safe_unpickle=True` and `pickle_allowed_classes`

This aims to address the concerns raised in the review regarding backward compatibility.
