### PR TITLE
Constrain recfile path operations to the configured storage root

### DIFF
--- a/gluon/recfile.py
+++ b/gluon/recfile.py
@@ -13,6 +13,35 @@ import builtins
 import os
 
 
+def _safe_join(root, *paths):
+    root = os.path.realpath(root)
+    target = os.path.realpath(os.path.join(root, *paths))
+    if not _is_within(target, root):
+        raise IOError("unsafe recfile path")
+    return target
+
+
+def _is_within(target, root):
+    target = os.path.normcase(os.path.realpath(target))
+    root = os.path.normcase(os.path.realpath(root))
+    if hasattr(os.path, "commonpath"):
+        try:
+            return os.path.commonpath([target, root]) == root
+        except ValueError:
+            return False
+    try:
+        relative = os.path.relpath(target, root)
+    except ValueError:
+        return False
+    return relative == os.curdir or not relative.startswith(os.pardir + os.sep)
+
+
+def _existing_inside_root(filename, path):
+    root = os.path.realpath(path)
+    target = os.path.realpath(filename)
+    return _is_within(target, root) and os.path.exists(target)
+
+
 def generate(filename, depth=2, base=512):
     if os.path.sep in filename:
         path, filename = os.path.split(filename)
@@ -32,22 +61,33 @@ def generate(filename, depth=2, base=512):
 
 
 def exists(filename, path=None):
-    if os.path.exists(filename):
+    if path is None and os.path.exists(filename):
         return True
     if path is None:
         path, filename = os.path.split(filename)
-    fullfilename = os.path.join(path, generate(filename))
+        fullfilename = os.path.join(path, generate(filename))
+    else:
+        if _existing_inside_root(filename, path):
+            return True
+        try:
+            fullfilename = _safe_join(path, generate(filename))
+        except IOError:
+            return False
     if os.path.exists(fullfilename):
         return True
     return False
 
 
 def remove(filename, path=None):
-    if os.path.exists(filename):
+    if path is None and os.path.exists(filename):
         return os.unlink(filename)
     if path is None:
         path, filename = os.path.split(filename)
-    fullfilename = os.path.join(path, generate(filename))
+        fullfilename = os.path.join(path, generate(filename))
+    else:
+        if _existing_inside_root(filename, path):
+            return os.unlink(os.path.realpath(filename))
+        fullfilename = _safe_join(path, generate(filename))
     if os.path.exists(fullfilename):
         return os.unlink(fullfilename)
     raise IOError
@@ -56,13 +96,18 @@ def remove(filename, path=None):
 def open(filename, mode="r", path=None):
     if not path:
         path, filename = os.path.split(filename)
+        join = os.path.join
+    else:
+        join = lambda root, name: _safe_join(root, name)
+        if not mode.startswith("w") and _existing_inside_root(filename, path):
+            return builtins.open(os.path.realpath(filename), mode)
     fullfilename = None
     if not mode.startswith("w"):
-        fullfilename = os.path.join(path, filename)
+        fullfilename = join(path, filename)
         if not os.path.exists(fullfilename):
             fullfilename = None
     if not fullfilename:
-        fullfilename = os.path.join(path, generate(filename))
+        fullfilename = join(path, generate(filename))
         if mode.startswith("w") and not os.path.exists(os.path.dirname(fullfilename)):
             os.makedirs(os.path.dirname(fullfilename))
     return builtins.open(fullfilename, mode)

--- a/gluon/recfile.py
+++ b/gluon/recfile.py
@@ -13,15 +13,15 @@ import builtins
 import os
 
 
-def _safe_join(root, *paths):
+def safe_join(root, *paths):
     root = os.path.realpath(root)
     target = os.path.realpath(os.path.join(root, *paths))
-    if not _is_within(target, root):
+    if not is_within(target, root):
         raise IOError("unsafe recfile path")
     return target
 
 
-def _is_within(target, root):
+def is_within(target, root):
     target = os.path.normcase(os.path.realpath(target))
     root = os.path.normcase(os.path.realpath(root))
     if hasattr(os.path, "commonpath"):
@@ -33,13 +33,13 @@ def _is_within(target, root):
         relative = os.path.relpath(target, root)
     except ValueError:
         return False
-    return relative == os.curdir or not relative.startswith(os.pardir + os.sep)
+    return not (relative == os.pardir or relative.startswith(os.pardir + os.sep))
 
 
-def _existing_inside_root(filename, path):
+def existing_inside_root(filename, path):
     root = os.path.realpath(path)
     target = os.path.realpath(filename)
-    return _is_within(target, root) and os.path.exists(target)
+    return is_within(target, root) and os.path.exists(target)
 
 
 def generate(filename, depth=2, base=512):
@@ -67,10 +67,10 @@ def exists(filename, path=None):
         path, filename = os.path.split(filename)
         fullfilename = os.path.join(path, generate(filename))
     else:
-        if _existing_inside_root(filename, path):
+        if existing_inside_root(filename, path):
             return True
         try:
-            fullfilename = _safe_join(path, generate(filename))
+            fullfilename = safe_join(path, generate(filename))
         except IOError:
             return False
     if os.path.exists(fullfilename):
@@ -85,9 +85,9 @@ def remove(filename, path=None):
         path, filename = os.path.split(filename)
         fullfilename = os.path.join(path, generate(filename))
     else:
-        if _existing_inside_root(filename, path):
+        if existing_inside_root(filename, path):
             return os.unlink(os.path.realpath(filename))
-        fullfilename = _safe_join(path, generate(filename))
+        fullfilename = safe_join(path, generate(filename))
     if os.path.exists(fullfilename):
         return os.unlink(fullfilename)
     raise IOError
@@ -98,8 +98,8 @@ def open(filename, mode="r", path=None):
         path, filename = os.path.split(filename)
         join = os.path.join
     else:
-        join = lambda root, name: _safe_join(root, name)
-        if not mode.startswith("w") and _existing_inside_root(filename, path):
+        join = safe_join
+        if not mode.startswith("w") and existing_inside_root(filename, path):
             return builtins.open(os.path.realpath(filename), mode)
     fullfilename = None
     if not mode.startswith("w"):

--- a/gluon/tests/test_recfile.py
+++ b/gluon/tests/test_recfile.py
@@ -161,10 +161,29 @@ class TestRecfile(unittest.TestCase):
             os.mkdir(outside_root)
             inside = os.path.join(root, "inside.test")
             outside = os.path.join(outside_root, "outside.test")
-            self.assertTrue(recfile._is_within(inside, root))
-            self.assertFalse(recfile._is_within(outside, root))
+            parent = os.path.dirname(root)
+            self.assertTrue(recfile.is_within(inside, root))
+            self.assertFalse(recfile.is_within(outside, root))
+            self.assertFalse(recfile.is_within(parent, root))
         finally:
             recfile.os.path = original_path
+
+    def test_is_within_commonpath_handles_value_error(self):
+        """commonpath raises ValueError on incompatible paths (e.g. different drives
+        on Windows); is_within must return False rather than propagate it."""
+        original_commonpath = os.path.commonpath
+
+        def raising_commonpath(paths):
+            raise ValueError("paths on different drives")
+
+        try:
+            os.path.commonpath = raising_commonpath
+            sandbox = tempfile.mkdtemp(dir=os.getcwd())
+            self.addCleanup(lambda s=sandbox: shutil.rmtree(s, ignore_errors=True))
+            inside = os.path.join(sandbox, "file.test")
+            self.assertFalse(recfile.is_within(inside, sandbox))
+        finally:
+            os.path.commonpath = original_commonpath
 
     def test_path_argument_rejects_symlink_escapes(self):
         if not hasattr(os, "symlink"):

--- a/gluon/tests/test_recfile.py
+++ b/gluon/tests/test_recfile.py
@@ -208,8 +208,13 @@ class TestRecfile(unittest.TestCase):
 
         self.assertFalse(recfile.exists(link_path, path=sandbox))
         self.assertRaises(IOError, recfile.open, link_path, "r", path=sandbox)
-        self.assertRaises(IOError, recfile.open, link_path, "w", path=sandbox)
         self.assertRaises(IOError, recfile.remove, link_path, path=sandbox)
+
+        # Write mode rewrites the name to a generated (hashed) path, so it never
+        # follows the symlink. The write is confined inside the sandbox and the
+        # outside file is left untouched.
+        with recfile.open(link_path, "w", path=sandbox) as f:
+            f.write("confined")
 
         with open(outside_file) as g:
             self.assertEqual(g.read(), "outside")

--- a/gluon/tests/test_recfile.py
+++ b/gluon/tests/test_recfile.py
@@ -6,6 +6,7 @@
 """
 import os
 import shutil
+import tempfile
 import unittest
 import uuid
 
@@ -71,3 +72,125 @@ class TestRecfile(unittest.TestCase):
         self.assertFalse(recfile.exists(filename))
         self.assertRaises(IOError, recfile.remove, filename)
         self.assertRaises(IOError, recfile.open, filename, "r")
+
+    def test_path_argument_confines_generated_files(self):
+        parent = tempfile.mkdtemp(dir=os.getcwd())
+        self.addCleanup(lambda parent=parent: shutil.rmtree(parent, ignore_errors=True))
+        sandbox = os.path.join(parent, "sandbox")
+        outside_dir = os.path.join(parent, "outside")
+        os.mkdir(sandbox)
+        os.mkdir(outside_dir)
+
+        outside_name = str(uuid.uuid4()) + ".test"
+        outside_path = os.path.join(outside_dir, outside_name)
+        with open(outside_path, "w") as g:
+            g.write("outside")
+
+        escape_paths = [
+            os.path.join("..", "outside", outside_name),
+            outside_path,
+        ]
+        for escape_path in escape_paths:
+            self.assertFalse(recfile.exists(escape_path, path=sandbox))
+            self.assertRaises(IOError, recfile.open, escape_path, "r", path=sandbox)
+            self.assertRaises(IOError, recfile.open, escape_path, "w", path=sandbox)
+            self.assertRaises(IOError, recfile.remove, escape_path, path=sandbox)
+
+        with open(outside_path) as g:
+            self.assertEqual(g.read(), "outside")
+
+    def test_path_argument_rejects_absolute_filenames(self):
+        filename = os.path.abspath(str(uuid.uuid4()) + ".test")
+
+        self.assertRaises(IOError, recfile.open, filename, "w", path="tests")
+        self.assertFalse(recfile.exists(filename, path="tests"))
+        self.assertRaises(IOError, recfile.remove, filename, path="tests")
+
+    def test_path_argument_handles_root_paths(self):
+        root = os.path.abspath(os.sep)
+
+        sandbox = tempfile.mkdtemp(dir=os.getcwd())
+        self.addCleanup(lambda sandbox=sandbox: shutil.rmtree(sandbox, ignore_errors=True))
+
+        existing_path = os.path.join(sandbox, "existing.test")
+        with open(existing_path, "w") as g:
+            g.write("existing")
+
+        with recfile.open(existing_path, "r", path=root) as f:
+            self.assertEqual(f.read(), "existing")
+        self.assertTrue(recfile.exists(existing_path, path=root))
+        recfile.remove(existing_path, path=root)
+        self.assertFalse(os.path.exists(existing_path))
+
+        generated_path = os.path.join(sandbox, "generated", "payload.test")
+        self.assertFalse(os.path.exists(generated_path))
+        with recfile.open(generated_path, "w", path=root) as g:
+            g.write("generated")
+        with recfile.open(generated_path, "r", path=root) as f:
+            self.assertEqual(f.read(), "generated")
+        self.assertTrue(recfile.exists(generated_path, path=root))
+        self.assertFalse(os.path.exists(generated_path))
+        recfile.remove(generated_path, path=root)
+        self.assertFalse(recfile.exists(generated_path, path=root))
+
+    def test_is_within_fallback_handles_root_paths(self):
+        original_path = recfile.os.path
+
+        class PathShim(object):
+            abspath = staticmethod(os.path.abspath)
+            dirname = staticmethod(os.path.dirname)
+            exists = staticmethod(os.path.exists)
+            isabs = staticmethod(os.path.isabs)
+            join = staticmethod(os.path.join)
+            normcase = staticmethod(os.path.normcase)
+            relpath = staticmethod(os.path.relpath)
+            realpath = staticmethod(os.path.realpath)
+            sep = os.path.sep
+            split = staticmethod(os.path.split)
+            splitdrive = staticmethod(os.path.splitdrive)
+            curdir = os.curdir
+            pardir = os.pardir
+
+        try:
+            recfile.os.path = PathShim
+            parent = tempfile.mkdtemp(dir=os.getcwd())
+            self.addCleanup(lambda parent=parent: shutil.rmtree(parent, ignore_errors=True))
+            root = os.path.join(parent, "sandbox")
+            outside_root = os.path.join(parent, "outside")
+            os.mkdir(root)
+            os.mkdir(outside_root)
+            inside = os.path.join(root, "inside.test")
+            outside = os.path.join(outside_root, "outside.test")
+            self.assertTrue(recfile._is_within(inside, root))
+            self.assertFalse(recfile._is_within(outside, root))
+        finally:
+            recfile.os.path = original_path
+
+    def test_path_argument_rejects_symlink_escapes(self):
+        if not hasattr(os, "symlink"):
+            self.skipTest("symlinks are not supported on this platform")
+
+        parent = tempfile.mkdtemp(dir=os.getcwd())
+        self.addCleanup(lambda parent=parent: shutil.rmtree(parent, ignore_errors=True))
+        sandbox = os.path.join(parent, "sandbox")
+        outside_dir = os.path.join(parent, "outside")
+        os.mkdir(sandbox)
+        os.mkdir(outside_dir)
+
+        outside_file = os.path.join(outside_dir, "outside.test")
+        with open(outside_file, "w") as g:
+            g.write("outside")
+
+        link_path = os.path.join(sandbox, "escape.test")
+        try:
+            os.symlink(outside_file, link_path)
+        except (OSError, NotImplementedError) as exc:
+            self.skipTest(str(exc))
+
+        self.assertFalse(recfile.exists(link_path, path=sandbox))
+        self.assertRaises(IOError, recfile.open, link_path, "r", path=sandbox)
+        self.assertRaises(IOError, recfile.open, link_path, "w", path=sandbox)
+        self.assertRaises(IOError, recfile.remove, link_path, path=sandbox)
+
+        with open(outside_file) as g:
+            self.assertEqual(g.read(), "outside")


### PR DESCRIPTION
## Summary

Constrain `recfile` operations to the configured storage root when `path=` is supplied.

This change prevents traversal and absolute-path escapes from accessing files outside the intended storage directory while preserving valid inside-root behavior.

## Changes

* Added centralized path confinement helpers for canonicalized boundary validation
* Confined generated and existing paths to the supplied storage root
* Blocked:

  * `../` traversal escapes
  * absolute-path escapes
  * symlink escapes outside the configured root
* Preserved legitimate access to existing files already inside the configured root
* Added Python 2-compatible fallback handling for environments without `os.path.commonpath`

## Regression Coverage

Added tests for:

* traversal escape attempts
* absolute-path escape attempts
* root-path handling
* symlink escape handling
* fallback containment logic
* preserving outside files during rejected operations