### PR TITLE
Harden tar extraction path validation during unpacking

### DIFF
--- a/gluon/fileutils.py
+++ b/gluon/fileutils.py
@@ -213,11 +213,42 @@ def cleanpath(path):
     return path
 
 
+def _is_within_path(target, root):
+    return target == root or target.startswith(root + os.sep)
+
+
 def _extractall(filename, path=".", members=None):
+    path = os.path.abspath(path)
     tar = tarfile.TarFile(filename, "r")
-    ret = tar.extractall(path, members)
-    tar.close()
-    return ret
+    try:
+        safe_members = []
+        for member in members or tar.getmembers():
+            # Check for path traversal and absolute paths
+            target = os.path.abspath(os.path.join(path, member.name))
+            if os.path.isabs(member.name) or not _is_within_path(target, path):
+                raise RuntimeError("Attempted path traversal in tar file")
+
+            # Check for unsafe special files (devices, FIFOs)
+            if member.isdev() or member.isfifo():
+                raise RuntimeError("Attempted unsafe special file in tar file")
+
+            # Check for symlinks/hardlinks escaping extraction root
+            if member.issym():
+                link_target = member.linkname
+                if not os.path.isabs(link_target):
+                    link_target = os.path.join(os.path.dirname(target), link_target)
+                link_target = os.path.abspath(link_target)
+                if not _is_within_path(link_target, path):
+                    raise RuntimeError("Attempted path traversal in tar file")
+            elif member.islnk():
+                link_target = os.path.abspath(os.path.join(path, member.linkname))
+                if not _is_within_path(link_target, path):
+                    raise RuntimeError("Attempted path traversal in tar file")
+
+            safe_members.append(member)
+        return tar.extractall(path, safe_members)
+    finally:
+        tar.close()
 
 
 def tar(file, dir, expression="^.+$", filenames=None, exclude_content_from=None):

--- a/gluon/tests/test_fileutils.py
+++ b/gluon/tests/test_fileutils.py
@@ -2,11 +2,13 @@
 # -*- coding: utf-8 -*-
 
 import datetime
+import io
 import os
+import tarfile
 import tempfile
 import unittest
 
-from gluon.fileutils import fix_newlines, get_session, parse_version, set_session
+from gluon.fileutils import fix_newlines, get_session, parse_version, set_session, untar
 from gluon.storage import Storage, load_storage, save_storage
 
 
@@ -35,6 +37,101 @@ class TestFileUtils(unittest.TestCase):
 
     def test_fix_newlines(self):
         fix_newlines(os.path.dirname(os.path.abspath(__file__)))
+
+    def _make_tar(self, tarname, members):
+        with tarfile.open(tarname, "w") as tar:
+            for member in members:
+                tar.addfile(member, io.BytesIO(b"test"))
+
+    def _regular_member(self, name):
+        member = tarfile.TarInfo(name)
+        member.size = 4
+        return member
+
+    def test_untar_extracts_safe_members(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tarname = os.path.join(tmpdir, "safe.tar")
+            extract_to = os.path.join(tmpdir, "app")
+            os.mkdir(extract_to)
+            self._make_tar(tarname, [self._regular_member("models/db.py")])
+
+            untar(tarname, extract_to)
+
+            with open(os.path.join(extract_to, "models", "db.py"), "rb") as stream:
+                self.assertEqual(stream.read(), b"test")
+
+    def test_untar_extracts_safe_symlink(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tarname = os.path.join(tmpdir, "safe_link.tar")
+            extract_to = os.path.join(tmpdir, "app")
+            os.mkdir(extract_to)
+            member = tarfile.TarInfo("models/link")
+            member.type = tarfile.SYMTYPE
+            member.linkname = "db.py"
+
+            with tarfile.open(tarname, "w") as tar:
+                tar.addfile(self._regular_member("models/db.py"), io.BytesIO(b"test"))
+                tar.addfile(member)
+
+            try:
+                untar(tarname, extract_to)
+            except OSError:
+                self.skipTest("Symlink extraction requires additional privileges")
+
+            # Verify extraction if skip didn't trigger
+            if os.path.islink(os.path.join(extract_to, "models", "link")):
+                self.assertTrue(os.path.exists(os.path.join(extract_to, "models", "link")))
+
+    def test_untar_rejects_parent_traversal_member(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tarname = os.path.join(tmpdir, "traversal.tar")
+            extract_to = os.path.join(tmpdir, "app")
+            os.mkdir(extract_to)
+            self._make_tar(tarname, [self._regular_member("../outside.py")])
+
+            with self.assertRaises(RuntimeError):
+                untar(tarname, extract_to)
+            self.assertFalse(os.path.exists(os.path.join(tmpdir, "outside.py")))
+
+    def test_untar_rejects_absolute_member(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tarname = os.path.join(tmpdir, "absolute.tar")
+            extract_to = os.path.join(tmpdir, "app")
+            os.mkdir(extract_to)
+            member_name = os.path.join(tmpdir, "outside.py")
+            self._make_tar(tarname, [self._regular_member(member_name)])
+
+            with self.assertRaises(RuntimeError):
+                untar(tarname, extract_to)
+
+    def test_untar_rejects_escaping_symlink(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tarname = os.path.join(tmpdir, "link.tar")
+            extract_to = os.path.join(tmpdir, "app")
+            os.mkdir(extract_to)
+            member = tarfile.TarInfo("models/link")
+            member.type = tarfile.SYMTYPE
+            member.linkname = "../../outside.py"
+
+            with tarfile.open(tarname, "w") as tar:
+                tar.addfile(member)
+
+            with self.assertRaises(RuntimeError):
+                untar(tarname, extract_to)
+
+    def test_untar_rejects_special_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tarname = os.path.join(tmpdir, "special.tar")
+            extract_to = os.path.join(tmpdir, "app")
+            os.mkdir(extract_to)
+            member = tarfile.TarInfo("models/fifo")
+            member.type = tarfile.FIFOTYPE
+
+            with tarfile.open(tarname, "w") as tar:
+                tar.addfile(member)
+
+            with self.assertRaises(RuntimeError):
+                untar(tarname, extract_to)
 
     def _make_session_request(self, application, folder, session_id, other_application="admin"):
         return Storage(

--- a/gluon/tests/test_fileutils.py
+++ b/gluon/tests/test_fileutils.py
@@ -119,6 +119,21 @@ class TestFileUtils(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 untar(tarname, extract_to)
 
+    def test_untar_rejects_escaping_hardlink(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tarname = os.path.join(tmpdir, "hardlink.tar")
+            extract_to = os.path.join(tmpdir, "app")
+            os.mkdir(extract_to)
+            member = tarfile.TarInfo("models/link")
+            member.type = tarfile.LNKTYPE
+            member.linkname = "../outside.py"
+
+            with tarfile.open(tarname, "w") as tar:
+                tar.addfile(member)
+
+            with self.assertRaises(RuntimeError):
+                untar(tarname, extract_to)
+
     def test_untar_rejects_special_file(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             tarname = os.path.join(tmpdir, "special.tar")


### PR DESCRIPTION
## Summary

Add boundary validation for tar archive extraction during unpacking.

This updates `_extractall()` in `gluon.fileutils` to validate archive members before extraction and reject unsafe entries that escape the intended extraction root.

## Changes

* reject archive members using `..` traversal paths
* reject absolute archive member paths
* reject symlink targets escaping the extraction root
* reject hardlink targets escaping the extraction root
* reject unsafe special file members such as FIFOs/devices
* validate all members before extraction begins

## Notes

* keeps existing extraction behavior for valid archives
* keeps validation centralized in the shared tar extraction helper
* focused only on extraction boundary enforcement without changing unrelated archive behavior