### PR TITLE
Fix directory traversal in admin unzip

### DIFF
--- a/gluon/admin.py
+++ b/gluon/admin.py
@@ -35,6 +35,17 @@ from gluon.fileutils import (
 from gluon.restricted import RestrictedError
 from gluon.settings import global_settings
 
+
+def _safe_extract_path(base_dir, member_name):
+    """Return an absolute safe extraction path inside base_dir."""
+    target = os.path.normpath(os.path.join(base_dir, member_name))
+    root = os.path.abspath(base_dir)
+    target_abspath = os.path.abspath(target)
+    if not (target_abspath == root or target_abspath.startswith(root + os.sep)):
+        raise RuntimeError("Attempted path traversal in zip file")
+    return target_abspath
+
+
 # TODO: move into add_path_first
 if not global_settings.web2py_runtime_gae:
     pass
@@ -384,20 +395,24 @@ def unzip(filename, dir, subfolder=""):
     filename = abspath(filename)
     if not zipfile.is_zipfile(filename):
         raise RuntimeError("Not a valid zipfile")
-    zf = zipfile.ZipFile(filename)
-    if not subfolder.endswith("/"):
-        subfolder += "/"
-    n = len(subfolder)
-    for name in sorted(zf.namelist()):
-        if not name.startswith(subfolder):
-            continue
-        # print(name[n:])
-        if name.endswith("/"):
-            folder = os.path.join(dir, name[n:])
-            if not os.path.exists(folder):
-                os.mkdir(folder)
-        else:
-            write_file(os.path.join(dir, name[n:]), zf.read(name), "wb")
+    with zipfile.ZipFile(filename) as zf:
+        if not subfolder.endswith("/"):
+            subfolder += "/"
+        n = len(subfolder)
+        for name in sorted(zf.namelist()):
+            if not name.startswith(subfolder):
+                continue
+            entry_name = name[n:]
+            if not entry_name:
+                continue
+            target_path = _safe_extract_path(dir, entry_name)
+            if name.endswith("/"):
+                os.makedirs(target_path, exist_ok=True)
+            else:
+                target_dir = os.path.dirname(target_path)
+                if target_dir and not os.path.exists(target_dir):
+                    os.makedirs(target_dir, exist_ok=True)
+                write_file(target_path, zf.read(name), "wb")
 
 
 def upgrade(request, url="http://web2py.com"):

--- a/gluon/tests/test_compileapp.py
+++ b/gluon/tests/test_compileapp.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import tempfile
 import unittest
+import zipfile
 
 from gluon.admin import (app_cleanup, app_compile, app_create, app_uninstall,
                          check_new_version)
@@ -76,3 +77,22 @@ class TestPack(unittest.TestCase):
     def test_check_new_version(self):
         vert = check_new_version(global_settings.web2py_version, WEB2PY_VERSION_URL)
         self.assertNotEqual(vert[0], -1)
+
+    def test_admin_unzip_path_traversal(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            zip_path = os.path.join(tmpdir, "evil.zip")
+            with zipfile.ZipFile(zip_path, "w") as zf:
+                zf.writestr("web2py/../evil.txt", "bad")
+                zf.writestr("web2py/subdir/../../evil2.txt", "bad")
+                zf.writestr("web2py/safe.txt", "good")
+
+            from gluon.admin import unzip
+
+            with self.assertRaises(RuntimeError):
+                unzip(zip_path, tmpdir, subfolder="web2py")
+
+            self.assertFalse(os.path.exists(os.path.join(tmpdir, "evil.txt")))
+            self.assertFalse(os.path.exists(os.path.join(tmpdir, "evil2.txt")))
+        finally:
+            shutil.rmtree(tmpdir)


### PR DESCRIPTION
### Summary

Fixes a directory traversal vulnerability in the admin `unzip` functionality.

### Changes

- Added `_safe_extract_path()` to normalize and validate extraction paths
- Ensured all extracted paths remain within the target directory
- Replaced direct path joins with validated safe paths
- Switched to `ZipFile` context manager for safer resource handling
- Used `os.makedirs(..., exist_ok=True)` for safe directory creation

### Tests

- Added regression test `test_admin_unzip_path_traversal`
- Verifies that malicious entries using `../` are rejected
- Confirms no files are written outside the target directory
- Existing tests pass successfully
