### PR TITLE
Remove unsafe eval() usage in controller test runner

### DIFF
--- a/gluon/compileapp.py
+++ b/gluon/compileapp.py
@@ -635,8 +635,8 @@ def _TEST():
     html = '<h2>Testing controller "%s.py" ... done.</h2><br/>\n' \
         % request.controller
     for key in sorted([key for key in globals() if not key in __symbols__+['_TEST']]):
-        eval_key = eval(key)
-        if type(eval_key) == types.FunctionType:
+        eval_key = globals().get(key)
+        if isinstance(eval_key, types.FunctionType):
             number_doctests = sum([len(ds.examples) for ds in doctest.DocTestFinder().find(eval_key)])
             if number_doctests>0:
                 sys.stdout = io.StringIO()

--- a/gluon/tests/test_compileapp.py
+++ b/gluon/tests/test_compileapp.py
@@ -10,7 +10,7 @@ import zipfile
 
 from gluon.admin import (app_cleanup, app_compile, app_create, app_uninstall,
                          check_new_version)
-from gluon.compileapp import compile_application, remove_compiled_application
+from gluon.compileapp import TEST_CODE, compile_application, remove_compiled_application
 from gluon.fileutils import create_app, w2p_pack, w2p_unpack
 from gluon.globals import Request
 from gluon.main import global_settings
@@ -73,6 +73,9 @@ class TestPack(unittest.TestCase):
         self.assertIsNone(app_compile(test_app2_name, request))
         self.assertTrue(app_cleanup(test_app2_name, request))
         self.assertTrue(app_uninstall(test_app2_name, request))
+
+    def test_admin_test_runner_no_eval(self):
+        self.assertNotIn("eval(", TEST_CODE)
 
     def test_check_new_version(self):
         vert = check_new_version(global_settings.web2py_version, WEB2PY_VERSION_URL)


### PR DESCRIPTION
This PR removes the use of `eval()` in the internal controller test runner (`_TEST`) in `gluon/compileapp.py`.

The previous implementation evaluated global names using `eval(key)`. Although the keys are currently derived from `globals()`, using `eval()` introduces an unnecessary dynamic execution path and is considered unsafe.

This change replaces `eval()` with `globals().get(key)`, preserving the original behavior while eliminating dynamic code execution.

### Changes

- Replaced `eval(key)` with `globals().get(key)`
- Updated type checking from `type(...) ==` to `isinstance(...)`
- Added regression test to ensure `eval()` is not reintroduced