### PR TITLE
Harden temporary plugin filename handling in plugin_install()

### DIFF
--- a/gluon/admin.py
+++ b/gluon/admin.py
@@ -47,6 +47,14 @@ def _safe_extract_path(base_dir, member_name):
     return target_abspath
 
 
+def _safe_deposit_path(request, filename):
+    """Return a safe path for a temporary file in the deposit folder."""
+    basename = os.path.basename(filename)
+    if basename != filename or basename in ("", os.curdir, os.pardir):
+        raise RuntimeError("Invalid upload filename")
+    return apath("../deposit/%s" % basename, request)
+
+
 # TODO: move into add_path_first
 if not global_settings.web2py_runtime_gae:
     pass
@@ -348,9 +356,10 @@ def plugin_install(app, fobj, request, filename):
         or `False` on failure
 
     """
-    upname = apath("../deposit/%s" % filename, request)
+    upname = None
 
     try:
+        upname = _safe_deposit_path(request, filename)
         with open(upname, "wb") as appfp:
             copyfileobj(fobj, appfp, 4194304)  # 4 MB buffer
         path = apath(app, request)
@@ -358,7 +367,8 @@ def plugin_install(app, fobj, request, filename):
         fix_newlines(path)
         return upname
     except Exception:
-        os.unlink(upname)
+        if upname and os.path.exists(upname):
+            os.unlink(upname)
         return False
 
 

--- a/gluon/admin.py
+++ b/gluon/admin.py
@@ -47,7 +47,7 @@ def _safe_extract_path(base_dir, member_name):
     return target_abspath
 
 
-def _safe_deposit_path(request, filename):
+def safe_deposit_path(request, filename):
     """Return a safe path for a temporary file in the deposit folder."""
     basename = os.path.basename(filename)
     if basename != filename or basename in ("", os.curdir, os.pardir):
@@ -359,7 +359,7 @@ def plugin_install(app, fobj, request, filename):
     upname = None
 
     try:
-        upname = _safe_deposit_path(request, filename)
+        upname = safe_deposit_path(request, filename)
         with open(upname, "wb") as appfp:
             copyfileobj(fobj, appfp, 4194304)  # 4 MB buffer
         path = apath(app, request)

--- a/gluon/tests/test_compileapp.py
+++ b/gluon/tests/test_compileapp.py
@@ -4,12 +4,20 @@
 
 import os
 import shutil
+from io import BytesIO
 import tempfile
 import unittest
 import zipfile
+from unittest.mock import patch
 
-from gluon.admin import (app_cleanup, app_compile, app_create, app_uninstall,
-                         check_new_version)
+from gluon.admin import (
+    app_cleanup,
+    app_compile,
+    app_create,
+    app_uninstall,
+    check_new_version,
+    plugin_install,
+)
 from gluon.compileapp import TEST_CODE, compile_application, remove_compiled_application
 from gluon.fileutils import create_app, w2p_pack, w2p_unpack
 from gluon.globals import Request
@@ -20,6 +28,63 @@ test_app2_name = "_test_compileapp_admin"
 test_unpack_dir = None
 
 WEB2PY_VERSION_URL = "http://web2py.com/examples/default/version"
+
+
+class TestAdminPaths(unittest.TestCase):
+    def _make_request(self):
+        request = Request(env={})
+        request.folder = os.path.join("applications", "admin")
+        return request
+
+    def test_plugin_install_rejects_traversal_filename_with_false(self):
+        request = self._make_request()
+
+        with patch("gluon.admin.w2p_unpack_plugin") as unpack_plugin:
+            result = plugin_install(
+                "welcome",
+                BytesIO(b"payload"),
+                request,
+                "web2py.plugin.evil/../../pwn.w2p",
+            )
+
+        self.assertFalse(result)
+        unpack_plugin.assert_not_called()
+        self.assertFalse(os.path.exists(os.path.join("applications", "pwn.w2p")))
+
+    def test_plugin_install_rejects_dot_names_with_false(self):
+        request = self._make_request()
+
+        for candidate in ("", ".", ".."):
+            with patch("gluon.admin.w2p_unpack_plugin") as unpack_plugin:
+                result = plugin_install("welcome", BytesIO(b"payload"), request, candidate)
+            self.assertFalse(result)
+            unpack_plugin.assert_not_called()
+
+    def test_plugin_install_accepts_safe_basename(self):
+        request = self._make_request()
+
+        with patch("gluon.admin.w2p_unpack_plugin") as unpack_plugin, patch(
+            "gluon.admin.fix_newlines"
+        ) as fix_newlines:
+            result = plugin_install(
+                "welcome", BytesIO(b"payload"), request, "web2py.plugin.safe.w2p"
+            )
+
+        self.assertTrue(result.endswith("deposit/web2py.plugin.safe.w2p"))
+        self.assertTrue(os.path.exists(result))
+        unpack_plugin.assert_called_once()
+        fix_newlines.assert_called_once()
+        os.unlink(result)
+
+    def test_plugin_install_cleanup_does_not_raise_when_open_fails(self):
+        request = self._make_request()
+
+        with patch("gluon.admin.open", side_effect=IOError("boom")):
+            result = plugin_install(
+                "welcome", BytesIO(b"payload"), request, "web2py.plugin.safe.w2p"
+            )
+
+        self.assertFalse(result)
 
 
 class TestPack(unittest.TestCase):

--- a/gluon/tests/test_compileapp.py
+++ b/gluon/tests/test_compileapp.py
@@ -17,6 +17,7 @@ from gluon.admin import (
     app_uninstall,
     check_new_version,
     plugin_install,
+    safe_deposit_path,
 )
 from gluon.compileapp import TEST_CODE, compile_application, remove_compiled_application
 from gluon.fileutils import create_app, w2p_pack, w2p_unpack
@@ -85,6 +86,18 @@ class TestAdminPaths(unittest.TestCase):
             )
 
         self.assertFalse(result)
+
+    def test_plugin_install_cleanup_removes_file_when_unpack_fails(self):
+        request = self._make_request()
+
+        with patch("gluon.admin.w2p_unpack_plugin", side_effect=RuntimeError("bad zip")):
+            result = plugin_install(
+                "welcome", BytesIO(b"payload"), request, "web2py.plugin.safe.w2p"
+            )
+
+        self.assertFalse(result)
+        deposit_path = safe_deposit_path(request, "web2py.plugin.safe.w2p")
+        self.assertFalse(os.path.exists(deposit_path))
 
 
 class TestPack(unittest.TestCase):


### PR DESCRIPTION
## Summary

Harden `plugin_install()` temporary upload path handling by enforcing basename-only filenames before creating files in the `deposit` directory.

## What Changed

- Added `_safe_deposit_path()` to centralize temporary deposit filename validation.
- Reject filenames containing path components before temp-file creation.
- Preserved the existing `plugin_install()` failure contract (`False` on failure).
- Guarded cleanup logic to avoid secondary `unlink()` failures when file creation never occurred.

## Why

`plugin_install()` previously constructed the temporary deposit path directly from the provided filename before archive validation occurred.

Most upload flows already normalize filenames, but at least one URL-install path can pass source-derived filename data into `plugin_install()` without enforcing a basename invariant first.

This change moves the validation to the actual temp-file write boundary so invalid path-bearing filenames are rejected consistently before file creation.

## Tests

Added regression tests covering:

- traversal-like filenames return `False`
- empty / `.` / `..` names are rejected
- valid plugin basenames still succeed
- cleanup path remains safe when file creation fails
- invalid filenames never reach unpack logic

## Compatibility

- Existing valid plugin installs are unchanged.
- Failure behavior remains consistent (`False` on failure).
- No archive extraction behavior was modified.