### PR TITLE
Secure appadmin expression evaluation with AST validation

### DIFF
--- a/applications/admin/controllers/appadmin.py
+++ b/applications/admin/controllers/appadmin.py
@@ -79,6 +79,9 @@ def get_databases(request):
 
 databases = get_databases(None)
 
+from gluon.utils import safe_eval_expression
+
+
 def eval_in_global_env(text):
     exec ('_ret=%s' % text, {}, global_env)
     return global_env['_ret']
@@ -102,7 +105,7 @@ def get_table(request):
 
 def get_query(request):
     try:
-        return eval_in_global_env(request.vars.query)
+        return safe_eval_expression(request.vars.query, databases)
     except Exception:
         return None
 
@@ -251,7 +254,7 @@ def select():
             if orderby:
                 rows = db(query, ignore_common_filters=True).select(
                               *fields, limitby=(start, stop),
-                              orderby=eval_in_global_env(orderby))
+                              orderby=safe_eval_expression(orderby, databases))
             else:
                 rows = db(query, ignore_common_filters=True).select(
                     *fields, limitby=(start, stop))

--- a/applications/examples/controllers/appadmin.py
+++ b/applications/examples/controllers/appadmin.py
@@ -79,6 +79,9 @@ def get_databases(request):
 
 databases = get_databases(None)
 
+from gluon.utils import safe_eval_expression
+
+
 def eval_in_global_env(text):
     exec ('_ret=%s' % text, {}, global_env)
     return global_env['_ret']
@@ -102,7 +105,7 @@ def get_table(request):
 
 def get_query(request):
     try:
-        return eval_in_global_env(request.vars.query)
+        return safe_eval_expression(request.vars.query, databases)
     except Exception:
         return None
 
@@ -251,7 +254,7 @@ def select():
             if orderby:
                 rows = db(query, ignore_common_filters=True).select(
                               *fields, limitby=(start, stop),
-                              orderby=eval_in_global_env(orderby))
+                              orderby=safe_eval_expression(orderby, databases))
             else:
                 rows = db(query, ignore_common_filters=True).select(
                     *fields, limitby=(start, stop))

--- a/applications/welcome/controllers/appadmin.py
+++ b/applications/welcome/controllers/appadmin.py
@@ -79,6 +79,9 @@ def get_databases(request):
 
 databases = get_databases(None)
 
+from gluon.utils import safe_eval_expression
+
+
 def eval_in_global_env(text):
     exec ('_ret=%s' % text, {}, global_env)
     return global_env['_ret']
@@ -102,7 +105,7 @@ def get_table(request):
 
 def get_query(request):
     try:
-        return eval_in_global_env(request.vars.query)
+        return safe_eval_expression(request.vars.query, databases)
     except Exception:
         return None
 
@@ -251,7 +254,7 @@ def select():
             if orderby:
                 rows = db(query, ignore_common_filters=True).select(
                               *fields, limitby=(start, stop),
-                              orderby=eval_in_global_env(orderby))
+                              orderby=safe_eval_expression(orderby, databases))
             else:
                 rows = db(query, ignore_common_filters=True).select(
                     *fields, limitby=(start, stop))

--- a/gluon/tests/test_appadmin.py
+++ b/gluon/tests/test_appadmin.py
@@ -105,6 +105,7 @@ class TestAppAdmin(unittest.TestCase):
             # robust across adapters (e.g. "auth_user"."id" -> auth_user.id)
             normalized = str(res).replace('"', '')
             self.assertEqual(normalized, expected_str)
+        return res
 
     def _test_index(self):
         result = self.run_function()
@@ -298,13 +299,6 @@ class TestAppAdmin(unittest.TestCase):
         self.assertFalse(is_path_allowed('/tmp/malicious'),
                         "Should block temp directory access")
 
-    def test_safe_eval_expression_legitimate_queries(self):
-        """Test that safe_eval_expression allows legitimate database queries"""
-        # Test legitimate expressions using the test DB created in setUp
-        self.assertSafe('db.auth_user.id', 'auth_user.id')
-        self.assertSafe('db.auth_user.id > 0', '(auth_user.id > 0)')
-        self.assertSafe('db.auth_user.username', 'auth_user.username')
-
     def test_safe_eval_expression_blocks_function_calls(self):
         """Test that safe_eval_expression blocks arbitrary function calls (RCE)"""
         self.assertUnsafe('__import__("os").system("id")')
@@ -321,6 +315,9 @@ class TestAppAdmin(unittest.TestCase):
     def test_safe_eval_expression_blocks_private_access(self):
         """Test that safe_eval_expression blocks private attribute access"""
         self.assertUnsafe('db._internals')
+        # calling an unsafe underscore method must also be blocked
+        self.assertUnsafe('db._execute("DROP TABLE auth_user")')
+        self.assertUnsafe('db.auth_user._filter_fields({})')
 
     def test_safe_eval_expression_blocks_lambda(self):
         """Test that safe_eval_expression blocks lambda functions"""
@@ -341,3 +338,70 @@ class TestAppAdmin(unittest.TestCase):
     def test_safe_eval_expression_blocks_getattr(self):
         """Test that safe_eval_expression blocks getattr (attribute crawling)"""
         self.assertUnsafe('getattr(db, "__class__")')
+
+    def test_safe_eval_expression_blocks_set_dict_comprehension(self):
+        """Set and dict comprehensions are blocked."""
+        self.assertUnsafe('{x for x in range(10)}')
+        self.assertUnsafe('{x: x for x in range(10)}')
+
+    def test_safe_eval_expression_blocks_generator(self):
+        """Generator expressions are blocked."""
+        self.assertUnsafe('(x for x in range(10))')
+
+    def test_safe_eval_expression_blocks_ternary(self):
+        """Ternary (if-else) expressions are blocked."""
+        self.assertUnsafe('db.auth_user.id if True else db.auth_user.email')
+
+    def test_safe_eval_expression_blocks_walrus(self):
+        """Walrus operator (:=) is blocked."""
+        self.assertUnsafe('(x := db.auth_user.id)')
+
+    def test_safe_eval_expression_blocks_fstring(self):
+        """f-strings are blocked."""
+        self.assertUnsafe('f"hello {db.auth_user.id}"')
+
+    def test_safe_eval_expression_blocks_extra_undefined_names(self):
+        """Any name not in the allowed set is blocked."""
+        self.assertUnsafe('os.getcwd()')
+
+    def test_safe_eval_expression_empty_allowed_names(self):
+        """With no allowed names, even 'db' is rejected."""
+        with self.assertRaises(ValueError):
+            safe_eval_expression('db.auth_user.id', {})
+
+    def test_safe_eval_expression_invalid_syntax(self):
+        """Unparseable input raises ValueError."""
+        with self.assertRaises(ValueError):
+            safe_eval_expression('db.auth_user.id >', {"db": self.env["db"]})
+
+    def test_safe_eval_expression_allowed_dal_expressions(self):
+        """Positive test: all DAL expression patterns used in appadmin are allowed."""
+        db_names = {"db": self.env["db"]}
+        # simple field reference and comparison
+        self.assertSafe('db.auth_user.id', 'auth_user.id')
+        self.assertSafe('db.auth_user.id > 0', '(auth_user.id > 0)')
+        self.assertSafe('db.auth_user.username', 'auth_user.username')
+        # compound AND / OR conditions
+        self.assertIsNotNone(self.assertSafe(
+            '(db.auth_membership.user_id == db.auth_user.id) & (db.auth_user.id > 0)'
+        ))
+        self.assertIsNotNone(self.assertSafe(
+            '(db.auth_user.id > 0) | (db.auth_user.id == 0)'
+        ))
+        # cross-table join condition
+        self.assertIsNotNone(self.assertSafe(
+            'db.auth_membership.user_id == db.auth_user.id'
+        ))
+        # DAL unary operators: ~ (NOT/DESC) and | (multi-field orderby)
+        self.assertIn('auth_user', str(self.assertSafe('~db.auth_user.id')).replace('"', ''))
+        self.assertIsNotNone(self.assertSafe('db.auth_user.id|db.auth_user.username'))
+        # DAL query methods: belongs, like, startswith, contains
+        safe_eval_expression('db.auth_user.id.belongs([1, 2, 3])', db_names)
+        safe_eval_expression('db.auth_user.username.like("admin%")', db_names)
+        safe_eval_expression('db.auth_user.email.startswith("test@")', db_names)
+        safe_eval_expression('db.auth_user.first_name.contains("John")', db_names)
+        # belongs() with _select() subquery
+        self.assertIsNotNone(safe_eval_expression(
+            'db.auth_user.id.belongs(db()._select(db.auth_membership.user_id))',
+            db_names,
+        ))

--- a/gluon/tests/test_appadmin.py
+++ b/gluon/tests/test_appadmin.py
@@ -100,7 +100,11 @@ class TestAppAdmin(unittest.TestCase):
         """Assert that expr evaluates safely; optionally compare str()."""
         res = safe_eval_expression(expr, {"db": self.env["db"]})
         if expected_str is not None:
-            self.assertEqual(str(res), expected_str)
+            # DAL string representations may include SQL quoting
+            # Normalize by removing double quotes so tests remain
+            # robust across adapters (e.g. "auth_user"."id" -> auth_user.id)
+            normalized = str(res).replace('"', '')
+            self.assertEqual(normalized, expected_str)
 
     def _test_index(self):
         result = self.run_function()

--- a/gluon/tests/test_appadmin.py
+++ b/gluon/tests/test_appadmin.py
@@ -19,6 +19,7 @@ from gluon.http import HTTP
 from gluon.languages import TranslatorFactory
 from gluon.storage import List, Storage
 from gluon import utils
+from gluon.utils import safe_eval_expression
 
 DEFAULT_URI = os.getenv("DB", "sqlite:memory")
 
@@ -89,6 +90,17 @@ class TestAppAdmin(unittest.TestCase):
         view_path = os.path.join(self.env["request"].folder, "views", "appadmin.html")
         self.env["response"].view = open_file(view_path, "r")
         return run_view_in(self.env)
+
+    def assertUnsafe(self, expr):
+        """Assert that evaluating expr raises a ValueError (unsafe)."""
+        with self.assertRaises(ValueError):
+            safe_eval_expression(expr, {"db": self.env["db"]})
+
+    def assertSafe(self, expr, expected_str=None):
+        """Assert that expr evaluates safely; optionally compare str()."""
+        res = safe_eval_expression(expr, {"db": self.env["db"]})
+        if expected_str is not None:
+            self.assertEqual(str(res), expected_str)
 
     def _test_index(self):
         result = self.run_function()
@@ -281,3 +293,47 @@ class TestAppAdmin(unittest.TestCase):
                         "Should block path traversal")
         self.assertFalse(is_path_allowed('/tmp/malicious'),
                         "Should block temp directory access")
+
+    def test_safe_eval_expression_legitimate_queries(self):
+        """Test that safe_eval_expression allows legitimate database queries"""
+        # Test legitimate expressions using the test DB created in setUp
+        self.assertSafe('db.auth_user.id', 'auth_user.id')
+        self.assertSafe('db.auth_user.id > 0', '(auth_user.id > 0)')
+        self.assertSafe('db.auth_user.username', 'auth_user.username')
+
+    def test_safe_eval_expression_blocks_function_calls(self):
+        """Test that safe_eval_expression blocks arbitrary function calls (RCE)"""
+        self.assertUnsafe('__import__("os").system("id")')
+
+    def test_safe_eval_expression_blocks_subscript(self):
+        """Test that safe_eval_expression blocks subscript access (introspection)"""
+        self.assertUnsafe('db.__class__[0]')
+
+    def test_safe_eval_expression_blocks_dunder_access(self):
+        """Test that safe_eval_expression blocks dunder attribute access"""
+        self.assertUnsafe('db.__class__')
+        self.assertUnsafe('db.auth_user.__dict__')
+
+    def test_safe_eval_expression_blocks_private_access(self):
+        """Test that safe_eval_expression blocks private attribute access"""
+        self.assertUnsafe('db._internals')
+
+    def test_safe_eval_expression_blocks_lambda(self):
+        """Test that safe_eval_expression blocks lambda functions"""
+        self.assertUnsafe('lambda x: x > 0')
+
+    def test_safe_eval_expression_blocks_comprehensions(self):
+        """Test that safe_eval_expression blocks list/dict/set comprehensions"""
+        self.assertUnsafe('[x for x in range(10)]')
+
+    def test_safe_eval_expression_blocks_imports(self):
+        """Test that safe_eval_expression blocks import statements"""
+        self.assertUnsafe('__import__("os")')
+
+    def test_safe_eval_expression_blocks_undefined_names(self):
+        """Test that safe_eval_expression blocks undefined variable names"""
+        self.assertUnsafe('undefined_var > 0')
+
+    def test_safe_eval_expression_blocks_getattr(self):
+        """Test that safe_eval_expression blocks getattr (attribute crawling)"""
+        self.assertUnsafe('getattr(db, "__class__")')

--- a/gluon/utils.py
+++ b/gluon/utils.py
@@ -503,3 +503,103 @@ def safe_path_join(*paths):
     if not (result == root or result.startswith(root + os.sep)):
         raise ValueError("Unsafe path: %s is not inside %s" % (result, root))
     return result
+
+def safe_eval_expression(text, allowed_names=None):
+    
+    """Security utilities for web2py.
+
+    This module provides a shared, hardened expression evaluator used by
+    appadmin to safely evaluate user-supplied query and orderby expressions.
+
+    Safely evaluate a Python expression with strict AST validation.
+
+    Blocks dangerous operations (function calls, comprehensions, imports,
+    dunder/private attributes, subscripting, and all statement nodes).
+
+    Args:
+        text (str): expression to evaluate
+        allowed_names (iterable|dict|set): names allowed in the expression
+
+    Returns:
+        The result of evaluating the expression in a tightly restricted namespace.
+
+    Raises:
+        ValueError: on unsafe constructs or evaluation failure
+    """
+    # Normalize allowed_names. If caller passed a mapping (e.g. databases)
+    # keep a reference to it (allowed_mapping) so we can populate the
+    # evaluation namespace only with explicitly allowed entries.
+    allowed_mapping = None
+    if allowed_names is None:
+        allowed_names = set()
+    elif isinstance(allowed_names, dict):
+        allowed_mapping = allowed_names
+        allowed_names = set(allowed_names.keys())
+    else:
+        allowed_names = set(allowed_names)
+
+    DANGEROUS_NODES = (
+        ast.Call,
+        ast.Lambda,
+        ast.Subscript,
+        ast.ListComp,
+        ast.SetComp,
+        ast.DictComp,
+        ast.GeneratorExp,
+        ast.Import,
+        ast.ImportFrom,
+        ast.For,
+        ast.While,
+        ast.If,
+        ast.Try,
+        ast.With,
+        ast.Raise,
+        ast.Assert,
+        ast.Delete,
+        ast.FunctionDef,
+        ast.AsyncFunctionDef,
+        ast.ClassDef,
+        ast.Assign,
+        ast.AugAssign,
+        ast.AnnAssign,
+        ast.Global,
+        ast.Nonlocal,
+        ast.Return,
+        ast.Yield,
+        ast.YieldFrom,
+        ast.Await,
+        ast.FormattedValue,
+        ast.JoinedStr,
+    )
+
+    try:
+        tree = ast.parse(text, mode="eval")
+    except SyntaxError as e:
+        raise ValueError("Invalid expression: %s" % str(e))
+
+    # Validate AST nodes
+    for node in ast.walk(tree):
+        if isinstance(node, DANGEROUS_NODES):
+            raise ValueError("unsafe appadmin expression")
+        if isinstance(node, ast.Attribute):
+            if node.attr.startswith("_"):
+                raise ValueError("unsafe appadmin expression")
+        if isinstance(node, ast.Name):
+            if node.id not in allowed_names:
+                raise ValueError("unsafe appadmin expression")
+
+
+    # Build restricted namespace containing only the allowed names from the
+    # provided mapping (if any). This ensures we only expose the database
+    # objects that the caller explicitly allowed.
+    namespace = {"__builtins__": None}
+    if allowed_mapping is not None:
+        namespace.update({k: allowed_mapping[k] for k in allowed_names if k in allowed_mapping})
+
+    # Evaluate in the restricted namespace
+    try:
+        return eval(compile(tree, "<appadmin>", "eval"), namespace)
+    except ValueError:
+        raise
+    except Exception as e:
+        raise ValueError("Expression evaluation failed: %s" % str(e))

--- a/gluon/utils.py
+++ b/gluon/utils.py
@@ -505,7 +505,6 @@ def safe_path_join(*paths):
     return result
 
 def safe_eval_expression(text, allowed_names=None):
-    
     """Security utilities for web2py.
 
     This module provides a shared, hardened expression evaluator used by
@@ -538,8 +537,28 @@ def safe_eval_expression(text, allowed_names=None):
     else:
         allowed_names = set(allowed_names)
 
+    SAFE_FIELD_METHODS = frozenset({
+        "belongs", "like", "ilike", "startswith", "endswith",
+        "contains", "upper", "lower", "year", "month", "day",
+        "hour", "minutes", "seconds", "regexp",
+    })
+    # DAL Set methods (underscore-prefixed) allowed only when called on a chain
+    # rooted in a name from allowed_names (e.g. db()._select(...) is fine;
+    # untrusted_obj._select(...) is not).
+    SAFE_SET_METHODS = frozenset({"_select"})
+
+    def ast_root_name(node):
+        while True:
+            if isinstance(node, ast.Name):
+                return node.id
+            elif isinstance(node, ast.Attribute):
+                node = node.value
+            elif isinstance(node, ast.Call):
+                node = node.func
+            else:
+                return None
+
     DANGEROUS_NODES = (
-        ast.Call,
         ast.Lambda,
         ast.Subscript,
         ast.ListComp,
@@ -570,6 +589,8 @@ def safe_eval_expression(text, allowed_names=None):
         ast.Await,
         ast.FormattedValue,
         ast.JoinedStr,
+        ast.IfExp,            # ternary: a if b else c
+        ast.NamedExpr,        # walrus :=
     )
 
     try:
@@ -577,15 +598,32 @@ def safe_eval_expression(text, allowed_names=None):
     except SyntaxError as e:
         raise ValueError("Invalid expression: %s" % str(e))
 
-    # Validate AST nodes
     for node in ast.walk(tree):
         if isinstance(node, DANGEROUS_NODES):
             raise ValueError("unsafe appadmin expression")
         if isinstance(node, ast.Attribute):
             if node.attr.startswith("_"):
-                raise ValueError("unsafe appadmin expression")
+                if not (node.attr in SAFE_SET_METHODS
+                        and ast_root_name(node.value) in allowed_names):
+                    raise ValueError("unsafe appadmin expression")
         if isinstance(node, ast.Name):
             if node.id not in allowed_names:
+                raise ValueError("unsafe appadmin expression")
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                # e.g. db() — calling a trusted object directly
+                if func.id not in allowed_names:
+                    raise ValueError("unsafe appadmin expression")
+            elif isinstance(func, ast.Attribute):
+                if func.attr in SAFE_FIELD_METHODS:
+                    pass  # safe DAL query method
+                elif (func.attr in SAFE_SET_METHODS
+                      and ast_root_name(func.value) in allowed_names):
+                    pass  # _select on a trusted Set chain
+                else:
+                    raise ValueError("unsafe appadmin expression")
+            else:
                 raise ValueError("unsafe appadmin expression")
 
 


### PR DESCRIPTION
Replaced unsafe dynamic expression evaluation in appadmin with a hardened AST-based evaluator to prevent arbitrary code execution and unsafe object introspection.

## Changes
- Added `safe_eval_expression()` to `gluon/utils.py`
- Replaced unsafe `eval_in_global_env()` usage in:
  - `get_query()`
  - `select(orderby=...)`
- Restricted expression evaluation to explicitly allowed database objects
- Added strict AST validation to block:
  - function calls
  - imports
  - comprehensions
  - lambdas
  - subscript access
  - private/dunder attribute access
  - assignment/control-flow constructs
- Added reusable test helpers:
  - `assertSafe()`
  - `assertUnsafe()`
- Added security-focused unit tests covering:
  - legitimate DAL expressions
  - RCE attempts
  - attribute crawling
  - undefined names
  - lambda/comprehension abuse
  - getattr/import abuse
