### PR TITLE
Escape include file URLs before HTML attribute rendering

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -850,9 +850,9 @@ class Response(Storage):
                     tmpl = template_mapping.get(ext)
                 if tmpl:
                     if self._csp_enabled:
-                        s.append(tmpl % (self.nonce, item))
+                        s.append(tmpl % (self.nonce, xmlescape(item)))
                     else:
-                        s.append(tmpl % item)
+                        s.append(tmpl % xmlescape(item))
             elif isinstance(item, (list, tuple)):
                 f = item[0]
                 if self._csp_enabled:
@@ -864,9 +864,14 @@ class Response(Storage):
                         if isinstance(item[1], tuple):
                             s.append(tmpl % ((self.nonce,) + item[1]))
                         else:
-                            s.append(tmpl % (self.nonce, item[1]))
+                            value = item[1] if f.endswith(":inline") else xmlescape(item[1])
+                            s.append(tmpl % (self.nonce, value))
                     else:
-                        s.append(tmpl % item[1])
+                        if isinstance(item[1], tuple):
+                            s.append(tmpl % item[1])
+                        else:
+                            value = item[1] if f.endswith(":inline") else xmlescape(item[1])
+                            s.append(tmpl % value)
 
         s = []
         for item in files:

--- a/gluon/tests/test_globals.py
+++ b/gluon/tests/test_globals.py
@@ -229,6 +229,39 @@ class testResponse(unittest.TestCase):
             '<script src="http://maps.google.com/maps/api/js?sensor=false" type="text/javascript"></script>',
         )
 
+    def test_include_files_escapes_url_attributes(self):
+        def return_includes(response):
+            response.include_files()
+            return response.body.getvalue()
+
+        malicious = 'https://cdn.example.com/app.js?x=" onerror="alert(1)'
+
+        response = Response()
+        response.files.append(malicious)
+        content = return_includes(response)
+        self.assertIn(
+            "https://cdn.example.com/app.js?x=&quot; onerror=&quot;alert(1)", content
+        )
+        self.assertNotIn('onerror="alert(1)', content)
+
+        response = Response()
+        response.files.append(("js", malicious))
+        content = return_includes(response)
+        self.assertIn(
+            "https://cdn.example.com/app.js?x=&quot; onerror=&quot;alert(1)", content
+        )
+        self.assertNotIn('onerror="alert(1)', content)
+
+        response = Response()
+        response.enable_csp()
+        response.files.append(("js", malicious))
+        content = return_includes(response)
+        self.assertIn('nonce="%s"' % response.nonce, content)
+        self.assertIn(
+            "https://cdn.example.com/app.js?x=&quot; onerror=&quot;alert(1)", content
+        )
+        self.assertNotIn('onerror="alert(1)', content)
+
         response = Response()
         response.files.append(
             ("js1", "http://maps.google.com/maps/api/js?sensor=false")


### PR DESCRIPTION
## Summary
Escape include file URLs before inserting them into generated HTML `src` / `href` attributes in `response.include_files()`.

## What Changed
- Escape direct include URL values during HTML rendering.
- Escape non-inline `(type, value)` include paths before attribute insertion.
- Preserve existing inline JS/CSS behavior (`:inline` paths remain unchanged).
- Preserve existing tuple formatting behavior and CSP nonce handling.

## Why
Previously, include URLs containing raw quotes could break out of generated HTML attributes and produce malformed markup, for example:

```html
<script src="...x=" onerror="alert(1)">
```

Escaping at the rendering boundary keeps the generated attribute structure intact.