### PR TITLE
Fix Form CSRF bypass caused by None formkey comparison

### DIFF
--- a/gluon/form.py
+++ b/gluon/form.py
@@ -1,3 +1,5 @@
+import hmac
+
 from gluon.dal import DAL
 from gluon.storage import Storage
 from gluon.utils import web2py_uuid
@@ -136,7 +138,7 @@ class Form(object):
             for field in table:
                 field.tablename = getattr(field, "tablename", formname)
 
-        if isinstance(record, (int, long, basestring)):
+        if isinstance(record, (int, str)):
             record_id = int(str(record))
             self.record = table[record_id]
         else:
@@ -170,8 +172,17 @@ class Form(object):
             # check for CSRF
             if csrf and self.formname in (current.session._formkeys or {}):
                 self.formkey = current.session._formkeys[self.formname]
-            # validate fields
-            if not csrf or post_vars._formkey == self.formkey:
+            submitted_formkey = post_vars._formkey
+            # validate fields. A missing/no-prior-form state must NOT pass CSRF:
+            # without an explicit identity check, both sides default to None and
+            # `None == None` would silently bypass the token check on the very
+            # first POST to a form the session has never issued.
+            csrf_ok = (
+                self.formkey is not None
+                and isinstance(submitted_formkey, str)
+                and hmac.compare_digest(submitted_formkey, self.formkey)
+            )
+            if not csrf or csrf_ok:
                 if not post_vars._delete:
                     for field in self.table:
                         if field.writable:

--- a/gluon/tests/__init__.py
+++ b/gluon/tests/__init__.py
@@ -8,6 +8,7 @@ from .test_contribs import *
 from .test_cron import *
 from .test_dal import *
 from .test_fileutils import *
+from .test_form import *
 from .test_globals import *
 from .test_html import *
 from .test_http import *

--- a/gluon/tests/test_form.py
+++ b/gluon/tests/test_form.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Unit tests for gluon.form.Form CSRF handling.
+
+Regression for a CSRF bypass: the prior `post_vars._formkey == self.formkey`
+check defaulted both sides to `None` when the session had never issued a key
+for this form, so the very first POST passed the CSRF check with no token.
+"""
+
+import unittest
+
+from gluon import current
+from gluon.dal import DAL, Field
+from gluon.form import Form
+from gluon.storage import Storage
+
+
+def _make_request(method, post_vars=None):
+    return Storage(
+        method=method,
+        post_vars=Storage(post_vars or {}),
+        folder="./",
+        application="test",
+    )
+
+
+class TestFormCSRF(unittest.TestCase):
+    def setUp(self):
+        self.db = DAL("sqlite:memory:")
+        self.db.define_table("thing", Field("name", "string"))
+        current.session = Storage()
+
+    def tearDown(self):
+        self.db.close()
+        current.__dict__.clear()
+
+    def test_csrf_bypass_when_no_prior_formkey(self):
+        # Session has a formkey for an unrelated form, never for "thing".
+        # Attacker POSTs with no _formkey at all.
+        current.session._formkeys = {"other": "some-prior-uuid"}
+        current.request = _make_request("POST", {"name": "attacker"})
+
+        form = Form(self.db.thing)
+
+        self.assertFalse(form.accepted)
+        self.assertEqual(self.db(self.db.thing).count(), 0)
+
+    def test_csrf_bypass_with_empty_session(self):
+        # Completely fresh session, no _formkeys dict at all.
+        current.request = _make_request("POST", {"name": "attacker"})
+
+        form = Form(self.db.thing)
+
+        self.assertFalse(form.accepted)
+        self.assertEqual(self.db(self.db.thing).count(), 0)
+
+    def test_csrf_rejects_none_formkey_param(self):
+        # Session has a real key issued for this form, but attacker omits the
+        # _formkey parameter. None must not match the stored UUID.
+        current.session._formkeys = {"thing": "issued-uuid-1234"}
+        current.request = _make_request("POST", {"name": "attacker"})
+
+        form = Form(self.db.thing)
+
+        self.assertFalse(form.accepted)
+
+    def test_csrf_rejects_wrong_formkey(self):
+        current.session._formkeys = {"thing": "issued-uuid-1234"}
+        current.request = _make_request(
+            "POST", {"name": "evil", "_formkey": "guessed-wrong"}
+        )
+
+        form = Form(self.db.thing)
+
+        self.assertFalse(form.accepted)
+
+    def test_csrf_accepts_matching_formkey(self):
+        current.session._formkeys = {"thing": "issued-uuid-1234"}
+        current.request = _make_request(
+            "POST", {"name": "legit", "_formkey": "issued-uuid-1234"}
+        )
+
+        form = Form(self.db.thing)
+
+        self.assertTrue(form.accepted)
+
+    def test_get_issues_formkey_then_post_accepts(self):
+        # GET renders the form and seeds the session key, POST then validates.
+        current.request = _make_request("GET")
+        rendered = Form(self.db.thing)
+        issued = rendered.formkey
+        self.assertIsNotNone(issued)
+
+        current.request = _make_request(
+            "POST", {"name": "legit", "_formkey": issued}
+        )
+        submitted = Form(self.db.thing)
+
+        self.assertTrue(submitted.accepted)
+
+    def test_csrf_disabled_allows_no_token(self):
+        # csrf=False is the explicit opt-out; behaviour must still let the
+        # request through.
+        current.request = _make_request("POST", {"name": "ok"})
+
+        form = Form(self.db.thing, csrf=False)
+
+        self.assertTrue(form.accepted)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes a CSRF validation bypass in `gluon/form.py` where a form submission could be accepted without a valid CSRF token when both the stored session formkey and submitted `_formkey` resolved to `None`.

Also updates outdated Python 2 type checks that caused `Form` initialization to fail on Python 3.

## Changes

### CSRF validation hardening
- Require `self.formkey` to be non-None
- Require submitted `_formkey` to be a string
- Replace direct equality comparison with `hmac.compare_digest()`
- Add inline documentation explaining the bypass condition

### Python 3 compatibility
Replace:
```python
(int, long, basestring)
```
with:
```python
(int, str)
```

## Security Impact

Previously, a first POST request to a form that had never issued a CSRF token in the current session could pass validation because:

    None == None

evaluated to `True`.

The updated logic ensures CSRF validation only succeeds when an actual issued token exists and matches securely.

## Tests

Added coverage for:

- no-prior-formkey bypass case
- empty-session bypass case
- missing token
- incorrect token
- valid token
- standard GET -> POST flow
- `csrf=False` opt-out behavior