### PR TITLE
Make legacy secure_loads payloads honor safe_unpickle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,39 @@
+## 3.1 - 3.3.X
 
+Security hardening since 3.0.x. Two opt-in features are worth calling out:
+
+- Opt-in safe-unpickle sessions: `session.connect(..., safe_unpickle=True)`
+  loads session data through a restricted unpickler instead of raw
+  `pickle.loads()`. Pass `pickle_allowed_classes={module: [names]}` to allow
+  specific classes. Defaults to `False` for backward compatibility; legacy
+  one-colon `secure_loads` payloads now honor the same flag.
+- Opt-in Content-Security-Policy: `response.enable_csp(**directives)` emits a
+  per-request nonce-based CSP header (`default-src 'self'`, nonce'd
+  `script-src`/`style-src`), with directive/token validation. Use
+  `response.nonce` on inline `<script>`/`<style>` tags.
+
+Breaking change:
+
+- `Auth.url(scheme=True)` (absolute URLs, used for password-reset and
+  verification emails) no longer derives the host from the client-supplied
+  `Host:` header. You must configure a trusted host via
+  `auth.settings.host` or an allowlist in `auth.settings.host_names`;
+  otherwise an `HTTP 500` is raised.
+
+Other security fixes in this range:
+
+- Hardened ticket deserialization with the restricted unpickler
+- `safe_load()` used for YAML deserialization in `loads_yaml`
+- Fixed XSS sanitizer attribute-breakout in `XML(..., sanitize=True)`
+- Escaped include file URLs and meta names before HTML attribute rendering
+- Added `SAFEJSON` helper for safe JSON embedding in script contexts
+- Removed `eval` on user-controlled input in appadmin; AST-validated expressions
+- Fixed directory traversal in admin unzip and hardened tar extraction paths
+- Prevented sibling-prefix traversal in static file routing
+- Hardened `Content-Disposition` filenames (attachments and SQLFORM.grid export)
+- Hardened temporary plugin filename handling in `plugin_install()`
+- CAS service allowlist validation
+- `secrets` module used for secure password generation
 
 ## 2.99 - 3.0.X
 

--- a/gluon/tests/test_utils.py
+++ b/gluon/tests/test_utils.py
@@ -200,6 +200,20 @@ class TestUtils(unittest.TestCase):
             secure_loads(secured, testkey, safe_unpickle=False),
         )
 
+    def test_secure_loads_deprecated_handles_compressed_payload(self):
+        """Legacy compressed data round-trips through the restricted unpickler."""
+        testobj = {"a": 1, "b": 2}
+        testkey = "mysecret"
+        secured = gluon.utils.secure_dumps_deprecated(
+            testobj, testkey, compression_level=9
+        )
+        self.assertEqual(secured.count(b":"), 1)
+
+        self.assertEqual(
+            testobj,
+            secure_loads(secured, testkey, compression_level=9),
+        )
+
     # TODO: def test_initialize_urandom(self):
 
     # TODO: def test_fast_urandom16(self):

--- a/gluon/tests/test_utils.py
+++ b/gluon/tests/test_utils.py
@@ -4,6 +4,8 @@
 """ Unit tests for utils.py """
 
 import pickle
+import os
+import tempfile
 import unittest
 from hashlib import md5
 
@@ -164,6 +166,39 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(wrong3, None)
         wrong4 = secure_loads(b"abc", "a", "b")
         self.assertEqual(wrong4, None)
+
+    def test_secure_loads_deprecated_blocks_rce_payload_by_default(self):
+        """Legacy signed data must use the restricted unpickler by default."""
+        sentinel_fd, sentinel_path = tempfile.mkstemp(prefix="web2py_legacy_rce_")
+        os.close(sentinel_fd)
+        os.remove(sentinel_path)
+
+        class Exploit:
+            def __reduce__(self):
+                return (open, (sentinel_path, "w"))
+
+        testkey = "mysecret"
+        secured = gluon.utils.secure_dumps_deprecated(Exploit(), testkey)
+        self.assertEqual(secured.count(b":"), 1)
+
+        try:
+            self.assertIsNone(secure_loads(secured, testkey))
+            self.assertFalse(os.path.exists(sentinel_path))
+        finally:
+            if os.path.exists(sentinel_path):
+                os.remove(sentinel_path)
+
+    def test_secure_loads_deprecated_can_opt_in_to_legacy_pickle(self):
+        """Callers that explicitly request old behavior keep compatibility."""
+        testobj = {"a": 1, "b": 2}
+        testkey = "mysecret"
+        secured = gluon.utils.secure_dumps_deprecated(testobj, testkey)
+        self.assertEqual(secured.count(b":"), 1)
+
+        self.assertEqual(
+            testobj,
+            secure_loads(secured, testkey, safe_unpickle=False),
+        )
 
     # TODO: def test_initialize_urandom(self):
 

--- a/gluon/utils.py
+++ b/gluon/utils.py
@@ -189,7 +189,12 @@ def secure_loads(
     components = data.count(b":")
     if components == 1:
         return secure_loads_deprecated(
-            data, encryption_key, hash_key, compression_level
+            data,
+            encryption_key,
+            hash_key,
+            compression_level,
+            safe_unpickle=safe_unpickle,
+            allowed_classes=allowed_classes,
         )
     if components != 2:
         return None
@@ -249,7 +254,12 @@ def secure_dumps_deprecated(
 
 
 def secure_loads_deprecated(
-    data, encryption_key, hash_key=None, compression_level=None
+    data,
+    encryption_key,
+    hash_key=None,
+    compression_level=None,
+    safe_unpickle=True,
+    allowed_classes=None,
 ):
     """loads signed data (deprecated because of incorrect padding)"""
     encryption_key = encryption_key.encode("utf8")
@@ -275,6 +285,10 @@ def secure_loads_deprecated(
         data = data.rstrip(b" ")
         if compression_level:
             data = zlib.decompress(data)
+        if safe_unpickle:
+            from gluon.restricted import safe_loads as safe_loads_restricted
+
+            return safe_loads_restricted(data, allowed_classes=allowed_classes)
         return pickle.loads(data)
     except Exception:
         return None


### PR DESCRIPTION
## Summary

The modern `secure_loads()` path already supports `safe_unpickle` and `allowed_classes`, but the deprecated one-colon payload format ignored those options and always deserialized with raw `pickle.loads()` after signature verification and decryption.

This change makes the deprecated format path honor the same `safe_unpickle` behavior as the modern path while preserving explicit legacy compatibility with `safe_unpickle=False`.

## Changes

- Propagate `safe_unpickle` and `allowed_classes` from `secure_loads()` into the deprecated payload path.
- Make `secure_loads_deprecated()` use the restricted unpickler by default.
- Preserve previous raw pickle behavior when `safe_unpickle=False` is explicitly requested.
- Add regression coverage for signed legacy-format payloads using a reduce-based pickle payload.
- Add compatibility coverage verifying explicit opt-out behavior still works.
- Add assertions verifying the deprecated one-colon format path is exercised.