### PR TITLE
Reject invalid HTTP ranges before generating 206 responses

### DIFF
--- a/gluon/streamer.py
+++ b/gluon/streamer.py
@@ -91,6 +91,9 @@ def stream_file_or_304_or_206(
             if not stop_items or int(stop_items[0]) > fsize - 1:
                 stop_items = [fsize - 1]
             part = (int(start_items[0]), int(stop_items[0]), fsize)
+            if part[0] > part[1] or part[0] >= fsize:
+                headers["Content-Range"] = "bytes */%i" % fsize
+                raise HTTP(416, **headers)
             bytes = part[1] - part[0] + 1
             try:
                 stream = open(static_file, "rb")

--- a/gluon/streamer.py
+++ b/gluon/streamer.py
@@ -91,7 +91,7 @@ def stream_file_or_304_or_206(
             if not stop_items or int(stop_items[0]) > fsize - 1:
                 stop_items = [fsize - 1]
             part = (int(start_items[0]), int(stop_items[0]), fsize)
-            if part[0] > part[1] or part[0] >= fsize:
+            if part[0] > part[1]:
                 headers["Content-Range"] = "bytes */%i" % fsize
                 raise HTTP(416, **headers)
             bytes = part[1] - part[0] + 1

--- a/gluon/tests/test_globals.py
+++ b/gluon/tests/test_globals.py
@@ -7,12 +7,16 @@
 
 
 import re
+import os
+import tempfile
 import unittest
 from io import BytesIO
 
 from gluon.html import XML, URL
 from gluon.globals import Request, Response, Session
+from gluon.http import HTTP
 from gluon.rewrite import regex_url_in
+from gluon.streamer import stream_file_or_304_or_206
 
 
 def setup_clean_session():
@@ -464,6 +468,40 @@ class testResponse(unittest.TestCase):
             response.headers["Content-Disposition"],
             'attachment; filename="caf%C3%A9.txt"',
         )
+
+    def test_stream_file_range(self):
+        fd, path = tempfile.mkstemp()
+        try:
+            os.write(fd, b"0123456789")
+            os.close(fd)
+            request = Request(env={})
+            request.env.http_if_modified_since = None
+            request.env.http_accept_encoding = ""
+            request.env.web2py_use_wsgi_file_wrapper = False
+
+            # Invalid ranges -> 416
+            for r in ["bytes=8-3", "bytes=999-", "bytes=10-10"]:
+                request.env.http_range = r
+                with self.assertRaises(HTTP) as ctx:
+                    stream_file_or_304_or_206(path, request=request, headers={})
+                self.assertEqual(ctx.exception.status, 416)
+                self.assertEqual(ctx.exception.headers.get("Content-Range"), "bytes */10")
+
+            # Valid range -> 206
+            request.env.http_range = "bytes=0-4"
+            with self.assertRaises(HTTP) as ctx:
+                stream_file_or_304_or_206(path, request=request, headers={})
+            self.assertEqual(ctx.exception.status, 206)
+            self.assertEqual(ctx.exception.headers.get("Content-Range"), "bytes 0-4/10")
+            self.assertEqual(ctx.exception.headers.get("Content-Length"), "5")
+
+        finally:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            if os.path.exists(path):
+                os.remove(path)
 
     def test_include_meta(self):
         response = Response()


### PR DESCRIPTION
## Summary

Fixes invalid HTTP Range handling in `stream_file_or_304_or_206()` where malformed or unsatisfiable ranges could generate invalid `206 Partial Content` responses.

Examples before this change:

* `Range: bytes=8-3`
* `Range: bytes=999-`

could produce responses with:

* impossible `Content-Range` values
* negative `Content-Length` values

## Changes

* Validate normalized byte ranges before generating a `206` response
* Return `416 Range Not Satisfiable` for:

  * reversed ranges (`start > end`)
  * ranges starting beyond EOF
* Include RFC-style:

  ```http
  Content-Range: bytes */<size>
  ```

  in `416` responses

## Tests

Added regression coverage for:

* reversed ranges (`bytes=8-3`)
* out-of-bounds ranges (`bytes=999-`, `bytes=10-10`)
* valid range requests still returning correct `206` responses
