### PR TITLE
Reject malformed multipart requests without caching partial form state

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -350,7 +350,7 @@ class Request(Storage):
         post_vars. application/json is also automatically parsed
         """
         env = self.env
-        post_vars = self._post_vars = Storage()
+        post_vars = Storage()
         body = self.body
 
         # if content-type is application/json, we must read the body
@@ -424,8 +424,10 @@ class Request(Storage):
                                 if part.name not in post_vars
                                 else listify(post_vars[part.name]) + [value]
                             )
-                    except (StopIteration, ParserError):
+                    except StopIteration:
                         break
+                    except ParserError:
+                        raise HTTP(400)
                 body.seek(0)
             # Handle application/x-www-form-urlencoded
             elif content_type.startswith("application/x-www-form-urlencoded"):
@@ -467,6 +469,7 @@ class Request(Storage):
                     post_vars[key] = (len(pvalue) > 1 and pvalue) or pvalue[0]
         # Reset body for reuse
         body.seek(0)
+        self._post_vars = post_vars
 
     @property
     def body(self):

--- a/gluon/tests/test_globals.py
+++ b/gluon/tests/test_globals.py
@@ -617,3 +617,23 @@ class testFileUpload(unittest.TestCase):
         filenames = [u.filename for u in uploads]
         self.assertIn("a.txt", filenames)
         self.assertIn("b.txt", filenames)
+
+    def test_malformed_multipart_is_rejected(self):
+        boundary = self.BOUNDARY
+        body = (
+            b"--" + boundary + b"\r\n"
+            b'Content-Disposition: form-data; name="token"\r\n\r\nabc\r\n'
+            b"--" + boundary + b"\r\n"
+            b'Content-Disposition: form-data; name="amount"\r\n\r\n10\r\n'
+        )
+        r = self._make_request(body)
+
+        with self.assertRaises(HTTP) as ctx:
+            r.post_vars
+        self.assertEqual(ctx.exception.status, 400)
+        self.assertIsNone(r._post_vars)
+
+        with self.assertRaises(HTTP) as second_ctx:
+            r.post_vars
+        self.assertEqual(second_ctx.exception.status, 400)
+        self.assertIsNone(r._post_vars)


### PR DESCRIPTION
## Summary

Malformed `multipart/form-data` requests were previously treated as successful partial parses because `ParserError` was handled together with `StopIteration`.

This could leave `request.post_vars` in an inconsistent partially populated state when parsing failed after some fields had already been processed.

This change makes multipart parsing transactional:

- valid multipart requests are parsed and cached normally,
- malformed multipart requests now raise `HTTP(400)`,
- partial `post_vars` state is no longer cached on parser failure.

## Changes

- separated `StopIteration` and `ParserError` handling in multipart parsing
- raise `HTTP(400)` for malformed multipart bodies
- defer `_post_vars` assignment until parsing completes successfully
- added regression coverage for malformed multipart requests
- verified repeated access does not expose partial cached state

## Regression Test

Added a regression test that verifies:

- malformed multipart requests raise `HTTP(400)`
- `_post_vars` remains unset after parser failure
- repeated access continues to fail consistently
- no partial form state is exposed after failure