### PR TITLE
Harden Content-Disposition filename handling in attachment responses

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -128,6 +128,16 @@ template_mapping_csp = {
 }
 
 
+def _content_disposition_filename(filename):
+    if filename is None:
+        filename = ""
+    # Keep historical semantics for normal values while ensuring dangerous
+    # bytes are encoded before insertion in a quoted header parameter.
+    if isinstance(filename, bytes):
+        return urllib_quote(filename, safe=b"")
+    return urllib_quote(str(filename), safe="")
+
+
 # IMPORTANT:
 # this is required so that pickled dict(s) and class.__dict__
 # are sorted and web2py can detect without ambiguity when a session changes
@@ -829,11 +839,7 @@ class Response(Storage):
         # for attachment settings and backward compatibility
         keys = [item.lower() for item in headers]
         if attachment:
-            # FIXME: should be done like in next download method
-            if filename is None:
-                attname = ""
-            else:
-                attname = filename
+            attname = _content_disposition_filename(filename)
             headers["Content-Disposition"] = 'attachment; filename="%s"' % attname
 
         if not request:
@@ -924,9 +930,9 @@ class Response(Storage):
         if attachment:
             # Browsers still don't have a simple uniform way to have non ascii
             # characters in the filename so for now we are percent encoding it
-            download_filename = urllib_quote(download_filename)
+            download_filename = _content_disposition_filename(download_filename)
             headers["Content-Disposition"] = (
-                'attachment; filename="%s"' % download_filename.replace('"', '\\"')
+                'attachment; filename="%s"' % download_filename
             )
         return self.stream(stream, chunk_size=chunk_size, request=request)
 

--- a/gluon/tests/test_globals.py
+++ b/gluon/tests/test_globals.py
@@ -293,6 +293,78 @@ class testResponse(unittest.TestCase):
         cookie = str(current.response.cookies)
         self.assertTrue("samesite=strict" in cookie.lower())
 
+    def test_stream_attachment_filename_encodes_quote(self):
+        response = Response()
+        request = Request(env={})
+        payload = BytesIO(b"hello")
+        filename = 'a"b.txt'
+
+        response.stream(payload, request=request, attachment=True, filename=filename)
+
+        disposition = response.headers["Content-Disposition"]
+        self.assertEqual(
+            disposition,
+            'attachment; filename="a%22b.txt"',
+        )
+
+    def test_stream_attachment_filename_encodes_semicolon(self):
+        response = Response()
+        request = Request(env={})
+        payload = BytesIO(b"hello")
+        filename = "a; filename=evil.txt"
+
+        response.stream(payload, request=request, attachment=True, filename=filename)
+
+        disposition = response.headers["Content-Disposition"]
+        self.assertEqual(
+            disposition,
+            'attachment; filename="a%3B%20filename%3Devil.txt"',
+        )
+        self.assertEqual(disposition.count(";"), 1)
+        self.assertNotIn("filename=evil.txt", disposition)
+
+    def test_stream_attachment_filename_encodes_crlf(self):
+        response = Response()
+        request = Request(env={})
+        payload = BytesIO(b"hello")
+        filename = "a.txt\r\nX-Evil: yes"
+
+        response.stream(payload, request=request, attachment=True, filename=filename)
+
+        disposition = response.headers["Content-Disposition"]
+        self.assertEqual(
+            disposition,
+            'attachment; filename="a.txt%0D%0AX-Evil%3A%20yes"',
+        )
+        self.assertNotIn("\r", disposition)
+        self.assertNotIn("\n", disposition)
+
+    def test_stream_attachment_safe_filenames_compatibility(self):
+        request = Request(env={})
+        payload = BytesIO(b"hello")
+        cases = [
+            ("report.csv", 'attachment; filename="report.csv"'),
+            ("my report.txt", 'attachment; filename="my%20report.txt"'),
+            ("caf\u00e9.txt", 'attachment; filename="caf%C3%A9.txt"'),
+            ("100%done.txt", 'attachment; filename="100%25done.txt"'),
+        ]
+        for filename, expected in cases:
+            response = Response()
+            response.stream(payload, request=request, attachment=True, filename=filename)
+            self.assertEqual(response.headers["Content-Disposition"], expected)
+
+    def test_stream_attachment_bytes_filename_compatibility(self):
+        response = Response()
+        request = Request(env={})
+        payload = BytesIO(b"hello")
+
+        response.stream(payload, request=request, attachment=True, filename=b"caf\xc3\xa9.txt")
+
+        self.assertEqual(
+            response.headers["Content-Disposition"],
+            'attachment; filename="caf%C3%A9.txt"',
+        )
+
     def test_include_meta(self):
         response = Response()
         response.meta["web2py"] = "web2py"


### PR DESCRIPTION
## Summary

Centralize and harden `Content-Disposition` filename handling for attachment responses.

This change makes `Response.stream(..., attachment=True)` use the same percent-encoding behavior already used by `Response.download()`, ensuring unsafe filename bytes are encoded before interpolation into the response header.

## Changes

* Added a shared `_content_disposition_filename()` helper in `gluon/globals.py`
* Updated `Response.stream(..., attachment=True, filename=...)` to use centralized filename encoding
* Updated `Response.download()` to use the same helper for consistent behavior across response paths
* Preserved existing `download()` compatibility behavior for:

  * unicode filenames
  * spaces
  * percent characters
  * `bytes` input

## Why

Previously, `Response.stream()` inserted raw filename values directly into:

```python
Content-Disposition: attachment; filename="..."
```

This allowed malformed or ambiguous header construction when filenames contained characters such as:

* quotes (`"`)
* semicolons (`;`)
* CRLF (`\r\n`)

The new helper percent-encodes unsafe bytes before interpolation, preventing ambiguous header construction while keeping the change minimal and backward-compatible.

## Tests

Added focused regression coverage for:

* quote encoding
* semicolon encoding
* CRLF encoding
* compatibility behavior for safe filenames
* compatibility behavior for `bytes` filenames