### PR TITLE
Replace eval() with safe parsing in language loading and FPDF template handling

### DIFF
--- a/gluon/contrib/fpdf/template.py
+++ b/gluon/contrib/fpdf/template.py
@@ -8,6 +8,7 @@ __author__ = "Mariano Reingart <reingart@gmail.com>"
 __copyright__ = "Copyright (C) 2010 Mariano Reingart"
 __license__ = "LGPL 3.0"
 
+import ast
 import csv
 import os
 import sys
@@ -95,7 +96,7 @@ class Template:
                     if v == "":
                         v = None
                     else:
-                        v = eval(v.strip())
+                        v = ast.literal_eval(v.strip())
                     kargs[keys[i]] = v
                 self.elements.append(kargs)
         self.keys = [v["name"].lower() for v in self.elements]

--- a/gluon/languages.py
+++ b/gluon/languages.py
@@ -284,7 +284,7 @@ def read_possible_languages(langpath):
 def read_plural_dict_aux(filename):
     lang_text = read_locked(filename).decode("utf8").replace("\r\n", "\n")
     try:
-        return eval(lang_text) or {}
+        return safe_eval(lang_text) or {}
     except Exception:
         e = sys.exc_info()[1]
         status = "Syntax error in %s (%s)" % (filename, e)


### PR DESCRIPTION
## Summary

Replace `eval()` with safe parsing in:

* `gluon/languages.py` → `safe_eval`
* `gluon/contrib/fpdf/template.py` → `ast.literal_eval`

---

## Motivation

These paths parse data from files (language files and template inputs).
Using `eval()` allows execution of arbitrary code if the input is modified.

This change restricts parsing to literal data only.

---

## Changes

* `eval` → `safe_eval` in `read_plural_dict_aux`
* `eval` → `ast.literal_eval` in template parsing
* Added `import ast`

---

## Compatibility

* Existing language files contain only dictionary literals
* Template inputs use simple literal values (numbers, strings, flags)

Behavior is unchanged for valid inputs.

Non-literal expressions (e.g. `1+1`) are no longer evaluated.
No such usage was found in existing data.

---

## Scope

Minimal change:

* only replaces unsafe parsing
* no other logic modified
