### PR TITLE
Add optional CSP nonce support for scripts and styles

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -568,6 +568,48 @@ class Response(Storage):
         self.delimiters = ("{{", "}}")
         self.formstyle = "table3cols"
         self.form_label_separator = ": "
+        self._csp_enabled = False
+
+    @property
+    def nonce(self):
+        if "nonce" not in self:
+            self["nonce"] = web2py_uuid()
+        return self["nonce"]
+
+    def enable_csp(self, nonce=True, **policies):
+        self._csp_enabled = True
+        existing = self.headers.get("Content-Security-Policy")
+        p = {}
+        if existing:
+            for directive in existing.split(";"):
+                directive = directive.strip()
+                if not directive:
+                    continue
+                bits = directive.split()
+                if bits:
+                    p[bits[0]] = bits[1:]
+
+        def merge(directive, sources):
+            if isinstance(sources, str):
+                sources = sources.split()
+            if directive not in p:
+                p[directive] = []
+            for s in sources:
+                if s not in p[directive]:
+                    p[directive].append(s)
+
+        if "default-src" not in p:
+            merge("default-src", ["'self'"])
+        if nonce:
+            n = self.nonce
+            merge("script-src", ["'self'", "'nonce-%s'" % n])
+            merge("style-src", ["'self'", "'nonce-%s'" % n])
+        for k, v in policies.items():
+            merge(k.replace("_", "-"), v)
+
+        self.headers["Content-Security-Policy"] = "; ".join(
+            "%s %s" % (k, " ".join(v)) for k, v in p.items()
+        )
 
     def write(self, data, escape=True):
         if not escape:
@@ -713,11 +755,31 @@ class Response(Storage):
                     )
                 tmpl = template_mapping.get(ext)
                 if tmpl:
+                    if (
+                        self._csp_enabled
+                        and (
+                            tmpl.startswith("<script")
+                            or tmpl.startswith("<style")
+                            or tmpl.startswith("<link")
+                        )
+                    ):
+                        tmpl = tmpl.replace(">", ' nonce="{0}">'.format(self.nonce), 1)
                     s.append(tmpl % item)
             elif isinstance(item, (list, tuple)):
                 f = item[0]
                 tmpl = template_mapping.get(f)
                 if tmpl:
+                    if (
+                        self._csp_enabled
+                        and (
+                            tmpl.startswith("<script")
+                            or tmpl.startswith("<style")
+                            or tmpl.startswith("<link")
+                        )
+                    ):
+                        tmpl = tmpl.replace(
+                            ">", ' nonce="{0}">'.format(self.nonce), 1
+                        )
                     s.append(tmpl % item[1])
 
         s = []

--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -117,6 +117,16 @@ template_mapping = {
     "js:inline": js_inline,
 }
 
+template_mapping_csp = {
+    "css": '<link nonce="%s" href="%s" rel="stylesheet" type="text/css" />',
+    "js": '<script nonce="%s" src="%s" type="text/javascript"></script>',
+    "coffee": '<script nonce="%s" src="%s" type="text/coffee"></script>',
+    "ts": '<script nonce="%s" src="%s" type="text/typescript"></script>',
+    "less": '<link nonce="%s" href="%s" rel="stylesheet/less" type="text/css" />',
+    "css:inline": '<style nonce="%s" type="text/css">\n%s\n</style>',
+    "js:inline": '<script nonce="%s" type="text/javascript">\n%s\n</script>',
+}
+
 
 # IMPORTANT:
 # this is required so that pickled dict(s) and class.__dict__
@@ -753,34 +763,29 @@ class Response(Storage):
                     item = item.replace(
                         "/static/", "/static/_%s/" % self.static_version, 1
                     )
-                tmpl = template_mapping.get(ext)
+                if self._csp_enabled:
+                    tmpl = template_mapping_csp.get(ext)
+                else:
+                    tmpl = template_mapping.get(ext)
                 if tmpl:
-                    if (
-                        self._csp_enabled
-                        and (
-                            tmpl.startswith("<script")
-                            or tmpl.startswith("<style")
-                            or tmpl.startswith("<link")
-                        )
-                    ):
-                        tmpl = tmpl.replace(">", ' nonce="{0}">'.format(self.nonce), 1)
-                    s.append(tmpl % item)
+                    if self._csp_enabled:
+                        s.append(tmpl % (self.nonce, item))
+                    else:
+                        s.append(tmpl % item)
             elif isinstance(item, (list, tuple)):
                 f = item[0]
-                tmpl = template_mapping.get(f)
+                if self._csp_enabled:
+                    tmpl = template_mapping_csp.get(f)
+                else:
+                    tmpl = template_mapping.get(f)
                 if tmpl:
-                    if (
-                        self._csp_enabled
-                        and (
-                            tmpl.startswith("<script")
-                            or tmpl.startswith("<style")
-                            or tmpl.startswith("<link")
-                        )
-                    ):
-                        tmpl = tmpl.replace(
-                            ">", ' nonce="{0}">'.format(self.nonce), 1
-                        )
-                    s.append(tmpl % item[1])
+                    if self._csp_enabled:
+                        if isinstance(item[1], tuple):
+                            s.append(tmpl % ((self.nonce,) + item[1]))
+                        else:
+                            s.append(tmpl % (self.nonce, item[1]))
+                    else:
+                        s.append(tmpl % item[1])
 
         s = []
         for item in files:

--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -586,7 +586,7 @@ class Response(Storage):
             self["nonce"] = web2py_uuid()
         return self["nonce"]
 
-    def enable_csp(self, nonce=True, **policies):
+    def enable_csp(self, **policies):
         self._csp_enabled = True
         existing = self.headers.get("Content-Security-Policy")
         p = {}
@@ -610,10 +610,9 @@ class Response(Storage):
 
         if "default-src" not in p:
             merge("default-src", ["'self'"])
-        if nonce:
-            n = self.nonce
-            merge("script-src", ["'self'", "'nonce-%s'" % n])
-            merge("style-src", ["'self'", "'nonce-%s'" % n])
+        n = self.nonce
+        merge("script-src", ["'self'", "'nonce-%s'" % n])
+        merge("style-src", ["'self'", "'nonce-%s'" % n])
         for k, v in policies.items():
             merge(k.replace("_", "-"), v)
 

--- a/gluon/html.py
+++ b/gluon/html.py
@@ -1517,6 +1517,15 @@ class SCRIPT(DIV):
     tag = "script"
     tagname = tag
 
+    def _xml(self):
+        fa, co = DIV._xml(self)
+        if not self.attributes.get("_nonce"):
+            from gluon.globals import current
+            response = getattr(current, "response", None)
+            if response and response._csp_enabled:
+                fa += ' nonce="%s"' % response.nonce
+        return fa, co
+
     def xml(self):
         (fa, co) = self._xml()
         # no escaping of subcomponents
@@ -1540,6 +1549,15 @@ class SCRIPT(DIV):
 class STYLE(DIV):
     tag = "style"
     tagname = tag
+
+    def _xml(self):
+        fa, co = DIV._xml(self)
+        if not self.attributes.get("_nonce"):
+            from gluon.globals import current
+            response = getattr(current, "response", None)
+            if response and response._csp_enabled:
+                fa += ' nonce="%s"' % response.nonce
+        return fa, co
 
     def xml(self):
         (fa, co) = self._xml()

--- a/gluon/tests/test_html.py
+++ b/gluon/tests/test_html.py
@@ -465,6 +465,28 @@ class TestBareHelpers(unittest.TestCase):
         js_content = current.response.body.getvalue()
         self.assertIn('nonce="%s"' % current.response.nonce, js_content)
 
+        # extra policies are merged alongside the nonce
+        current.response = Response()
+        current.request = Request(env={})
+        current.request.application = "a"
+        current.response.enable_csp(script_src="'unsafe-inline'")
+        csp = current.response.headers["Content-Security-Policy"]
+        self.assertIn("'nonce-%s'" % current.response.nonce, csp)
+        self.assertIn("'unsafe-inline'", csp)
+        # nonce is still injected into SCRIPT tags
+        self.assertIn('nonce="%s"' % current.response.nonce, SCRIPT('alert(1)').xml())
+
+        # pre-existing CSP header is merged, not overwritten
+        current.response = Response()
+        current.request = Request(env={})
+        current.request.application = "a"
+        current.response.headers["Content-Security-Policy"] = "img-src 'self' https://cdn.example.com"
+        current.response.enable_csp()
+        csp = current.response.headers["Content-Security-Policy"]
+        self.assertIn("img-src", csp)
+        self.assertIn("https://cdn.example.com", csp)
+        self.assertIn("'nonce-%s'" % current.response.nonce, csp)
+
         # CAT(' ')
         self.assertEqual(CAT(" ").xml(), " ")
 

--- a/gluon/tests/test_html.py
+++ b/gluon/tests/test_html.py
@@ -5,6 +5,7 @@
     Unit tests for gluon.html
 """
 
+import io
 import re
 import unittest
 
@@ -418,7 +419,7 @@ class TestBareHelpers(unittest.TestCase):
         # use existing pattern from other tests: append URL
         current.response.files.append(URL("a", "static", "css/file.css"))
         # clear body and call include_files
-        current.response.body = __import__('io').StringIO()
+        current.response.body = io.StringIO()
         current.response.include_files()
         content = current.response.body.getvalue()
         self.assertNotIn('nonce="', content)
@@ -437,10 +438,33 @@ class TestBareHelpers(unittest.TestCase):
         # include_files should inject nonce into link when enabled
         current.response.files = []
         current.response.files.append(URL("a", "static", "css/file.css"))
-        current.response.body = __import__('io').StringIO()
+        current.response.body = io.StringIO()
         current.response.include_files()
         content = current.response.body.getvalue()
         self.assertIn('nonce="%s"' % current.response.nonce, content)
+        # nonce must appear as a proper attribute, not mangled into "/>"
+        # e.g. '<link ... / nonce="x">' would be invalid HTML
+        self.assertNotIn('/ nonce=', content)
+        self.assertIn('/>', content)
+
+        # same check for .less files
+        current.response.files = []
+        current.response.files.append(URL("a", "static", "css/file.less"))
+        current.response.body = io.StringIO()
+        current.response.include_files()
+        less_content = current.response.body.getvalue()
+        self.assertIn('nonce="%s"' % current.response.nonce, less_content)
+        self.assertNotIn('/ nonce=', less_content)
+        self.assertIn('/>', less_content)
+
+        # .js files should also get a nonce
+        current.response.files = []
+        current.response.files.append(URL("a", "static", "js/file.js"))
+        current.response.body = io.StringIO()
+        current.response.include_files()
+        js_content = current.response.body.getvalue()
+        self.assertIn('nonce="%s"' % current.response.nonce, js_content)
+
         # CAT(' ')
         self.assertEqual(CAT(" ").xml(), " ")
 

--- a/gluon/tests/test_html.py
+++ b/gluon/tests/test_html.py
@@ -20,6 +20,7 @@ from gluon.html import (ASSIGNJS, BEAUTIFY, BODY, BR, BUTTON, CAT, CENTER,
                         XML_unpickle, truncate_string, verifyURL,
                         web2pyHTMLParser, xmlescape)
 from gluon.storage import Storage
+from gluon.globals import current, Request, Response
 
 
 class TestBareHelpers(unittest.TestCase):
@@ -398,6 +399,48 @@ class TestBareHelpers(unittest.TestCase):
         self.assertEqual(CAT().xml(), "")
         # CAT('')
         self.assertEqual(CAT("").xml(), "")
+
+    def test_csp_nonce_injection(self):
+        # setup request/response
+        current.request = Request(env={})
+        current.request.application = "a"
+        current.response = Response()
+
+        # no nonce when CSP not enabled
+        s = SCRIPT('alert(1)')
+        self.assertNotIn('nonce="', s.xml())
+        st = STYLE('body { color: red }')
+        self.assertNotIn('nonce="', st.xml())
+
+        # include_files without CSP shouldn't add nonce
+        current.response.files = []
+        current.response.body = Storage()
+        # use existing pattern from other tests: append URL
+        current.response.files.append(URL("a", "static", "css/file.css"))
+        # clear body and call include_files
+        current.response.body = __import__('io').StringIO()
+        current.response.include_files()
+        content = current.response.body.getvalue()
+        self.assertNotIn('nonce="', content)
+
+        # enable CSP and check nonce appears in SCRIPT and STYLE
+        current.response = Response()
+        current.request = Request(env={})
+        current.request.application = "a"
+        current.response.enable_csp()
+
+        s = SCRIPT('console.log(1)')
+        self.assertIn('nonce="%s"' % current.response.nonce, s.xml())
+        st = STYLE('body { color: blue }')
+        self.assertIn('nonce="%s"' % current.response.nonce, st.xml())
+
+        # include_files should inject nonce into link when enabled
+        current.response.files = []
+        current.response.files.append(URL("a", "static", "css/file.css"))
+        current.response.body = __import__('io').StringIO()
+        current.response.include_files()
+        content = current.response.body.getvalue()
+        self.assertIn('nonce="%s"' % current.response.nonce, content)
         # CAT(' ')
         self.assertEqual(CAT(" ").xml(), " ")
 


### PR DESCRIPTION
### Summary

Adds **optional CSP nonce support** for inline `<script>` and `<style>` elements.

---

### What’s included

* `response.enable_csp()` to configure CSP headers
* `response.nonce` (per-response, lazy)
* Automatic nonce injection into:

  * `SCRIPT`
  * `STYLE`
  * inline resources via `include_files`
* Merges with existing CSP headers (no overwrite)
* Supports adding domains via parameters

---

### Design

* Implemented in `Response` (as discussed)
* Fully opt-in → no behavior change unless enabled
* Compatible with existing CSP headers
* Works with views, helpers, and `LOAD`

---

### Usage

```python
response.enable_csp(script_src=["https://cdn.example.com"])
```

---

### Backward compatibility

No changes unless `enable_csp()` is called.
