### PR TITLE
Validate CSP nonce values before HTML and CSP serialization

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -129,6 +129,7 @@ template_mapping_csp = {
 
 CSP_DIRECTIVE = re.compile(r"^[A-Za-z0-9-]+$")
 CSP_DIRECTIVE_TOKEN = re.compile(r"^[\x21-\x2B\x2D-\x3A\x3C-\x7E]+$")
+CSP_NONCE_VALUE = re.compile(r"^[A-Za-z0-9+/_=-]+$")
 CSP_STANDARD_DIRECTIVES = frozenset(
     (
         "base-uri",
@@ -199,6 +200,11 @@ def sorting_dumps(obj, protocol=None):
 def _validate_csp_directive(directive):
     if not CSP_DIRECTIVE.match(directive):
         raise ValueError("invalid CSP directive: %r" % directive)
+
+
+def _validate_csp_nonce(nonce):
+    if not isinstance(nonce, str) or not CSP_NONCE_VALUE.match(nonce):
+        raise ValueError("invalid CSP nonce: %r" % nonce)
 
 
 def _split_serialized_csp_list(serialized):
@@ -661,6 +667,7 @@ class Response(Storage):
     def nonce(self):
         if "nonce" not in self:
             self["nonce"] = web2py_uuid()
+        _validate_csp_nonce(self["nonce"])
         return self["nonce"]
 
     def enable_csp(self, **policies):

--- a/gluon/tests/test_globals.py
+++ b/gluon/tests/test_globals.py
@@ -308,6 +308,20 @@ class testResponse(unittest.TestCase):
             with self.assertRaises(TypeError):
                 response.enable_csp(script_src=invalid)
 
+    def test_enable_csp_rejects_malformed_nonce_values(self):
+        response = Response()
+        response["nonce"] = 'abc" onload="alert(1)'
+        response.files.append(("js", "/a/static/app.js"))
+        with self.assertRaises(ValueError):
+            response.enable_csp()
+
+        response = Response()
+        # This payload has no whitespace, so the pre-existing CSP token parser
+        # does not reject it before the nonce validator runs.
+        response["nonce"] = 'abc"onload="alert(1)'
+        with self.assertRaises(ValueError):
+            response.enable_csp()
+
     def test_enable_csp_accepts_valid_policy_tokens(self):
         response = Response()
         response.enable_csp(

--- a/gluon/tests/test_html.py
+++ b/gluon/tests/test_html.py
@@ -518,6 +518,21 @@ class TestBareHelpers(unittest.TestCase):
         self.assertIn("https://cdn.example.com", csp)
         self.assertIn("'nonce-%s'" % current.response.nonce, csp)
 
+    def test_csp_nonce_rejects_attribute_injection(self):
+        current.request = Request(env={})
+        current.request.application = "a"
+        current.response = Response()
+        current.response["nonce"] = 'abc" onload="alert(1)'
+        current.response._csp_enabled = True
+
+        with self.assertRaises(ValueError):
+            current.response.files = [("js", "/a/static/app.js")]
+            current.response.include_files()
+        with self.assertRaises(ValueError):
+            SCRIPT("alert(1)").xml()
+        with self.assertRaises(ValueError):
+            STYLE("body { color: red }").xml()
+
         # CAT(' ')
         self.assertEqual(CAT(" ").xml(), " ")
 


### PR DESCRIPTION
## Summary

Adds defensive validation for `Response.nonce` before it is reused by built-in HTML and CSP serializers.

This prevents malformed nonce values from propagating into:

* CSP nonce attributes emitted by `SCRIPT`, `STYLE`, and `include_files`
* serialized CSP policy values generated by `enable_csp`

## Changes

* Added `_validate_csp_nonce()` helper for nonce format validation
* Added centralized nonce validation in `Response.nonce`
* Added regression coverage for malformed nonce values reaching:

  * `SCRIPT`
  * `STYLE`
  * `include_files`
  * `enable_csp`

## Notes

* The validation is intentionally narrow and preserves existing valid nonce formats generated by the framework
* The change focuses on preventing malformed nonce propagation and unsafe serialization paths
* No CSP policy semantics or rendering behavior were otherwise changed