### PR TITLE
Prevent sibling-prefix traversal in static file routing

### DIFF
--- a/gluon/rewrite.py
+++ b/gluon/rewrite.py
@@ -723,11 +723,12 @@ def regex_url_in(request, environ):
         items = filename.split("/", 1)
         if REGEX_VERSION.match(items[0]):
             version, filename = items
-        static_folder = pjoin(
+        static_folder = os.path.abspath(pjoin(
             global_settings.applications_parent, "applications", application, "static"
-        )
+        ))
         static_file = os.path.abspath(pjoin(static_folder, filename))
-        if not (static_file == static_folder or static_file.startswith(static_folder + os.sep)):
+        if not (static_file == static_folder
+                or static_file.startswith(static_folder + os.sep)):
             invalid_url(routes)
         return (static_file, version, environ)
     else:

--- a/gluon/tests/test_routes.py
+++ b/gluon/tests/test_routes.py
@@ -503,3 +503,29 @@ routes_out = [
             filter_url("http://domain.com/index/a%20bc", env=True).request_uri,
             "/init/default/index/a bc",
         )
+
+    def test_static_traversal_prefix_sibling(self):
+        """A sibling directory whose name shares the 'static' prefix must
+        not be reachable from /<app>/static/... — the boundary check must
+        enforce a path-separator after the static root, not bare startswith.
+
+        REGEX_URL forces the first path segment after /<app>/static/ to
+        match \\w+, so the traversal is hidden behind a valid-looking
+        filename. Without an os.sep boundary in the safety check, the
+        abspath result <root>/applications/welcome/staticbackup/secret.txt
+        passes startswith(<root>/applications/welcome/static) and the
+        file is served outside the static root."""
+        load(data="")
+        sibling = os.path.join(root, "applications", "welcome", "staticbackup")
+        os.mkdir(sibling)
+        try:
+            with open(os.path.join(sibling, "secret.txt"), "w") as fp:
+                fp.write("secret")
+            self.assertRaises(
+                HTTP,
+                filter_url,
+                "http://domain.com/welcome/static/"
+                "x.txt/../../staticbackup/secret.txt",
+            )
+        finally:
+            shutil.rmtree(sibling)


### PR DESCRIPTION
Harden static-file path validation in `rewrite.py` to prevent prefix-confusion directory traversal attacks that could escape the
application static root.

The previous validation used a naive `startswith(static_folder)` check, which incorrectly treated sibling directories sharing the same prefix (e.g. `staticbackup`) as descendants of the intended `static` directory.

## Changes

### Static path validation hardening

Updated static-file routing validation to:

- Normalize `static_folder` with `os.path.abspath()` before comparison
- Enforce a path-separator boundary when validating descendants:

    static_file.startswith(static_folder + os.sep)

This ensures only files truly located inside the static directory are
accepted.

The validation now correctly rejects sibling-prefix paths such as:

    /applications/welcome/staticbackup/...

when accessed through traversal sequences routed via `/static/...`.

## Tests

Added regression coverage in
`gluon/tests/test_routes.py`:

### `test_static_traversal_prefix_sibling`

Verifies that a sibling directory whose name shares the `static`
prefix cannot be accessed through traversal sequences like:

    x.txt/../../staticbackup/secret.txt

The test demonstrates the exact prefix-confusion scenario fixed by this patch and ensures the separator-boundary validation remains enforced.