### PR TITLE
Prevent Host header poisoning in Auth-generated email links

### DIFF
--- a/gluon/tests/test_tools.py
+++ b/gluon/tests/test_tools.py
@@ -1449,6 +1449,113 @@ class TestAuth(unittest.TestCase):
     # End Auth test
 
 
+class TestAuthHostHeaderPoisoning(unittest.TestCase):
+    """
+    Regression tests for Host-header poisoning in Auth.url(scheme=True).
+
+    Without this guard, an attacker can submit a password-reset request
+    with `Host: attacker.com` and the framework emails the victim a reset
+    link rooted at attacker.com -- the token leaks on click (CWE-640).
+    """
+
+    def _make_auth(self, http_host, host_names=None):
+        request = Request(env={})
+        request.application = "a"
+        request.controller = "c"
+        request.function = "f"
+        request.folder = "applications/admin"
+        request.env.http_host = http_host
+        response = Response()
+        session = Session()
+        T = TranslatorFactory("", "en")
+        session.connect(request, response)
+        current.request = request
+        current.response = response
+        current.session = session
+        current.T = T
+        db = DAL(DEFAULT_URI, check_reserved=["all"])
+        auth = Auth(db, host_names=host_names)
+        auth.define_tables(username=True, signature=False)
+        auth.settings.function = "user"
+        return auth, db
+
+    def tearDown(self):
+        # cleanup any tables this test left behind
+        try:
+            db = getattr(self, "_db", None)
+            if db is not None:
+                for t in (
+                    "auth_cas",
+                    "auth_event",
+                    "auth_membership",
+                    "auth_permission",
+                    "auth_group",
+                    "auth_user",
+                ):
+                    if t in db:
+                        db[t].drop()
+        except Exception:
+            pass
+
+    def test_absolute_url_refuses_request_host_without_allowlist(self):
+        # Default config: no settings.host, no host_names. The pre-fix
+        # behavior used request.env.http_host directly, allowing the
+        # attacker to poison absolute URLs. Post-fix: HTTP 500.
+        auth, self._db = self._make_auth("attacker.example")
+        self.assertIsNone(auth.settings.host)
+        with self.assertRaises(HTTP) as cm:
+            auth.url("user", args=("reset_password",), scheme=True)
+        self.assertEqual(cm.exception.status, 500)
+
+    def test_absolute_url_uses_explicit_settings_host(self):
+        # If the developer pinned settings.host, that wins regardless of
+        # the attacker's Host header.
+        auth, self._db = self._make_auth("attacker.example")
+        auth.settings.host = "good.example"
+        url = auth.url("user", args=("reset_password",), scheme=True)
+        self.assertIn("//good.example", str(url))
+        self.assertNotIn("attacker.example", str(url))
+
+    def test_absolute_url_with_host_names_allowlist_accepts_match(self):
+        # Host header is in the allowlist -> validated, URL minted.
+        auth, self._db = self._make_auth(
+            "good.example", host_names=["good.example"]
+        )
+        url = auth.url("user", args=("reset_password",), scheme=True)
+        self.assertIn("//good.example", str(url))
+
+    def test_absolute_url_with_host_names_allowlist_rejects_mismatch(self):
+        # Host header is NOT in the allowlist. Auth.__init__ raises 403
+        # via select_host before Auth.url() is ever reached -- this is
+        # the existing behavior we are relying on, and the test guards
+        # against a regression.
+        with self.assertRaises(HTTP) as cm:
+            self._make_auth("attacker.example", host_names=["good.example"])
+        self.assertEqual(cm.exception.status, 403)
+
+    def test_relative_url_unaffected_by_missing_host(self):
+        # scheme=False is the common case and must still work without
+        # any host configuration -- we are not breaking that.
+        auth, self._db = self._make_auth("attacker.example")
+        url = auth.url("user", args=("login",))
+        self.assertTrue(str(url).startswith("/"))
+        self.assertNotIn("attacker.example", str(url))
+
+    def test_email_reset_password_link_not_poisoned(self):
+        # End-to-end: the password-reset link that would have been
+        # emailed must not contain the attacker's Host header.
+        auth, self._db = self._make_auth("attacker.example")
+        auth.settings.host = "good.example"
+        link = auth.url(
+            "user",
+            args=("reset_password",),
+            vars={"key": "abc"},
+            scheme=True,
+        )
+        self.assertIn("//good.example", str(link))
+        self.assertNotIn("attacker.example", str(link))
+
+
 # TODO: class TestCrud(unittest.TestCase):
 # It deprecated so far from a priority
 

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -1816,6 +1816,29 @@ class Auth(AuthAPI):
         if vars is None:
             vars = {}
         host = scheme and self.settings.host
+        if scheme and not host:
+            # Absolute URL requested but no host was pinned in
+            # settings.host. Falling through to URL() would derive the
+            # host from request.env.http_host, which is taken verbatim
+            # from the client-supplied Host: header. This is the classic
+            # password-reset token-leak primitive (CWE-640): an attacker
+            # submits the reset form with `Host: attacker.com` and the
+            # victim is emailed `http://attacker.com/.../reset_password
+            # ?key=<TOKEN>`; the token leaks on click. Require an
+            # explicit allowlist instead.
+            host_names = self.settings.host_names
+            if host_names:
+                host = self.select_host(
+                    current.request.env.http_host, host_names
+                )
+            else:
+                raise HTTP(
+                    500,
+                    "Auth.url(scheme=True) requires auth.settings.host or "
+                    "host_names to be configured; refusing to derive the "
+                    "host from the request Host header.",
+                    web2py_error="absolute Auth URL without trusted host",
+                )
         return URL(
             c=self.settings.controller,
             f=f,
@@ -1962,7 +1985,12 @@ class Auth(AuthAPI):
             label_separator=current.response.form_label_separator,
             two_factor_methods=[],
             two_factor_onvalidation=[],
-            host=host,
+            # Only pin settings.host when the app supplied an allowlist
+            # (host_names); otherwise leave it unset so that Auth.url()
+            # refuses to mint absolute URLs from an unverified request
+            # Host header. See Auth.url() for the rationale.
+            host=host if host_names else None,
+            host_names=host_names,
         )
         settings.lock_keys = True
         # ## these are messages that can be customized


### PR DESCRIPTION
This patch fixes a Host header injection issue affecting Auth-generated absolute URLs used in:

* password reset emails
* email verification flows
* invitation confirmation flows

Previously, when `auth.settings.host` was unset, `Auth.url(..., scheme=True)` could derive the host component from `request.env.http_host`, allowing attacker-controlled `Host` headers to influence security-sensitive links sent by email.

An attacker could trigger a password-reset request using a crafted `Host` header such as:

```text
Host: attacker.example
```

causing the victim to receive a reset link pointing to the attacker-controlled domain. When clicked, the reset token could be exposed to the attacker, enabling account takeover.

## Root Cause

`Auth.url(..., scheme=True)` delegated host resolution to `URL(...)` with `host=None`, which eventually fell back to:

```python
request.env.http_host
```

inside `gluon.rewrite.url_out`.

Although `Auth.__init__()` already validated hosts through `select_host(...)` when `host_names` was configured, the validated value was not reused during Auth email-link generation.

## Changes

### `gluon/tools.py`

* Persist `host_names` into Auth settings
* Prevent `Auth.url(scheme=True)` from silently deriving hosts from the request `Host` header
* Use `select_host(...)` with `auth.settings.host_names` when resolving absolute URLs
* Raise HTTP 500 when absolute Auth URLs are requested without trusted host configuration

### `gluon/tests/test_tools.py`

Added regression coverage for:

* refusal without trusted host configuration
* explicit `settings.host` precedence
* allowlisted host acceptance
* allowlisted host mismatch rejection
* relative URL behavior remaining unchanged
* end-to-end password-reset link poisoning prevention