### PR TITLE
selected-directory boundaries in admin file manager writes

### DIFF
--- a/applications/admin/controllers/default.py
+++ b/applications/admin/controllers/default.py
@@ -15,6 +15,7 @@ import io
 import importlib
 
 from gluon.admin import *
+from gluon.admin import _check_app_path, _is_within_root, _join_app_path
 from gluon.fileutils import abspath, read_file, write_file
 from gluon.restricted import safe_load, safe_loads, TicketStorage
 from gluon.utils import web2py_uuid
@@ -77,10 +78,6 @@ def log_progress(app, mode='EDIT', filename=None, progress=0):
     if filename:
         safe_open(progress_file, 'a').write(
             '[%s] %s %s: %s\n' % (now, mode, filename, progress))
-
-
-def _is_within_root(path, root):
-    return path == root or path.startswith(root + os.sep)
 
 
 def safe_open(a, b):
@@ -1378,6 +1375,7 @@ def create_file():
                 request.vars.location += request.vars.dir + '/'
             app = get_app(name=request.vars.location.split('/')[0])
             path = apath(request.vars.location, r=request)
+        path = _check_app_path(request, app, path)
         filename = re.sub(r'[^\w./-]+', '_', request.vars.filename)
         if path[-7:] == '/rules/':
             # Handle plural rules files
@@ -1413,7 +1411,7 @@ def create_file():
                 raise SyntaxError
             if not filename[-3:] == '.py':
                 filename += '.py'
-            path = os.path.join(apath(app, r=request), 'languages', filename)
+            path = _join_app_path(request, app, os.path.join(apath(app, r=request), 'languages'), filename)
             if not os.path.exists(path):
                 safe_write(path, '')
             # create language xx[-yy].py file:
@@ -1492,7 +1490,7 @@ def create_file():
         else:
             redirect(request.vars.sender + anchor)
 
-        full_filename = os.path.join(path, filename)
+        full_filename = _join_app_path(request, app, path, filename)
         dirpath = os.path.dirname(full_filename)
 
         if not os.path.exists(dirpath):
@@ -1598,7 +1596,7 @@ def upload_file():
         if path[-11:] == '/languages/' and not filename[-3:] == '.py':
             filename += '.py'
 
-        filename = os.path.join(path, filename)
+        filename = _join_app_path(request, app, path, filename)
         dirpath = os.path.dirname(filename)
 
         if not os.path.exists(dirpath):

--- a/applications/admin/controllers/default.py
+++ b/applications/admin/controllers/default.py
@@ -15,7 +15,7 @@ import io
 import importlib
 
 from gluon.admin import *
-from gluon.admin import _check_app_path, _is_within_root, _join_app_path
+from gluon.admin import check_app_path, is_within_root, join_app_path
 from gluon.fileutils import abspath, read_file, write_file
 from gluon.restricted import safe_load, safe_loads, TicketStorage
 from gluon.utils import web2py_uuid
@@ -97,7 +97,7 @@ def safe_open(a, b):
     web2py_deposit_root = os.path.join(up(web2py_apps_root), 'deposit')
 
     allowed_roots = [web2py_apps_root, web2py_deposit_root]
-    if not any(_is_within_root(a_for_check, root) for root in allowed_roots):
+    if not any(is_within_root(a_for_check, root) for root in allowed_roots):
         raise HTTP(403)
 
     if 'b' in b:
@@ -128,7 +128,7 @@ def get_app(name=None):
         path = apath(app, r=request)
         web2py_apps_root = os.path.abspath(up(request.folder))
         path_abs = os.path.abspath(path)
-        if not _is_within_root(path_abs, web2py_apps_root):
+        if not is_within_root(path_abs, web2py_apps_root):
             session.flash = T('App does not exist or you are not authorized')
             redirect(URL('site'))
         if (os.path.exists(path) and
@@ -1375,7 +1375,7 @@ def create_file():
                 request.vars.location += request.vars.dir + '/'
             app = get_app(name=request.vars.location.split('/')[0])
             path = apath(request.vars.location, r=request)
-        path = _check_app_path(request, app, path)
+        path = check_app_path(request, app, path)
         filename = re.sub(r'[^\w./-]+', '_', request.vars.filename)
         if path[-7:] == '/rules/':
             # Handle plural rules files
@@ -1411,7 +1411,7 @@ def create_file():
                 raise SyntaxError
             if not filename[-3:] == '.py':
                 filename += '.py'
-            path = _join_app_path(request, app, os.path.join(apath(app, r=request), 'languages'), filename)
+            path = join_app_path(request, app, os.path.join(apath(app, r=request), 'languages'), filename)
             if not os.path.exists(path):
                 safe_write(path, '')
             # create language xx[-yy].py file:
@@ -1490,7 +1490,7 @@ def create_file():
         else:
             redirect(request.vars.sender + anchor)
 
-        full_filename = _join_app_path(request, app, path, filename)
+        full_filename = join_app_path(request, app, path, filename)
         dirpath = os.path.dirname(full_filename)
 
         if not os.path.exists(dirpath):
@@ -1535,7 +1535,7 @@ def listfiles(app, dir, regexp=r'.*\.py$'):
     path = apath('%(app)s/%(dir)s/' % {'app': app, 'dir': dir}, r=request)
     web2py_apps_root = os.path.abspath(up(request.folder))
     path_abs = os.path.abspath(path)
-    if not _is_within_root(path_abs, web2py_apps_root):
+    if not is_within_root(path_abs, web2py_apps_root):
         return []
     files = sorted(
         listdir(path, regexp))
@@ -1596,7 +1596,7 @@ def upload_file():
         if path[-11:] == '/languages/' and not filename[-3:] == '.py':
             filename += '.py'
 
-        filename = _join_app_path(request, app, path, filename)
+        filename = join_app_path(request, app, path, filename)
         dirpath = os.path.dirname(filename)
 
         if not os.path.exists(dirpath):

--- a/gluon/admin.py
+++ b/gluon/admin.py
@@ -32,6 +32,7 @@ from gluon.fileutils import (
     w2p_unpack_plugin,
     write_file,
 )
+from gluon.http import HTTP
 from gluon.restricted import RestrictedError
 from gluon.settings import global_settings
 
@@ -71,6 +72,26 @@ def apath(path="", r=None):
         opath = up(opath)
         path = path[3:]
     return os.path.join(opath, path).replace("\\", "/")
+
+
+def _is_within_root(path, root):
+    return path == root or path.startswith(root + os.sep)
+
+
+def _check_app_path(request, app, path):
+    app_root = os.path.abspath(apath(app, r=request))
+    path = os.path.abspath(os.path.normpath(path))
+    if not _is_within_root(path, app_root):
+        raise HTTP(403)
+    return path
+
+
+def _join_app_path(request, app, base, *paths):
+    base = _check_app_path(request, app, base)
+    path = os.path.abspath(os.path.normpath(os.path.join(base, *paths)))
+    if not _is_within_root(path, base):
+        raise HTTP(403)
+    return path
 
 
 def app_pack(app, request, raise_ex=False, filenames=None):

--- a/gluon/admin.py
+++ b/gluon/admin.py
@@ -74,22 +74,22 @@ def apath(path="", r=None):
     return os.path.join(opath, path).replace("\\", "/")
 
 
-def _is_within_root(path, root):
+def is_within_root(path, root):
     return path == root or path.startswith(root + os.sep)
 
 
-def _check_app_path(request, app, path):
+def check_app_path(request, app, path):
     app_root = os.path.abspath(apath(app, r=request))
     path = os.path.abspath(os.path.normpath(path))
-    if not _is_within_root(path, app_root):
+    if not is_within_root(path, app_root):
         raise HTTP(403)
     return path
 
 
-def _join_app_path(request, app, base, *paths):
-    base = _check_app_path(request, app, base)
+def join_app_path(request, app, base, *paths):
+    base = check_app_path(request, app, base)
     path = os.path.abspath(os.path.normpath(os.path.join(base, *paths)))
-    if not _is_within_root(path, base):
+    if not is_within_root(path, base):
         raise HTTP(403)
     return path
 

--- a/gluon/tests/test_appadmin.py
+++ b/gluon/tests/test_appadmin.py
@@ -299,6 +299,52 @@ class TestAppAdmin(unittest.TestCase):
         self.assertFalse(is_path_allowed('/tmp/malicious'),
                         "Should block temp directory access")
 
+    def test_admin_file_manager_boundaries(self):
+        """Test that admin file manager enforces app boundaries."""
+        from gluon.admin import _join_app_path
+        from gluon.globals import Request
+        from gluon.http import HTTP
+        request = Request(env={})
+        request.folder = os.path.abspath('applications/admin')
+
+        web2py_apps_root = os.path.abspath('applications')
+        app_root = os.path.join(web2py_apps_root, "welcome")
+
+        base = os.path.join(app_root, "views")
+        res = _join_app_path(request, "welcome", base, "default/index.html")
+        self.assertTrue(res.endswith(os.path.join("welcome", "views", "default", "index.html")))
+
+        static_base = os.path.join(app_root, "static")
+        static_res = _join_app_path(request, "welcome", static_base, "js/app.js")
+        self.assertTrue(static_res.endswith(os.path.join("welcome", "static", "js", "app.js")))
+
+        self.assertRaises(
+            HTTP,
+            _join_app_path,
+            request,
+            "welcome",
+            os.path.join(app_root, "views"),
+            "../controllers/default.py"
+        )
+
+        self.assertRaises(
+            HTTP,
+            _join_app_path,
+            request,
+            "welcome",
+            os.path.join(app_root, "static"),
+            "../../admin/controllers/default.py"
+        )
+
+        self.assertRaises(
+            HTTP,
+            _join_app_path,
+            request,
+            "welcome",
+            os.path.join(app_root, "static"),
+            "/tmp/pwn.py"
+        )
+
     def test_safe_eval_expression_blocks_function_calls(self):
         """Test that safe_eval_expression blocks arbitrary function calls (RCE)"""
         self.assertUnsafe('__import__("os").system("id")')

--- a/gluon/tests/test_appadmin.py
+++ b/gluon/tests/test_appadmin.py
@@ -301,7 +301,7 @@ class TestAppAdmin(unittest.TestCase):
 
     def test_admin_file_manager_boundaries(self):
         """Test that admin file manager enforces app boundaries."""
-        from gluon.admin import _join_app_path
+        from gluon.admin import join_app_path
         from gluon.globals import Request
         from gluon.http import HTTP
         request = Request(env={})
@@ -311,16 +311,16 @@ class TestAppAdmin(unittest.TestCase):
         app_root = os.path.join(web2py_apps_root, "welcome")
 
         base = os.path.join(app_root, "views")
-        res = _join_app_path(request, "welcome", base, "default/index.html")
+        res = join_app_path(request, "welcome", base, "default/index.html")
         self.assertTrue(res.endswith(os.path.join("welcome", "views", "default", "index.html")))
 
         static_base = os.path.join(app_root, "static")
-        static_res = _join_app_path(request, "welcome", static_base, "js/app.js")
+        static_res = join_app_path(request, "welcome", static_base, "js/app.js")
         self.assertTrue(static_res.endswith(os.path.join("welcome", "static", "js", "app.js")))
 
         self.assertRaises(
             HTTP,
-            _join_app_path,
+            join_app_path,
             request,
             "welcome",
             os.path.join(app_root, "views"),
@@ -329,7 +329,7 @@ class TestAppAdmin(unittest.TestCase):
 
         self.assertRaises(
             HTTP,
-            _join_app_path,
+            join_app_path,
             request,
             "welcome",
             os.path.join(app_root, "static"),
@@ -338,7 +338,7 @@ class TestAppAdmin(unittest.TestCase):
 
         self.assertRaises(
             HTTP,
-            _join_app_path,
+            join_app_path,
             request,
             "welcome",
             os.path.join(app_root, "static"),


### PR DESCRIPTION
## Summary

This change tightens admin file-manager path handling so file creation and upload operations remain constrained to the selected application directory.

## What Changed

- Added centralized path validation helpers:
  - `_check_app_path()`
  - `_join_app_path()`

- Validated that selected locations remain inside the authorized application root.

- Replaced direct path joins in `create_file()` and `upload_file()` with normalized boundary-checked joins.

- Preserved valid nested paths such as:
  - `views/default/index.html`
  - `static/js/app.js`

- Blocked traversal attempts that escape the selected directory or application boundary.

## Examples Now Rejected

- `../controllers/default.py`
- `../../admin/controllers/default.py`
- absolute path injection such as `/tmp/pwn.py`

## Tests

Added regression coverage that exercises the real admin controller helpers and verifies:

- valid nested paths continue to work
- traversal outside the selected directory is rejected
- cross-application escapes are rejected
- absolute-path injections are rejected

## Result

File-manager writes are now consistently normalized and constrained to the selected application directory instead of relying only on the broader `applications/` root boundary.