### PR TITLE
Enable safe session unpickling by default

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -1135,10 +1135,16 @@ class Session(Storage):
 
         if safe_unpickle:
             if pickle_allowed_classes is None:
-                pickle_allowed_classes = {"gluon.globals": {"Session"}}
+                pickle_allowed_classes = {
+                    "gluon.globals": {"Session"},
+                    "gluon.storage": {"Storage"}
+                }
             else:
                 pickle_allowed_classes.setdefault("gluon.globals", set()).add(
                     "Session"
+                )
+                pickle_allowed_classes.setdefault("gluon.storage", set()).add(
+                    "Storage"
                 )
 
         # check if there is a session_id in cookies

--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -1088,7 +1088,7 @@ class Session(Storage):
         cookie_key=None,
         cookie_expires=None,
         compression_level=None,
-        safe_unpickle=False,
+        safe_unpickle=True,
         pickle_allowed_classes=None,
     ):
         """
@@ -1132,6 +1132,14 @@ class Session(Storage):
         response.session_client = str(request.client).replace(":", ".")
         current._session_cookie_key = cookie_key
         response.session_cookie_compression_level = compression_level
+
+        if safe_unpickle:
+            if pickle_allowed_classes is None:
+                pickle_allowed_classes = {"gluon.globals": {"Session"}}
+            else:
+                pickle_allowed_classes.setdefault("gluon.globals", set()).add(
+                    "Session"
+                )
 
         # check if there is a session_id in cookies
         try:


### PR DESCRIPTION
This patch hardens session deserialization by enabling safe unpickling by default and restricting allowed pickle classes during session restoration.

## Changes

* Changed `safe_unpickle` default from `False` to `True`
* Added default allowed-class handling for `pickle_allowed_classes`
* Restricted safe unpickling to the `Session` class from `gluon.globals`
* Preserved compatibility with existing custom `pickle_allowed_classes` configurations
