### PR TITLE
Restrict eval builtins in smartdictform to reduce code execution risk

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -2283,8 +2283,9 @@ class SQLFORM(FORM):
         if query:
             session[name] = query.db(query).select().first().as_dict()
         elif os.path.exists(filename):
-            env = {"datetime": datetime}
-            session[name] = eval(open(filename).read(), {}, env)
+            session[name] = eval(
+                open(filename).read(), {"__builtins__": {}}, {"datetime": datetime}
+            )
         form = SQLFORM.dictform(session[name])
         if form.process().accepted:
             session[name].update(form.vars)


### PR DESCRIPTION
### Problem

`smartdictform` uses `eval()` to load dictionary data from a file, which allows execution of arbitrary Python code if the file content is compromised.

---

### Change

Restrict the evaluation environment by disabling access to Python builtins:

```python
eval(open(filename).read(), {"__builtins__": {}}, {"datetime": datetime})
```

---

### Security Impact

* Removes access to dangerous builtins (e.g. `__import__`, `eval`, `exec`, `open`)
* Reduces risk of arbitrary code execution from crafted input

---

### Compatibility

* Existing behavior preserved (`datetime` expressions and dict parsing continue to work)
* No changes to return types or control flow
