### PR TITLE
Validate CAS service URLs before ticket issuance and validation

### DIFF
--- a/gluon/tests/test_tools.py
+++ b/gluon/tests/test_tools.py
@@ -1950,7 +1950,20 @@ class TestCASServiceAllowlist(unittest.TestCase):
             self.auth._is_allowed_cas_service("https://nope.example/foo")
         )
 
-    def test_rejects_non_http_schemes(self):
+    def test_rejects_non_https_schemes(self):
+        # http:// is rejected even if explicitly listed: tickets would be
+        # exposed in plaintext in transit and in proxy/server access logs.
+        self.auth.settings.cas_allowed_services = [
+            "http://internal.example/",
+            "http://internal.example/app",
+        ]
+        self.assertFalse(
+            self.auth._is_allowed_cas_service("http://internal.example/")
+        )
+        self.assertFalse(
+            self.auth._is_allowed_cas_service("http://internal.example/app")
+        )
+        # Non-http schemes are also rejected.
         self.auth.settings.cas_allowed_services = ["javascript:alert(1)"]
         self.assertFalse(
             self.auth._is_allowed_cas_service("javascript:alert(1)")

--- a/gluon/tests/test_tools.py
+++ b/gluon/tests/test_tools.py
@@ -1853,3 +1853,167 @@ class Test_OpenRedirectPrevention(unittest.TestCase):
                 prevent_open_redirect(c + "//evil.com", "test.com"), None)
             self.assertEqual(
                 prevent_open_redirect("/foo" + c + "bar", "test.com"), None)
+
+
+class TestCASServiceAllowlist(unittest.TestCase):
+    """Regression tests for the CAS provider service-URL allowlist.
+
+    Before this guard was added, `Auth.cas_login` accepted any value for
+    `request.vars.service` and redirected the authenticated user there with
+    a freshly-minted CAS ticket appended, leaking the ticket to attacker-
+    controlled origins.
+    """
+
+    def setUp(self):
+        request = Request(env={})
+        request.application = "a"
+        request.controller = "c"
+        request.function = "f"
+        request.folder = "applications/admin"
+        request.env.http_host = "cas.example.com"
+        request.env.remote_addr = "127.0.0.1"
+        response = Response()
+        session = Session()
+        T = TranslatorFactory("", "en")
+        session.connect(request, response)
+        from gluon.globals import current
+
+        current.request = request
+        current.response = response
+        current.session = session
+        current.T = T
+        self.current = current
+        self.request = request
+        self.db = DAL(DEFAULT_URI, check_reserved=["all"])
+        self.auth = Auth(self.db)
+        self.auth.define_tables(username=True, signature=False)
+        self.auth.settings.cas_domains = ["cas.example.com"]
+
+    def tearDown(self):
+        self.db.commit()
+        self.db.close()
+
+    def test_default_denies_external_service(self):
+        # No allowlist configured → only same-host services accepted.
+        self.assertFalse(
+            self.auth._is_allowed_cas_service("https://evil.example/")
+        )
+        self.assertFalse(
+            self.auth._is_allowed_cas_service("http://evil.example/path")
+        )
+
+    def test_default_allows_same_host_service(self):
+        self.assertTrue(
+            self.auth._is_allowed_cas_service("https://cas.example.com/app")
+        )
+
+    def test_list_allowlist_exact_and_origin_match(self):
+        self.auth.settings.cas_allowed_services = [
+            "https://relying.example/app",
+            "https://other.example",
+        ]
+        self.assertTrue(
+            self.auth._is_allowed_cas_service("https://relying.example/app")
+        )
+        self.assertTrue(
+            self.auth._is_allowed_cas_service("https://other.example")
+        )
+        # Different path, no trailing-slash prefix entry → reject.
+        self.assertFalse(
+            self.auth._is_allowed_cas_service("https://relying.example/other")
+        )
+
+    def test_list_allowlist_prefix_requires_trailing_slash(self):
+        # Prefix-match entries must end with "/" so that "https://good.example"
+        # does not match "https://good.example.attacker.com/...".
+        self.auth.settings.cas_allowed_services = ["https://good.example/"]
+        self.assertTrue(
+            self.auth._is_allowed_cas_service("https://good.example/")
+        )
+        self.assertTrue(
+            self.auth._is_allowed_cas_service("https://good.example/anything")
+        )
+        self.assertFalse(
+            self.auth._is_allowed_cas_service(
+                "https://good.example.attacker.com/x"
+            )
+        )
+
+    def test_callable_allowlist(self):
+        self.auth.settings.cas_allowed_services = (
+            lambda u: u.startswith("https://ok.example/")
+        )
+        self.assertTrue(
+            self.auth._is_allowed_cas_service("https://ok.example/foo")
+        )
+        self.assertFalse(
+            self.auth._is_allowed_cas_service("https://nope.example/foo")
+        )
+
+    def test_rejects_non_http_schemes(self):
+        self.auth.settings.cas_allowed_services = ["javascript:alert(1)"]
+        self.assertFalse(
+            self.auth._is_allowed_cas_service("javascript:alert(1)")
+        )
+        self.assertFalse(self.auth._is_allowed_cas_service("file:///etc/passwd"))
+        self.assertFalse(self.auth._is_allowed_cas_service("ftp://example/"))
+
+    def test_rejects_control_characters(self):
+        # CRLF / NUL must not be accepted — browsers strip them from
+        # Location headers and the residual prefix would bypass the check.
+        self.auth.settings.cas_allowed_services = ["https://ok.example/"]
+        self.assertFalse(
+            self.auth._is_allowed_cas_service(
+                "https://ok.example/\r\nLocation: https://evil/"
+            )
+        )
+        self.assertFalse(
+            self.auth._is_allowed_cas_service("https://ok.example/\x00")
+        )
+
+    def test_cas_login_blocks_disallowed_service(self):
+        # Reproduces the original bug: a request to cas/login with an
+        # attacker-controlled service URL must be rejected, not redirected.
+        self.request.vars.service = "https://attacker.example/"
+        with self.assertRaises(HTTP) as ctx:
+            self.auth.cas_login()
+        self.assertEqual(ctx.exception.status, 403)
+
+    def test_cas_login_does_not_poison_session_with_invalid_service(self):
+        # An invalid request.vars.service must not overwrite a previously
+        # stored session._cas_service value.
+        self.current.session._cas_service = "https://cas.example.com/legit"
+        self.request.vars.service = "https://attacker.example/"
+        with self.assertRaises(HTTP):
+            self.auth.cas_login()
+        self.assertEqual(
+            self.current.session._cas_service, "https://cas.example.com/legit"
+        )
+
+    def test_cas_validate_refuses_ticket_for_disallowed_service(self):
+        user_id = self.db.auth_user.insert(
+            username="alice", email="alice@example.com", password="x"
+        )
+        self.db.commit()
+        table = self.auth.table_cas()
+        ticket = "ST-test-ticket-1234567890"
+        table.insert(
+            service="https://attacker.example/",
+            user_id=user_id,
+            ticket=ticket,
+            created_on=self.request.now,
+            renew=False,
+        )
+        self.db.commit()
+        self.request.vars.ticket = ticket
+        with self.assertRaises(HTTP) as ctx:
+            self.auth.cas_validate(version=2)
+        # cas_validate always returns 200 with an XML body. Failure is signalled
+        # in the body, not the status code.
+        self.assertEqual(ctx.exception.status, 200)
+        body = ctx.exception.body
+        if isinstance(body, bytes):
+            body = body.decode("utf8")
+        self.assertIn("authenticationFailure", body)
+        # And the stored ticket must have been purged.
+        self.assertIsNone(table(ticket=ticket))

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -2727,6 +2727,9 @@ class Auth(AuthAPI):
         #                 (`https://good.example` matching
         #                 `https://good.example.attacker.com/...`).
         #   callable    - `f(url) -> bool`
+        #
+        # Only https:// service URLs are accepted. http:// would expose the
+        # CAS ticket in plaintext in transit and in proxy/server access logs.
         if not url or not isinstance(url, str):
             return False
         if any(ord(c) < 0x20 or ord(c) == 0x7F for c in url):
@@ -2735,7 +2738,7 @@ class Auth(AuthAPI):
             parsed = urlparse.urlparse(url)
         except ValueError:
             return False
-        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        if parsed.scheme != "https" or not parsed.netloc:
             return False
         allowed = self.settings.cas_allowed_services
         if allowed is None:

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -1600,6 +1600,7 @@ class Auth(AuthAPI):
         auth_two_factor_tries_left=3,
         bulk_register_enabled=False,
         captcha=None,
+        cas_allowed_services=None,
         cas_maps=None,
         client_side=True,
         formstyle=None,
@@ -2707,6 +2708,55 @@ class Auth(AuthAPI):
             return False
         return user
 
+    def _is_allowed_cas_service(self, url):
+        # The CAS provider redirects an authenticated user to `service` with a
+        # freshly-minted ticket appended. Without validation, an attacker
+        # phishes the victim to /user/cas/login?service=https://attacker/ and
+        # receives a valid ticket they can replay against any relying party
+        # that trusts this provider (CWE-601 + credential leak). The CAS
+        # protocol therefore requires the provider to enforce a service-URL
+        # allowlist; `cas_allowed_services` is that allowlist.
+        #
+        # Accepted values:
+        #   None        - deny all external services (default; only allow
+        #                 services whose host matches `cas_domains`)
+        #   list/tuple  - of allowed URL strings. An entry ending in "/"
+        #                 matches by prefix; otherwise the URL or its origin
+        #                 ("scheme://host[:port]") must match exactly. The
+        #                 trailing-slash rule prevents prefix-confusion
+        #                 (`https://good.example` matching
+        #                 `https://good.example.attacker.com/...`).
+        #   callable    - `f(url) -> bool`
+        if not url or not isinstance(url, str):
+            return False
+        if any(ord(c) < 0x20 or ord(c) == 0x7F for c in url):
+            return False
+        try:
+            parsed = urlparse.urlparse(url)
+        except ValueError:
+            return False
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            return False
+        allowed = self.settings.cas_allowed_services
+        if allowed is None:
+            return parsed.netloc in (self.settings.cas_domains or [])
+        if callable(allowed):
+            try:
+                return bool(allowed(url))
+            except Exception:
+                return False
+        if not isinstance(allowed, (list, tuple)):
+            return False
+        origin = "%s://%s" % (parsed.scheme, parsed.netloc)
+        for entry in allowed:
+            if not isinstance(entry, str):
+                continue
+            if url == entry or origin == entry.rstrip("/"):
+                return True
+            if entry.endswith("/") and url.startswith(entry):
+                return True
+        return False
+
     def cas_login(
         self,
         next=DEFAULT,
@@ -2719,10 +2769,16 @@ class Auth(AuthAPI):
         response = current.response
         session = current.session
         db, table = self.db, self.table_cas()
-        session._cas_service = request.vars.service or session._cas_service
+        incoming_service = request.vars.service
+        if incoming_service is not None and not self._is_allowed_cas_service(
+            incoming_service
+        ):
+            raise HTTP(403, "service not allowed")
+        session._cas_service = incoming_service or session._cas_service
         if (
             request.env.http_host not in self.settings.cas_domains
             or not session._cas_service
+            or not self._is_allowed_cas_service(session._cas_service)
         ):
             raise HTTP(403, "not authorized")
 
@@ -2773,6 +2829,12 @@ class Auth(AuthAPI):
         renew = "renew" in request.vars
         row = table(ticket=ticket)
         success = False
+        if row and not self._is_allowed_cas_service(row.service):
+            # Refuse to validate a ticket whose stored service URL is no
+            # longer in the allowlist (e.g. allowlist tightened after the
+            # ticket was minted, or ticket forged in an older version).
+            row.delete_record()
+            row = None
         if row:
             userfield = (
                 self.settings.login_userfield or "username"


### PR DESCRIPTION
Fixes a CAS service validation flaw in `Auth.cas_login()` and `cas_validate()` where attacker-controlled `service` URLs could receive valid CAS service tickets.

Previously, `request.vars.service` was accepted without validation and later used as the redirect target after successful authentication. This allowed an attacker to obtain a valid CAS service ticket by directing a victim to:

`/user/cas/login?service=https://attacker.example/`

After authentication, the CAS provider redirected the victim to the attacker-controlled URL with a valid `ticket=ST-...` appended, allowing ticket replay against relying parties that trust the provider.

## Changes

### CAS service allowlist

Added a new `cas_allowed_services` setting to `Auth.default_settings`.

Supported forms:

* `None`

  * Default behavior
  * Denies external services
  * Allows only services whose host matches `cas_domains`

* `list` / `tuple`

  * Exact URL match
  * Exact origin match (`scheme://host[:port]`)
  * Prefix match only for entries ending in `/`

* `callable`

  * Custom validation logic (`f(url) -> bool`)

* Added `_is_allowed_cas_service()` helper to centralize service validation.


## Tests

Adds comprehensive regression coverage for:

* Default-deny external services
* Same-host allowance
* Exact/origin/prefix allowlist behavior
* Callable allowlists
* Rejection of non-http(s) schemes
* CRLF and NUL injection rejection
* Regression test for attacker-controlled redirect/ticket exfiltration
* Session poisoning prevention
* Ticket purge on validation failure