### PR TITLE
Harden SQLFORM.grid export Content-Disposition filenames

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -32,7 +32,7 @@ from pydal.helpers.methods import _repr_ref, bar_encode, merge_tablemaps, smart_
 from pydal.objects import Expression, Field, Row, Rows, Set, Table
 
 import gluon.serializers as serializers
-from gluon.globals import current
+from gluon.globals import _content_disposition_filename, current
 from gluon.html import (
     BR,
     CAT,
@@ -3157,10 +3157,20 @@ class SQLFORM(FORM):
                 rows.colnames = expcolumns
                 oExp = clazz(rows)
                 export_filename = request.vars.get("_export_filename") or "rows"
-                filename = ".".join((export_filename, oExp.file_ext))
+                # `_export_filename` is taken verbatim from the query string.
+                # Concatenating it raw into Content-Disposition let an
+                # attacker inject extra directives (e.g. a second `filename=`)
+                # by submitting `_export_filename=a";filename=evil.exe`. The
+                # http layer only strips CR/LF, so `"` and `;` would survive.
+                # Percent-encode via the same helper used by Response.stream
+                # / Response.download (see commit 3e656ed7).
+                filename = "%s.%s" % (
+                    _content_disposition_filename(export_filename),
+                    oExp.file_ext,
+                )
                 response.headers["Content-Type"] = oExp.content_type
                 response.headers["Content-Disposition"] = (
-                    "attachment;filename=" + filename + ";"
+                    'attachment; filename="%s"' % filename
                 )
                 raise HTTP(200, oExp.export(), **response.headers)
 

--- a/gluon/tests/test_sqlhtml.py
+++ b/gluon/tests/test_sqlhtml.py
@@ -350,6 +350,73 @@ class TestSQLFORM(unittest.TestCase):
         smartgrid_form = SQLFORM.smartgrid(self.db.auth_user)
         self.assertEqual(smartgrid_form.xml()[:4], "<div")
 
+    def _grid_export_disposition(self, export_filename):
+        # SQLFORM.grid raises HTTP(200, body, **headers) when an export is
+        # triggered via `_export_type`. Drive that path and return the
+        # Content-Disposition header that would be emitted.
+        from gluon.globals import current
+
+        current.request.vars._export_type = "csv"
+        if export_filename is not None:
+            current.request.vars._export_filename = export_filename
+        with self.assertRaises(HTTP) as cm:
+            SQLFORM.grid(self.db.auth_user)
+        # Cleanup so the next test sees a clean request.vars
+        del current.request.vars._export_type
+        if "_export_filename" in current.request.vars:
+            del current.request.vars._export_filename
+        return cm.exception.headers["Content-Disposition"]
+
+    def test_grid_export_filename_encodes_quote(self):
+        # Pre-fix: `_export_filename=a"b` produced
+        #   attachment;filename=a"b.csv;
+        # which is a broken-out quoted-string and lets the attacker close
+        # the quote and append directives. Must be percent-encoded.
+        disposition = self._grid_export_disposition('a"b')
+        self.assertEqual(disposition, 'attachment; filename="a%22b.csv"')
+
+    def test_grid_export_filename_encodes_semicolon(self):
+        # Pre-fix: `_export_filename=a; filename=evil.exe` produced
+        #   attachment;filename=a; filename=evil.exe.csv;
+        # which browsers parse as two directives -- a classic filename
+        # spoof / RFD primitive. The injected directive must not survive.
+        disposition = self._grid_export_disposition("a; filename=evil.exe")
+        self.assertEqual(
+            disposition,
+            'attachment; filename="a%3B%20filename%3Devil.exe.csv"',
+        )
+        # exactly one ";" separator between "attachment" and "filename="
+        self.assertEqual(disposition.count(";"), 1)
+        self.assertNotIn("filename=evil.exe", disposition)
+
+    def test_grid_export_filename_encodes_crlf(self):
+        # The http layer already strips CR/LF from header values, but the
+        # filename must also lose them before that happens so the header
+        # stays well-formed (defense in depth, matches Response.stream).
+        disposition = self._grid_export_disposition("a\r\nX-Evil: yes")
+        self.assertEqual(
+            disposition,
+            'attachment; filename="a%0D%0AX-Evil%3A%20yes.csv"',
+        )
+        self.assertNotIn("\r", disposition)
+        self.assertNotIn("\n", disposition)
+
+    def test_grid_export_filename_safe_values_compatibility(self):
+        # Plain values keep working; only unsafe characters are encoded.
+        # The default ("rows", no _export_filename) must still produce the
+        # historical filename, just now in canonical quoted form.
+        cases = [
+            (None, 'attachment; filename="rows.csv"'),
+            ("report", 'attachment; filename="report.csv"'),
+            ("my report", 'attachment; filename="my%20report.csv"'),
+            ("café", 'attachment; filename="caf%C3%A9.csv"'),
+            ("100%done", 'attachment; filename="100%25done.csv"'),
+        ]
+        for export_filename, expected in cases:
+            self.assertEqual(
+                self._grid_export_disposition(export_filename), expected
+            )
+
 
 class TestSQLTABLE(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This PR hardens `SQLFORM.grid` export responses against `Content-Disposition` header directive injection through attacker-controlled `_export_filename` values.

The fix reuses `_content_disposition_filename()` to percent-encode unsafe characters before interpolation into the response header and switches the generated header to canonical quoted formatting:

```http
Content-Disposition: attachment; filename="..."
```

This follows the same mitigation strategy already used by `Response.stream` and `Response.download` (commit `3e656ed7`).

---

## Vulnerability

Before this patch, `_export_filename` was concatenated directly into the `Content-Disposition` header.

An attacker could inject additional directives using characters such as:

* `"`
* `;`
* CR/LF sequences

Example pre-fix output reproduced by the regression tests:

```http
attachment;filename=a; filename=evil.exe.csv;
```

This creates multiple `filename=` directives and can enable filename spoofing / reflected file download style attacks depending on client behavior.

---

## Changes

### `gluon/sqlhtml.py`

* Import `_content_disposition_filename` from `gluon.globals`
* Percent-encode `_export_filename` before header construction
* Switch to canonical quoted `attachment; filename="..."` formatting
* Add inline documentation explaining the injection primitive and relationship to existing hardening work

### `gluon/tests/test_sqlhtml.py`

Add regression coverage for:

* quote injection
* semicolon directive injection
* CR/LF handling
* compatibility for safe filenames:

  * default value
  * spaces
  * non-ASCII characters
  * `%`