### PR TITLE
Change LATEX image source to codecogs.com

### DIFF
--- a/gluon/contrib/markmin/markmin2html.py
+++ b/gluon/contrib/markmin/markmin2html.py
@@ -550,7 +550,8 @@ html_colors = [
 META = "\x06"
 LINK = "\x07"
 DISABLED_META = "\x08"
-LATEX = '<img src="http://chart.apis.google.com/chart?cht=tx&chl=%s" />'
+#LATEX = '<img src="http://chart.apis.google.com/chart?cht=tx&chl=%s" />'
+LATEX = '<img src="https://latex.codecogs.com/png.latex?%s" />' 
 regex_URL = re.compile(
     r"@/(?P<a>\w*)/(?P<c>\w*)/(?P<f>\w*(\.\w+)?)(/(?P<args>[\w\.\-/]+))?"
 )


### PR DESCRIPTION
LATEX image uses the deprecated Google Charts API. The fix is to update it to use a working LaTeX rendering service like CodeCogs.