### PR TITLE
Use safe_unpickle=True by default and allowlist Session for safe deserialization

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -1022,7 +1022,7 @@ class Session(Storage):
         cookie_key=None,
         cookie_expires=None,
         compression_level=None,
-        safe_unpickle=False,
+        safe_unpickle=True,
         pickle_allowed_classes=None,
     ):
         """
@@ -1066,6 +1066,14 @@ class Session(Storage):
         response.session_client = str(request.client).replace(":", ".")
         current._session_cookie_key = cookie_key
         response.session_cookie_compression_level = compression_level
+
+        if safe_unpickle:
+            if pickle_allowed_classes is None:
+                pickle_allowed_classes = {"gluon.globals": {"Session"}}
+            else:
+                pickle_allowed_classes.setdefault("gluon.globals", set()).add(
+                    "Session"
+                )
 
         # check if there is a session_id in cookies
         try:


### PR DESCRIPTION
This change makes session deserialization use `safe_unpickle=True` by default.

Previously, session data was deserialized using `pickle` by default. Since pickle can execute arbitrary code during deserialization, this is unsafe if session storage is compromised (e.g., via database manipulation or file tampering).

This patch switches the default to safe unpickling and ensures compatibility by allowlisting `gluon.globals.Session`, which is required for normal session reconstruction.

Key points:
- Uses existing safe unpickling mechanism already present in the codebase
- Preserves backward compatibility by allowing `safe_unpickle=False` explicitly
- Limits allowed classes to only `Session`, avoiding broad exposure
- Minimal and localized change to session deserialization logic