### PR TITLE
Fix XSS attribute breakout in sanitizer

### DIFF
--- a/gluon/html.py
+++ b/gluon/html.py
@@ -27,6 +27,9 @@ from urllib.parse import quote as urllib_quote
 from urllib.parse import urlencode
 
 from yatl import sanitizer
+# Importing gluon.sanitizer installs an XSS-hardening patch on
+# yatl.sanitizer.XssCleaner; do not remove.
+from gluon import sanitizer as _gluon_sanitizer  # noqa: F401
 from gluon import decoder
 from gluon.highlight import highlight
 from gluon.storage import Storage

--- a/gluon/sanitizer.py
+++ b/gluon/sanitizer.py
@@ -70,4 +70,21 @@ def _safe_handle_starttag(self, tag, attrs):
         self.open_tags.insert(0, tag)
 
 
-XssCleaner.handle_starttag = _safe_handle_starttag
+def _yatl_is_vulnerable():
+    """Return True if yatl's XssCleaner has the href attribute-breakout bug.
+
+    Tests with the known exploit payload so the patch is skipped automatically
+    once yatl fixes the bug upstream.
+    """
+    probe = XssCleaner(
+        permitted_tags=["a"],
+        allowed_attributes={"a": ["href"]},
+    )
+    result = probe.strip(
+        '<a href="http://x.com/&quot; onclick=&quot;alert(1)">x</a>'
+    )
+    return "onclick" in result
+
+
+if _yatl_is_vulnerable():
+    XssCleaner.handle_starttag = _safe_handle_starttag

--- a/gluon/sanitizer.py
+++ b/gluon/sanitizer.py
@@ -1,1 +1,73 @@
-from yatl.sanitizer import sanitize
+"""
+gluon.sanitizer — XSS defense exposed by web2py.
+
+Delegates to yatl.sanitizer but installs a hardening patch on
+yatl.sanitizer.XssCleaner.handle_starttag before re-exporting
+sanitize().
+
+Background
+----------
+yatl's XssCleaner emits values of url-bearing attributes (href, src,
+background) without escaping:
+
+    bt += ' %s="%s"' % (attribute, attrs[attribute])
+
+HTMLParser decodes character references (including ``&quot;`` -> ``"``)
+inside attribute values, so an attacker can supply
+
+    <a href="https://example.com/&quot; onclick=&quot;alert(1)">x</a>
+
+and have the resulting ``"`` close the href attribute on the way out,
+injecting an event-handler attribute (XSS). Every other attribute
+already goes through xml.sax.saxutils.quoteattr; this module makes the
+url-bearing branch do the same.
+
+The patch is applied at the XssCleaner.handle_starttag class method, so
+every existing call site — gluon.sanitizer.sanitize, gluon.html.XML
+(sanitize=True), yatl.helpers.XML(sanitize=True) — picks it up after
+this module has been imported. gluon.html imports this module to make
+that ordering explicit.
+"""
+from xml.sax.saxutils import quoteattr
+
+from yatl.sanitizer import XssCleaner, sanitize, xmlescape
+
+__all__ = ["sanitize"]
+
+
+def _safe_handle_starttag(self, tag, attrs):
+    if tag not in self.permitted_tags:
+        self.in_disallowed.append(True)
+        if not self.strip_disallowed:
+            self.result += xmlescape("<%s>" % tag)
+        return
+    self.in_disallowed.append(False)
+    bt = "<" + tag
+    if tag in self.allowed_attributes:
+        attrs = dict(attrs)
+        self.allowed_attributes_here = [
+            x
+            for x in self.allowed_attributes[tag]
+            if x in attrs and len(attrs[x]) > 0
+        ]
+        for attribute in self.allowed_attributes_here:
+            if attribute in ("href", "src", "background"):
+                if self.url_is_acceptable(attrs[attribute]):
+                    bt += " %s=%s" % (attribute, quoteattr(attrs[attribute]))
+            else:
+                bt += " %s=%s" % (
+                    xmlescape(attribute),
+                    quoteattr(attrs[attribute]),
+                )
+    # deal with <a> without href and <img> without src
+    if bt == "<a" or bt == "<img":
+        return
+    if tag in self.requires_no_close:
+        bt += "/"
+    bt += ">"
+    self.result += bt
+    if tag not in self.requires_no_close:
+        self.open_tags.insert(0, tag)
+
+
+XssCleaner.handle_starttag = _safe_handle_starttag

--- a/gluon/tests/test_html.py
+++ b/gluon/tests/test_html.py
@@ -8,6 +8,7 @@
 import io
 import re
 import unittest
+from html.parser import HTMLParser
 
 from gluon.decoder import decoder
 from gluon.html import (ASSIGNJS, BEAUTIFY, BODY, BR, BUTTON, CAT, CENTER,
@@ -310,6 +311,36 @@ class TestBareHelpers(unittest.TestCase):
             XML("<p>Test</p><br/><p>Test</p><br/>", sanitize=True).xml(),
             XML("<p>Test</p><br/><p>Test</p><br/>").xml(),
         )
+        # sanitizer must not allow attribute-breakout XSS via
+        # entity-encoded quotes inside href/src/background. HTMLParser
+        # decodes &quot; into " in attribute values; the sanitizer must
+        # re-escape (or otherwise contain) those quotes when emitting
+        # the attribute, otherwise an attacker can inject extra
+        # attributes such as event handlers.
+        for raw in (
+            '<a href="https://example.com/&quot; onclick=&quot;alert(1)">x</a>',
+            '<a href="http://a.b/&quot; onmouseover=&quot;alert(1)">x</a>',
+            '<img src="http://a.b/&quot; onerror=&quot;alert(1)" alt="x">',
+            "<a href='http://a.b/&quot; onclick=&quot;alert(1)'>x</a>",
+        ):
+            cleaned = XML(raw, sanitize=True).xml()
+            seen_attrs = []
+
+            class _Spy(HTMLParser):
+                def handle_starttag(self, tag, attrs):
+                    seen_attrs.extend(name.lower() for name, _ in attrs)
+
+                handle_startendtag = handle_starttag
+
+            spy = _Spy()
+            spy.feed(cleaned)
+            for handler in (
+                "onclick", "onerror", "onmouseover", "onload",
+                "onfocus", "onmouseout",
+            ):
+                self.assertNotIn(handler, seen_attrs,
+                    "sanitize() leaked %s via attribute-breakout: %r"
+                    % (handler, cleaned))
         # basic flatten test
         self.assertEqual(XML("<p>Test</p>").flatten(), "<p>Test</p>")
         self.assertEqual(


### PR DESCRIPTION
## Summary

Fix a real XSS vulnerability in web2py’s sanitizer integration where attacker-controlled values in URL-bearing attributes (`href`, `src`, `background`) could break out of the attribute context and inject executable HTML attributes such as `onclick`.

The issue affected the documented:

- `gluon.sanitizer.sanitize`
- `XML(..., sanitize=True)`

APIs.

The root cause was inconsistent escaping behavior inside `yatl.sanitizer.XssCleaner.handle_starttag`: most attributes already used `xml.sax.saxutils.quoteattr`, but URL-bearing attributes were emitted using raw string interpolation.

Because `HTMLParser` decodes character references such as `&quot;` into literal `"`, attacker-controlled input like:

    <a href="https://example.com/&quot; onclick=&quot;alert(1)">x</a>

was sanitized into:

    <a href="https://example.com/" onclick="alert(1)">x</a>

creating a real executable event-handler attribute and enabling XSS.

After this patch, URL-bearing attributes are emitted using `quoteattr`, ensuring injected quotes remain safely contained inside the attribute value.

Example after fix:

    <a href='https://example.com/" onclick="alert(1)'>x</a>

`HTMLParser` correctly sees only a single `href` attribute.


## Changes

### `gluon/sanitizer.py`

- Replace the previous one-line re-export with a documented compatibility wrapper.
- Import `XssCleaner`, `sanitize`, and `xmlescape` from `yatl.sanitizer`.
- Install a hardened replacement for `XssCleaner.handle_starttag`.
- Route `href`, `src`, and `background` through `xml.sax.saxutils.quoteattr`.
- Preserve existing sanitizer behavior for non-URL attributes and disallowed tags.
- Add detailed inline documentation describing the vulnerability and exploit mechanics.

### `gluon/html.py`

- Explicitly import `gluon.sanitizer` during initialization.
- Ensure the sanitizer hardening patch is installed whenever `gluon.html` loads.
- Remove reliance on indirect import ordering or optional yatl integration paths.

### `gluon/tests/test_html.py`

Add regression tests covering attribute-breakout payloads using entity-encoded quotes.

The tests:

- Pass malicious payloads through `XML(..., sanitize=True)`.
- Parse the resulting HTML using `html.parser.HTMLParser`.
- Assert that no injected event-handler attributes (`onclick`, `onerror`, etc.) appear on sanitized output.
