### PR TITLE
Fix unsafe JavaScript interpolation in FORM redirect helper

### DIFF
--- a/gluon/html.py
+++ b/gluon/html.py
@@ -2376,7 +2376,16 @@ class FORM(DIV):
         self.validate(**kwargs)
         return self
 
-    REDIRECT_JS = "window.location='%s';return false"
+    REDIRECT_JS = "window.location=%s;return false"
+
+    @staticmethod
+    def _redirect_js(url):
+        if url.startswith("javascript:"):
+            return url
+
+        from gluon.serializers import json
+
+        return FORM.REDIRECT_JS % json(url)
 
     def add_button(self, value, url, _class=None):
         submit = self.element(_type="submit")
@@ -2385,9 +2394,7 @@ class FORM(DIV):
             TAG["button"](
                 value,
                 _class=_class,
-                _onclick=(
-                    url if url.startswith("javascript:") else self.REDIRECT_JS % url
-                ),
+                _onclick=self._redirect_js(url),
             )
         )
 
@@ -2398,7 +2405,7 @@ class FORM(DIV):
         if not hidden:
             hidden = {}
         inputs = [
-            INPUT(_type="button", _value=name, _onclick=FORM.REDIRECT_JS % link)
+            INPUT(_type="button", _value=name, _onclick=FORM._redirect_js(link))
             for name, link in buttons.items()
         ]
         inputs += [

--- a/gluon/tests/test_html.py
+++ b/gluon/tests/test_html.py
@@ -922,6 +922,13 @@ class TestBareHelpers(unittest.TestCase):
         # TODO check tags content
         self.assertEqual(len(FORM("<>", _a="1", _b="2").as_xml()), 326)
 
+    def test_FORM_add_button_escapes_redirect_url(self):
+        form = FORM(INPUT(_type="submit", _value="Go"))
+        form.add_button("Cancel", "/path?x=bar'")
+        html = form.xml()
+        self.assertIn('window.location=&quot;/path?x=bar&#x27;&quot;;return false', html)
+        self.assertNotIn("window.location='", html)
+
     def test_BEAUTIFY(self):
         # self.assertEqual(BEAUTIFY(['a', 'b', {'hello': 'world'}]).xml(),
         #                 '<div><table><tr><td><div>a</div></td></tr><tr><td><div>b</div></td></tr><tr><td><div><table><tr><td style="font-weight:bold;vertical-align:top;">hello</td><td style="vertical-align:top;">:</td><td><div>world</div></td></tr></table></div></td></tr></table></div>')


### PR DESCRIPTION
This change fixes an injection issue in the FORM helper where redirect URLs were directly interpolated into inline JavaScript without proper escaping.

Previously user-controlled input could break out of the JavaScript string and inject arbitrary code. For example:

    /path?x=bar';alert(1);//

would produce:

    window.location='/path?x=bar';alert(1);//';

This allows execution of unintended JavaScript in the browser.

The fix introduces a centralized helper (`_redirect_js`) that safely embeds URLs using JSON string encoding before inserting them into JavaScript. This prevents string breakouts and ensures the URL is treated as data rather than code.

The existing `javascript:` behavior is preserved as an explicit opt-in for cases where raw JavaScript execution is intentionally required.

Changes include:
- Safe encoding of redirect URLs before embedding into inline JavaScript
- Refactoring to a shared helper to avoid duplication
- Regression test demonstrating the exploit and verifying the fix

This improves the security of a commonly used helper by eliminating an injection primitive in a core code path.