### PR TITLE
sibling-prefix boundary validation in static file routing

### DIFF
--- a/gluon/rewrite.py
+++ b/gluon/rewrite.py
@@ -727,7 +727,7 @@ def regex_url_in(request, environ):
             global_settings.applications_parent, "applications", application, "static"
         )
         static_file = os.path.abspath(pjoin(static_folder, filename))
-        if not static_file.startswith(static_folder):
+        if not (static_file == static_folder or static_file.startswith(static_folder + os.sep)):
             invalid_url(routes)
         return (static_file, version, environ)
     else:

--- a/gluon/tests/test_routes.py
+++ b/gluon/tests/test_routes.py
@@ -86,6 +86,18 @@ class TestRoutes(unittest.TestCase):
             filter_url("http://domain.com/welcome/static/path/to/static"),
             norm_root("%s/applications/welcome/static/path/to/static" % root),
         )
+        self.assertEqual(
+            filter_url("http://domain.com/welcome/static/css/deep/style.css"),
+            norm_root("%s/applications/welcome/static/css/deep/style.css" % root),
+        )
+        sibling_static = os.path.join(root, "applications", "welcome", "static_evil")
+        if not os.path.exists(sibling_static):
+            os.mkdir(sibling_static)
+        self.assertRaises(
+            HTTP,
+            filter_url,
+            "http://domain.com/welcome/static/_/../../static_evil/secret.txt",
+        )
         # no more necessary since explcit check for directory traversal attacks
         """
         self.assertRaises(HTTP, filter_url, 'http://domain.com/welcome/static/bad/path/to/st~tic')


### PR DESCRIPTION
## Summary

Fix a boundary-validation issue in `gluon/rewrite.py::regex_url_in` where static file paths were validated using `startswith()` without enforcing a directory boundary.

A request containing a valid intermediate segment followed by traversal (for example `_/../../static_evil/...`) could normalize to a sibling directory sharing the `static` prefix and still pass the original check.

## Root Cause

The previous validation used:

```python
static_file.startswith(static_folder)
```

This allowed sibling-prefixed paths such as:

```text
/applications/welcome/static_evil/...
```

to incorrectly match:

```text
/applications/welcome/static
```

after path normalization.

## Fix

The containment check now explicitly requires either:

* an exact directory match, or
* a properly bounded descendant path using `os.sep`.

```python
static_file == static_folder
or static_file.startswith(static_folder + os.sep)
```

## Tests

Added regression coverage for:

* reachable sibling-prefix traversal via:

  * `/_/../../static_evil/...`
* valid nested static file routing to ensure normal behavior remains unchanged.
