### PR TITLE
Harden CSP policy parsing and directive token validation

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -127,6 +127,44 @@ template_mapping_csp = {
     "js:inline": '<script nonce="%s" type="text/javascript">\n%s\n</script>',
 }
 
+CSP_DIRECTIVE = re.compile(r"^[A-Za-z0-9-]+$")
+CSP_DIRECTIVE_TOKEN = re.compile(r"^[\x21-\x2B\x2D-\x3A\x3C-\x7E]+$")
+CSP_STANDARD_DIRECTIVES = frozenset(
+    (
+        "base-uri",
+        "block-all-mixed-content",
+        "child-src",
+        "connect-src",
+        "default-src",
+        "fenced-frame-src",
+        "font-src",
+        "form-action",
+        "frame-ancestors",
+        "frame-src",
+        "img-src",
+        "manifest-src",
+        "media-src",
+        "navigate-to",
+        "object-src",
+        "prefetch-src",
+        "report-to",
+        "report-uri",
+        "require-sri-for",
+        "require-trusted-types-for",
+        "sandbox",
+        "script-src",
+        "script-src-attr",
+        "script-src-elem",
+        "style-src",
+        "style-src-attr",
+        "style-src-elem",
+        "trusted-types",
+        "upgrade-insecure-requests",
+        "webrtc",
+        "worker-src",
+    )
+)
+
 
 # IMPORTANT:
 # this is required so that pickled dict(s) and class.__dict__
@@ -146,6 +184,38 @@ def sorting_dumps(obj, protocol=None):
     file = StringIO()
     SortingPickler(file, protocol).dump(obj)
     return file.getvalue()
+
+
+def _validate_csp_directive(directive):
+    if not CSP_DIRECTIVE.match(directive):
+        raise ValueError("invalid CSP directive: %r" % directive)
+
+
+def _split_serialized_csp_list(serialized):
+    policies = []
+    start = 0
+    for match in re.finditer(r",([\t\n\f\r ]*)([A-Za-z0-9-]+)", serialized):
+        directive = match.group(2)
+        if match.group(1) or directive in CSP_STANDARD_DIRECTIVES or "-" in directive:
+            policies.append(serialized[start : match.start()].strip())
+            start = match.end(1)
+    policies.append(serialized[start:].strip())
+    return [policy for policy in policies if policy]
+
+
+def _normalize_csp_tokens(sources):
+    if isinstance(sources, str):
+        sources = sources.split()
+    elif sources is None:
+        sources = []
+    else:
+        sources = list(sources)
+    for source in sources:
+        if not isinstance(source, str):
+            raise TypeError("CSP directive tokens must be strings: %r" % (source,))
+        if not CSP_DIRECTIVE_TOKEN.match(source):
+            raise ValueError("invalid CSP directive token: %r" % source)
+    return sources
 
 
 # END #####################################################################
@@ -591,17 +661,19 @@ class Response(Storage):
         existing = self.headers.get("Content-Security-Policy")
         p = {}
         if existing:
-            for directive in existing.split(";"):
-                directive = directive.strip()
-                if not directive:
-                    continue
-                bits = directive.split()
-                if bits:
-                    p[bits[0]] = bits[1:]
+            for policy in _split_serialized_csp_list(existing):
+                for directive in policy.split(";"):
+                    directive = directive.strip()
+                    if not directive:
+                        continue
+                    bits = directive.split()
+                    if bits:
+                        _validate_csp_directive(bits[0])
+                        p[bits[0]] = _normalize_csp_tokens(bits[1:])
 
         def merge(directive, sources):
-            if isinstance(sources, str):
-                sources = sources.split()
+            _validate_csp_directive(directive)
+            sources = _normalize_csp_tokens(sources)
             if directive not in p:
                 p[directive] = []
             for s in sources:

--- a/gluon/tests/test_globals.py
+++ b/gluon/tests/test_globals.py
@@ -232,6 +232,106 @@ class testResponse(unittest.TestCase):
         content = return_includes(response)
         self.assertEqual(content, "")
 
+    def test_enable_csp_rejects_injected_policy_tokens(self):
+        response = Response()
+        with self.assertRaises(ValueError):
+            response.enable_csp(script_src="'self'; img-src *")
+
+        response = Response()
+        response.headers["Content-Security-Policy"] = "script>src 'self'"
+        with self.assertRaises(ValueError):
+            response.enable_csp()
+
+        response = Response()
+        response.headers["Content-Security-Policy"] = "report-to group,name"
+        with self.assertRaises(ValueError):
+            response.enable_csp()
+
+        response = Response()
+        with self.assertRaises(ValueError):
+            response.enable_csp(report_to="group,name")
+
+        response = Response()
+        response.headers["Content-Security-Policy"] = "report-to group,name"
+        with self.assertRaises(ValueError):
+            response.enable_csp()
+
+        response = Response()
+        with self.assertRaises(ValueError):
+            response.enable_csp(script_src="https://good.example/\x00evil")
+
+        response = Response()
+        response.headers["Content-Security-Policy"] = "default-src 'self'; report-to group,name"
+        with self.assertRaises(ValueError):
+            response.enable_csp()
+
+    def test_enable_csp_rejects_non_string_iterable_tokens(self):
+        for invalid in ([None], [123], [b"foo"]):
+            response = Response()
+            with self.assertRaises(TypeError):
+                response.enable_csp(script_src=invalid)
+
+    def test_enable_csp_accepts_valid_policy_tokens(self):
+        response = Response()
+        response.enable_csp(
+            script_src=(
+                "'self' 'none' 'unsafe-inline' 'unsafe-eval' "
+                "'nonce-abcDEF0123+/_=' "
+                "'sha256-abcDEF0123+/_=' "
+                "*.example.com https://cdn.example.com blob: data: ws: wss:"
+            ),
+            report_uri="https://example.com/report",
+            report_to="csp-endpoint",
+            sandbox="allow-scripts allow-same-origin",
+            upgrade_insecure_requests="",
+        )
+        csp = response.headers["Content-Security-Policy"]
+        self.assertIn("'self'", csp)
+        self.assertIn("'unsafe-inline'", csp)
+        self.assertIn("'nonce-abcDEF0123+/_='", csp)
+        self.assertIn("'sha256-abcDEF0123+/_='", csp)
+        self.assertIn("*.example.com", csp)
+        self.assertIn("blob:", csp)
+        self.assertIn("data:", csp)
+        self.assertIn("ws:", csp)
+        self.assertIn("wss:", csp)
+        self.assertIn("report-uri https://example.com/report", csp)
+        self.assertIn("report-to csp-endpoint", csp)
+        self.assertIn("sandbox allow-scripts allow-same-origin", csp)
+        self.assertIn("upgrade-insecure-requests", csp)
+
+    def test_enable_csp_accepts_existing_policy_lists(self):
+        response = Response()
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'self', report-uri https://example.com/report"
+        )
+        response.enable_csp(report_to="csp-endpoint")
+        csp = response.headers["Content-Security-Policy"]
+        self.assertIn("default-src 'self'", csp)
+        self.assertIn("report-uri https://example.com/report", csp)
+        self.assertIn("report-to csp-endpoint", csp)
+        self.assertIn("script-src 'self'", csp)
+        self.assertIn("style-src 'self'", csp)
+
+        response = Response()
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'self',report-uri https://example.com/report"
+        )
+        response.enable_csp(report_to="csp-endpoint")
+        csp = response.headers["Content-Security-Policy"]
+        self.assertIn("default-src 'self'", csp)
+        self.assertIn("report-uri https://example.com/report", csp)
+        self.assertIn("report-to csp-endpoint", csp)
+
+        response = Response()
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'self',x-foo bar"
+        )
+        response.enable_csp()
+        csp = response.headers["Content-Security-Policy"]
+        self.assertIn("default-src 'self'", csp)
+        self.assertIn("x-foo bar", csp)
+
     def test_cookies(self):
         current = setup_clean_session()
         cookie = str(current.response.cookies)


### PR DESCRIPTION
## Summary

Harden `Response.enable_csp()` by validating CSP directive names and serialized directive tokens before merging or generating `Content-Security-Policy` headers.

## Changes

* Added validation for CSP directive names
* Added validation for serialized CSP directive tokens
* Reject malformed directive names and malformed serialized tokens before policy merge/generation
* Added handling for existing comma-separated CSP policy lists
* Reject non-string iterable directive tokens instead of silently coercing them

## Tests

Added regression coverage for:

* malformed directive-name rejection
* malformed serialized token rejection
* semicolon injection rejection
* comma-invalid token rejection
* existing CSP policy-list parsing
* non-string iterable token rejection
* valid CSP acceptance paths
