### PR TITLE
Fix tickets

### DIFF
--- a/applications/admin/controllers/default.py
+++ b/applications/admin/controllers/default.py
@@ -16,7 +16,7 @@ import importlib
 
 from gluon.admin import *
 from gluon.fileutils import abspath, read_file, write_file
-from gluon.restricted import safe_load, safe_loads
+from gluon.restricted import safe_load, safe_loads, TicketStorage
 from gluon.utils import web2py_uuid
 from gluon.tools import Config, prevent_open_redirect
 from gluon.compileapp import find_exposed_functions
@@ -1655,7 +1655,7 @@ def errors():
             try:
                 fullpath_file = safe_open(fullpath, 'rb')
                 try:
-                    error = safe_load(fullpath_file)
+                    error = safe_load(fullpath_file, allowed_classes=TicketStorage.TICKET_ALLOWED_CLASSES)
                 finally:
                     fullpath_file.close()
             except (IOError, pickle.UnpicklingError, EOFError):
@@ -1695,7 +1695,7 @@ def errors():
 
         for fn in tk_db(tk_table.id > 0).select():
             try:
-                error = safe_loads(fn.ticket_data)
+                error = safe_loads(fn.ticket_data, allowed_classes=TicketStorage.TICKET_ALLOWED_CLASSES)
                 hash = hashlib.md5(error['traceback']).hexdigest()
 
                 if hash in delete_hashes:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 build: false
+image: Visual Studio 2022
 before_build:
   - choco install redis-64
   - redis-server --service-install
@@ -6,15 +7,19 @@ before_build:
 
 environment:
   matrix:
-    - PYTHON: "C:/Python36"
+    - PYTHON: "C:/Python39-x64"
       COVERAGE_PROCESS_START: gluon/tests/coverage.ini
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:/Python37"
+    - PYTHON: "C:/Python311-x64"
       COVERAGE_PROCESS_START: gluon/tests/coverage.ini
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:/Python314"
+    - PYTHON: "C:/Python312-x64"
+      COVERAGE_PROCESS_START: gluon/tests/coverage.ini
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:/Python314-x64"
       COVERAGE_PROCESS_START: gluon/tests/coverage.ini
       PYTHON_ARCH: "64"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,10 @@ environment:
       COVERAGE_PROCESS_START: gluon/tests/coverage.ini
       PYTHON_ARCH: "64"
 
+    - PYTHON: "C:/Python314"
+      COVERAGE_PROCESS_START: gluon/tests/coverage.ini
+      PYTHON_ARCH: "64"
+
 clone_depth: 50
 
 init:

--- a/gluon/restricted.py
+++ b/gluon/restricted.py
@@ -101,6 +101,7 @@ class SafeUnpickler(pickle.Unpickler):
                     "global '%s.%s' is forbidden" % (module, name)
                 )
             return getattr(mod, name)
+        logger.warning("SafeUnpickler blocked: '%s.%s'", module, name)
         raise pickle.UnpicklingError("global '%s.%s' is forbidden" % (module, name))
 
 
@@ -178,6 +179,10 @@ class TicketStorage(Storage):
             )
         return table
 
+    # gluon.html.XML objects are stored in ticket snapshots for request/response/session.
+    # XML uses XML_unpickle as its __reduce__ helper, so both must be allowed.
+    TICKET_ALLOWED_CLASSES = {"gluon.html": {"XML", "XML_unpickle"}}
+
     def load(
         self,
         request,
@@ -190,7 +195,7 @@ class TicketStorage(Storage):
             except IOError:
                 return {}
             try:
-                return safe_load(ef)
+                return safe_load(ef, allowed_classes=self.TICKET_ALLOWED_CLASSES)
             except (pickle.UnpicklingError, EOFError):
                 return {}
             finally:
@@ -201,7 +206,7 @@ class TicketStorage(Storage):
             if not rows:
                 return {}
             try:
-                return safe_loads(rows[0].ticket_data)
+                return safe_loads(rows[0].ticket_data, allowed_classes=self.TICKET_ALLOWED_CLASSES)
             except (pickle.UnpicklingError, EOFError):
                 return {}
 
@@ -241,8 +246,9 @@ class RestrictedError(Exception):
                 self.snapshot = snapshot(
                     context=10, code=code, environment=self.environment
                 )
-            except:
+            except Exception as e:
                 self.snapshot = {}
+                logger.warning("snapshot() failed: %s", e)
         else:
             self.traceback = "(no error)"
             self.snapshot = {}
@@ -327,9 +333,7 @@ def restricted(ccode, environment=None, layer="Unknown", scode=None):
 
 def snapshot(info=None, context=5, code=None, environment=None):
     """Return a dict describing a given traceback (based on cgitb.text)."""
-    import cgitb
     import inspect
-    import linecache
     import pydoc
     import time
 
@@ -370,17 +374,6 @@ def snapshot(info=None, context=5, code=None, environment=None):
         # basic frame information
         f = {"file": file, "func": func, "call": call, "lines": {}, "lnum": lnum}
 
-        highlight = {}
-
-        def reader(lnum=[lnum]):
-            highlight[lnum[0]] = 1
-            try:
-                return linecache.getline(file, lnum[0])
-            finally:
-                lnum[0] += 1
-
-        vars = cgitb.scanvars(reader, frame, locals)
-
         # if it is a view, replace with generated code
         if file.endswith("html"):
             lmin = lnum > context and (lnum - context) or 0
@@ -394,19 +387,10 @@ def snapshot(info=None, context=5, code=None, environment=None):
                 f["lines"][i] = line.rstrip()
                 i += 1
 
-        # dump local variables (referenced in current line only)
+        # dump all local variables in this frame
         f["dump"] = {}
-        for name, where, value in vars:
-            if name in f["dump"]:
-                continue
-            if value is not cgitb.__UNDEF__:
-                if where == "global":
-                    name = "global " + name
-                elif where != "local":
-                    name = where + name.split(".")[-1]
-                f["dump"][name] = pydoc.text.repr(value)
-            else:
-                f["dump"][name] = "undefined"
+        for name, value in locals.items():
+            f["dump"][name] = pydoc.text.repr(value)
 
         s["frames"].append(f)
 

--- a/gluon/tests/test_restricted.py
+++ b/gluon/tests/test_restricted.py
@@ -113,6 +113,73 @@ class CustomClass(object):
         with self.assertRaises(Exception):
             safe_loads(b"")
 
+    def test_ticket_allowed_classes_permits_xml(self):
+        """TicketStorage.load must round-trip ticket data containing XML objects."""
+        from gluon.html import XML
+        from gluon.restricted import TicketStorage
+
+        payload = {
+            "layer": "test",
+            "traceback": "ZeroDivisionError: division by zero",
+            "output": "error",
+            "code": "a = 1/0",
+            "snapshot": {
+                "session": XML("<b>session data</b>"),
+                "request": XML("<b>request data</b>"),
+            },
+        }
+        pickled = pickle.dumps(payload, pickle.HIGHEST_PROTOCOL)
+        result = safe_loads(pickled, allowed_classes=TicketStorage.TICKET_ALLOWED_CLASSES)
+        self.assertEqual(str(result["snapshot"]["session"]), "<b>session data</b>")
+        self.assertEqual(str(result["snapshot"]["request"]), "<b>request data</b>")
+
+    def test_ticket_allowed_classes_still_blocks_unsafe(self):
+        """TICKET_ALLOWED_CLASSES must not open the door to arbitrary classes."""
+        from gluon.restricted import TicketStorage
+        malicious = pickle.dumps({"bad": subprocess.Popen}, pickle.HIGHEST_PROTOCOL)
+        with self.assertRaises(pickle.UnpicklingError):
+            safe_loads(malicious, allowed_classes=TicketStorage.TICKET_ALLOWED_CLASSES)
+
+    def test_snapshot_returns_expected_structure(self):
+        """snapshot() must return frame/locals/exception keys without cgitb."""
+        from gluon.restricted import snapshot
+
+        try:
+            sentinel = 42
+            raise ZeroDivisionError("division by zero")
+        except ZeroDivisionError:
+            s = snapshot(context=5, code="", environment={})
+
+        self.assertEqual(s["etype"], "ZeroDivisionError")
+        self.assertEqual(s["evalue"], "division by zero")
+        self.assertIn("frames", s)
+        self.assertTrue(len(s["frames"]) > 0)
+        # locals of the faulting frame must include our sentinel variable
+        self.assertIn("sentinel", s["locals"])
+        self.assertIn("pyver", s)
+        self.assertIn("date", s)
+
+    def test_snapshot_stores_environment_as_xml(self):
+        """snapshot() must store request/response/session as XML objects."""
+        from gluon.html import XML
+        from gluon.restricted import snapshot
+
+        env = {
+            "request": {"application": "welcome"},
+            "response": {"status": 200},
+            "session": {"user": "test"},
+            "db": object(),  # non-web2py key — must be ignored
+        }
+        try:
+            raise ValueError("test")
+        except ValueError:
+            s = snapshot(context=5, code="", environment=env)
+
+        self.assertIsInstance(s["request"], XML)
+        self.assertIsInstance(s["response"], XML)
+        self.assertIsInstance(s["session"], XML)
+        self.assertNotIn("db", s)
+
     def test_session_file_blocks_rce_payload(self):
         """Session file loading must not execute malicious pickle."""
         from gluon.globals import Request, Session, Response
@@ -285,3 +352,55 @@ class TestTicketStorageFilePath(unittest.TestCase):
         self._write_raw_ticket("truncated", b"\x80\x05\x95")
         result = self.storage.load(self.request, "welcome", "truncated")
         self.assertEqual(result, {})
+
+
+class TestRestrictedErrorSnapshot(unittest.TestCase):
+    """Integration tests: RestrictedError captures snapshot data correctly."""
+
+    def test_snapshot_non_empty_after_exception(self):
+        """RestrictedError.snapshot must be populated when an exception is active."""
+        from gluon.restricted import RestrictedError
+
+        try:
+            raise ZeroDivisionError("division by zero")
+        except ZeroDivisionError:
+            e = RestrictedError(layer="test", code="a = 1/0", output="error", environment={})
+
+        self.assertIsInstance(e.snapshot, dict)
+        self.assertNotEqual(e.snapshot, {})
+        self.assertEqual(e.snapshot["etype"], "ZeroDivisionError")
+
+    def test_snapshot_xml_survives_pickle_roundtrip(self):
+        """A ticket dict with XML snapshot values must survive safe_loads with TICKET_ALLOWED_CLASSES.
+
+        This is the end-to-end proof that the two bugs are fixed together:
+        snapshot() producing XML objects (cgitb fix) + TICKET_ALLOWED_CLASSES allowing
+        them through safe_loads (allowlist fix).
+        """
+        from gluon.html import XML
+        from gluon.restricted import RestrictedError, TicketStorage
+
+        env = {
+            "request": {"application": "welcome"},
+            "response": {"status": 200},
+            "session": {"user": "alice"},
+        }
+        try:
+            raise ZeroDivisionError("division by zero")
+        except ZeroDivisionError:
+            e = RestrictedError(layer="test", code="a = 1/0", output="error", environment=env)
+
+        self.assertIsInstance(e.snapshot.get("request"), XML)
+        self.assertIsInstance(e.snapshot.get("session"), XML)
+
+        ticket_dict = {
+            "layer": e.layer,
+            "code": e.code,
+            "output": e.output,
+            "traceback": e.traceback,
+            "snapshot": e.snapshot,
+        }
+        pickled = pickle.dumps(ticket_dict, pickle.HIGHEST_PROTOCOL)
+        result = safe_loads(pickled, allowed_classes=TicketStorage.TICKET_ALLOWED_CLASSES)
+        self.assertIsInstance(result["snapshot"]["request"], XML)
+        self.assertIsInstance(result["snapshot"]["session"], XML)


### PR DESCRIPTION
Two silent bugs broke the ticket system on Python 3.13+:

1. cgitb was removed from stdlib in Python 3.13, snapshot() raised ImportError (that was caught by a naked except) and silently stored {} instead.
2. XML objects produced by snapshot() were blocked by SafeUnpickler when loading tickets in the admin, causing those tickets to be silently skipped.