### PR TITLE
Restrict admin file paths to selected app

### DIFF
--- a/applications/admin/controllers/default.py
+++ b/applications/admin/controllers/default.py
@@ -122,6 +122,31 @@ def safe_write(a, value, b='w'):
         safe_file.close()
 
 
+def safe_app_path(app, *members):
+    try:
+        return safe_join_admin_path(apath(app, r=request), *members)
+    except RuntimeError:
+        raise HTTP(403)
+
+
+def safe_app_location_path(app, location, *members):
+    try:
+        app_root = apath(app, r=request)
+        return safe_join_admin_app_path(app_root, app, location, *members)
+    except RuntimeError:
+        raise HTTP(403)
+
+
+def safe_request_args_path(app):
+    filename = '/'.join(request.args)
+    relative_filename = filename if request.vars.app else '/'.join(request.args[1:])
+    return filename, safe_app_path(app, relative_filename)
+
+
+def path_endswith_dir(path, dirname):
+    return path.replace('\\', '/').rstrip('/').endswith('/' + dirname)
+
+
 def get_app(name=None):
     app = name or request.args(0)
     if app:
@@ -565,7 +590,7 @@ def delete():
 
     if dialog.accepted:
         try:
-            full_path = apath(filename, r=request)
+            full_path = safe_app_path(app, '/'.join(request.args[1:]))
             lineno = count_lines(safe_open(full_path, 'r').read())
             os.unlink(full_path)
             log_progress(app, 'DELETE', filename, progress=-lineno)
@@ -595,11 +620,7 @@ def enable():
 def peek():
     """ Visualize object code """
     app = get_app(request.vars.app)
-    filename = '/'.join(request.args)
-    if request.vars.app:
-        path = abspath(filename)
-    else:
-        path = apath(filename, r=request)
+    filename, path = safe_request_args_path(app)
     try:
         data = safe_read(path).replace('\r', '')
     except IOError:
@@ -685,12 +706,8 @@ def edit():
     """ File edit handler """
     # Load json only if it is ajax edited...
     app = get_app(request.vars.app)
-    filename = '/'.join(request.args)
+    filename, path = safe_request_args_path(app)
     realfilename = request.args[-1]
-    if request.vars.app:
-        path = abspath(filename)
-    else:
-        path = apath(filename, r=request)
     # Try to discover the file type
     if filename[-3:] == '.py':
         filetype = 'python'
@@ -923,9 +940,10 @@ def resolve():
     """
     """
 
+    app = get_app()
     filename = '/'.join(request.args)
     # ## check if file is not there
-    path = apath(filename, r=request)
+    path = safe_app_path(app, '/'.join(request.args[1:]))
     a = safe_read(path).split('\n')
     try:
         b = safe_read(path + '.1').split('\n')
@@ -985,8 +1003,9 @@ def edit_language():
     """ Edit language file """
     app = get_app()
     filename = '/'.join(request.args)
+    path = safe_app_path(app, '/'.join(request.args[1:]))
     response.title = request.args[-1]
-    strings = read_dict(apath(filename, r=request))
+    strings = read_dict(path)
 
     if '__corrupted__' in strings:
         form = SPAN(strings['__corrupted__'], _class='error')
@@ -1034,7 +1053,7 @@ def edit_language():
             if form.vars[name] == chr(127):
                 continue
             strs[key] = form.vars[name]
-        write_dict(apath(filename, r=request), strs)
+        write_dict(path, strs)
         session.flash = T('file saved on %(time)s', dict(time=time.ctime()))
         redirect(URL(r=request, args=request.args))
     return dict(app=request.args[0], filename=filename, form=form)
@@ -1044,8 +1063,9 @@ def edit_plurals():
     """ Edit plurals file """
     app = get_app()
     filename = '/'.join(request.args)
+    path = safe_app_path(app, '/'.join(request.args[1:]))
     plurals = read_plural_dict(
-        apath(filename, r=request))  # plural forms dictionary
+        path)  # plural forms dictionary
     nplurals = int(request.vars.nplurals) - 1  # plural forms quantity
     xnplurals = range(nplurals)
 
@@ -1085,7 +1105,7 @@ def edit_plurals():
                 continue
             new_plurals[key] = [form.vars[name + '_' + str(n)]
                                 for n in xnplurals]
-        write_plural_dict(apath(filename, r=request), new_plurals)
+        write_plural_dict(path, new_plurals)
         session.flash = T('file saved on %(time)s', dict(time=time.ctime()))
         redirect(URL(r=request, args=request.args, vars=dict(
             nplurals=request.vars.nplurals)))
@@ -1365,19 +1385,19 @@ def create_file():
     """ Create files handler """
     if request.vars and not request.vars.token == session.token:
         redirect(URL('logout'))
+    result = T('cannot create file')
     try:
         anchor = '#' + request.vars.id if request.vars.id else ''
         if request.vars.app:
             app = get_app(request.vars.app)
-            path = abspath(request.vars.location)
+            path = safe_app_location_path(app, request.vars.location)
         else:
             if request.vars.dir:
                 request.vars.location += request.vars.dir + '/'
             app = get_app(name=request.vars.location.split('/')[0])
-            path = apath(request.vars.location, r=request)
-        path = check_app_path(request, app, path)
+            path = safe_app_location_path(app, request.vars.location)
         filename = re.sub(r'[^\w./-]+', '_', request.vars.filename)
-        if path[-7:] == '/rules/':
+        if path_endswith_dir(path, 'rules'):
             # Handle plural rules files
             if len(filename) == 0:
                 raise SyntaxError
@@ -1405,13 +1425,13 @@ def create_file():
                    construct_plural_form = lambda word, plural_id: word
                    """)[1:] % dict(lang=langinfo[0], langname=langinfo[1])
 
-        elif path[-11:] == '/languages/':
+        elif path_endswith_dir(path, 'languages'):
             # Handle language files
             if len(filename) == 0:
                 raise SyntaxError
             if not filename[-3:] == '.py':
                 filename += '.py'
-            path = join_app_path(request, app, os.path.join(apath(app, r=request), 'languages'), filename)
+            path = safe_app_path(app, 'languages', filename)
             if not os.path.exists(path):
                 safe_write(path, '')
             # create language xx[-yy].py file:
@@ -1420,7 +1440,7 @@ def create_file():
                               dict(filename=filename))
             redirect(request.vars.sender + anchor)
 
-        elif path[-8:] == '/models/':
+        elif path_endswith_dir(path, 'models'):
             # Handle python models
             if not filename[-3:] == '.py':
                 filename += '.py'
@@ -1430,7 +1450,7 @@ def create_file():
 
             text = '# -*- coding: utf-8 -*-\n'
 
-        elif path[-13:] == '/controllers/':
+        elif path_endswith_dir(path, 'controllers'):
             # Handle python controllers
             if not filename[-3:] == '.py':
                 filename += '.py'
@@ -1441,7 +1461,7 @@ def create_file():
             text = '# -*- coding: utf-8 -*-\n# %s\ndef index(): return dict(message="hello from %s")'
             text = text % (T('try something like'), filename)
 
-        elif path[-7:] == '/views/':
+        elif path_endswith_dir(path, 'views'):
             if request.vars.plugin and not filename.startswith('plugin_%s/' % request.vars.plugin):
                 filename = 'plugin_%s/%s' % (request.vars.plugin, filename)
             # Handle template (html) views
@@ -1466,7 +1486,7 @@ def create_file():
                 else:
                     text = ''
 
-        elif path[-9:] == '/modules/':
+        elif path_endswith_dir(path, 'modules'):
             if request.vars.plugin and not filename.startswith('plugin_%s/' % request.vars.plugin):
                 filename = 'plugin_%s/%s' % (request.vars.plugin, filename)
             # Handle python module files
@@ -1481,7 +1501,7 @@ def create_file():
                    # -*- coding: utf-8 -*-
                    from gluon import *\n""")[1:]
 
-        elif (path[-8:] == '/static/') or (path[-9:] == '/private/'):
+        elif path_endswith_dir(path, 'static') or path_endswith_dir(path, 'private'):
             if (request.vars.plugin and
                     not filename.startswith('plugin_%s/' % request.vars.plugin)):
                 filename = 'plugin_%s/%s' % (request.vars.plugin, filename)
@@ -1518,6 +1538,7 @@ def create_file():
     except Exception as e:
         if not isinstance(e, HTTP):
             session.flash = T('cannot create file')
+        result = T('cannot create file')
 
     if request.vars.dir:
         response.flash = result
@@ -1532,11 +1553,7 @@ def create_file():
 
 
 def listfiles(app, dir, regexp=r'.*\.py$'):
-    path = apath('%(app)s/%(dir)s/' % {'app': app, 'dir': dir}, r=request)
-    web2py_apps_root = os.path.abspath(up(request.folder))
-    path_abs = os.path.abspath(path)
-    if not is_within_root(path_abs, web2py_apps_root):
-        return []
+    path = safe_app_path(app, dir)
     files = sorted(
         listdir(path, regexp))
     files = [x.replace('\\', '/') for x in files if not x.endswith('.bak')]
@@ -1550,7 +1567,7 @@ def editfile(path, file, vars={}, app=None):
 
 
 def files_menu():
-    app = request.vars.app or 'welcome'
+    app = get_app(request.vars.app or 'welcome')
     dirs = [{'name': 'models', 'reg': r'.*\.py$'},
             {'name': 'controllers', 'reg': r'.*\.py$'},
             {'name': 'views', 'reg': r'[\w/\-]+(\.\w+)+$'},
@@ -1574,26 +1591,26 @@ def upload_file():
     try:
         filename = None
         app = get_app(name=request.vars.location.split('/')[0])
-        path = apath(request.vars.location, r=request)
+        path = safe_app_location_path(app, request.vars.location)
 
         if request.vars.filename:
             filename = re.sub(r'[^\w\./]+', '_', request.vars.filename)
         else:
             filename = os.path.split(request.vars.file.filename)[-1]
 
-        if path[-8:] == '/models/' and not filename[-3:] == '.py':
+        if path_endswith_dir(path, 'models') and not filename[-3:] == '.py':
             filename += '.py'
 
-        if path[-9:] == '/modules/' and not filename[-3:] == '.py':
+        if path_endswith_dir(path, 'modules') and not filename[-3:] == '.py':
             filename += '.py'
 
-        if path[-13:] == '/controllers/' and not filename[-3:] == '.py':
+        if path_endswith_dir(path, 'controllers') and not filename[-3:] == '.py':
             filename += '.py'
 
-        if path[-7:] == '/views/' and not filename[-5:] == '.html':
+        if path_endswith_dir(path, 'views') and not filename[-5:] == '.html':
             filename += '.html'
 
-        if path[-11:] == '/languages/' and not filename[-3:] == '.py':
+        if path_endswith_dir(path, 'languages') and not filename[-3:] == '.py':
             filename += '.py'
 
         filename = join_app_path(request, app, path, filename)

--- a/gluon/admin.py
+++ b/gluon/admin.py
@@ -37,14 +37,33 @@ from gluon.restricted import RestrictedError
 from gluon.settings import global_settings
 
 
-def _safe_extract_path(base_dir, member_name):
-    """Return an absolute safe extraction path inside base_dir."""
-    target = os.path.normpath(os.path.join(base_dir, member_name))
+def safe_join_admin_path(base_dir, *members):
+    """Return an absolute path after verifying it remains inside base_dir."""
     root = os.path.abspath(base_dir)
+    target = os.path.normpath(os.path.join(root, *members))
     target_abspath = os.path.abspath(target)
     if not (target_abspath == root or target_abspath.startswith(root + os.sep)):
-        raise RuntimeError("Attempted path traversal in zip file")
+        raise RuntimeError("Attempted path traversal in admin path")
     return target_abspath
+
+
+def safe_join_admin_app_path(app_root, app_name, location="", *members):
+    """Return an absolute admin path scoped to a single application root."""
+    app_root = os.path.abspath(app_root)
+    location = (location or "").replace("\\", "/")
+    if app_name and (location == app_name or location.startswith(app_name + "/")):
+        location = location[len(app_name):].lstrip("/")
+    if os.path.isabs(location):
+        location = os.path.relpath(location, app_root)
+    return safe_join_admin_path(app_root, location, *members)
+
+
+def _safe_extract_path(base_dir, member_name):
+    """Return an absolute safe extraction path inside base_dir."""
+    try:
+        return safe_join_admin_path(base_dir, member_name)
+    except RuntimeError:
+        raise RuntimeError("Attempted path traversal in zip file")
 
 
 # TODO: move into add_path_first

--- a/gluon/tests/test_compileapp.py
+++ b/gluon/tests/test_compileapp.py
@@ -9,7 +9,8 @@ import unittest
 import zipfile
 
 from gluon.admin import (app_cleanup, app_compile, app_create, app_uninstall,
-                         check_new_version)
+                         check_new_version, safe_join_admin_app_path,
+                         safe_join_admin_path)
 from gluon.compileapp import TEST_CODE, compile_application, remove_compiled_application
 from gluon.fileutils import create_app, w2p_pack, w2p_unpack
 from gluon.globals import Request
@@ -97,5 +98,65 @@ class TestPack(unittest.TestCase):
 
             self.assertFalse(os.path.exists(os.path.join(tmpdir, "evil.txt")))
             self.assertFalse(os.path.exists(os.path.join(tmpdir, "evil2.txt")))
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def test_admin_safe_join_rejects_sibling_app_traversal(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            apps_root = os.path.join(tmpdir, "applications")
+            owned_static = os.path.join(apps_root, "owned", "static")
+            victim_controllers = os.path.join(apps_root, "victim", "controllers")
+            os.makedirs(owned_static)
+            os.makedirs(victim_controllers)
+
+            old_target = os.path.abspath(
+                os.path.join(owned_static, "../../victim/controllers/pwn.py")
+            )
+            self.assertTrue(old_target.startswith(os.path.abspath(apps_root) + os.sep))
+            self.assertEqual(
+                old_target,
+                os.path.join(os.path.abspath(victim_controllers), "pwn.py"),
+            )
+
+            with self.assertRaises(RuntimeError):
+                safe_join_admin_path(owned_static, "../../victim/controllers/pwn.py")
+
+            self.assertFalse(
+                os.path.exists(os.path.join(victim_controllers, "pwn.py"))
+            )
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def test_admin_app_location_stays_under_selected_app(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            app_root = os.path.join(tmpdir, "applications", "owned")
+            os.makedirs(os.path.join(app_root, "controllers"))
+            target = safe_join_admin_app_path(
+                app_root, "owned", "owned/controllers", "default.py"
+            )
+            self.assertEqual(
+                target,
+                os.path.join(os.path.abspath(app_root), "controllers", "default.py"),
+            )
+
+            target = safe_join_admin_app_path(
+                app_root, "owned", os.path.join(app_root, "static"), "file.txt"
+            )
+            self.assertEqual(
+                target, os.path.join(os.path.abspath(app_root), "static", "file.txt")
+            )
+
+            with self.assertRaises(RuntimeError):
+                safe_join_admin_app_path(
+                    app_root, "owned", "owned/static/../../victim/controllers"
+                )
+            with self.assertRaises(RuntimeError):
+                safe_join_admin_app_path(
+                    app_root,
+                    "owned",
+                    os.path.join(tmpdir, "applications", "victim", "controllers"),
+                )
         finally:
             shutil.rmtree(tmpdir)


### PR DESCRIPTION
 ## Summary

  This tightens admin file operations so paths are scoped to the selected application root, not only the broader applications directory.

  Previously, admin create/upload/edit/delete paths were normalized only through the global applications root. In multi-user admin mode, a user authorized for one app could submit path traversal in a file
  location or filename and reach a sibling app under the same applications directory.

  ## Changes

  - Add reusable admin path join helpers that verify the resolved path stays under the intended base directory.
  - Scope admin file operations to the selected app root.
  - Preserve existing create/upload behavior for models, controllers, views, modules, static, private, and language paths.
  - Add regression coverage for sibling-app traversal.

  ## Validation

  - python3 -m py_compile gluon/admin.py applications/admin/controllers/default.py gluon/tests/test_compileapp.py
  - python3 -m unittest discover -s gluon/tests -p 'test_compileapp.py'
  - git diff --check HEAD~1..HEAD