### PR TITLE
Centralize Content-Disposition filename handling across export and download paths

### DIFF
--- a/applications/admin/controllers/appadmin.py
+++ b/applications/admin/controllers/appadmin.py
@@ -10,6 +10,7 @@ import copy
 import gluon.contenttype
 import gluon.fileutils
 import gluon.utils
+from gluon.globals import _content_disposition_header
 
 is_gae = request.env.web2py_runtime_gae or False
 
@@ -166,8 +167,9 @@ def csv():
     query = get_query(request)
     if not query:
         return None
-    response.headers['Content-disposition'] = 'attachment; filename=%s_%s.csv'\
-        % tuple(request.vars.query.split('.')[:2])
+    response.headers['Content-disposition'] = _content_disposition_header(
+        '%s_%s.csv' % tuple(request.vars.query.split('.')[:2])
+    )
     return str(db(query, ignore_common_filters=True).select())
 
 

--- a/applications/admin/controllers/appadmin.py
+++ b/applications/admin/controllers/appadmin.py
@@ -10,7 +10,7 @@ import copy
 import gluon.contenttype
 import gluon.fileutils
 import gluon.utils
-from gluon.globals import _content_disposition_header
+from gluon.http import content_disposition_header
 
 is_gae = request.env.web2py_runtime_gae or False
 
@@ -167,7 +167,7 @@ def csv():
     query = get_query(request)
     if not query:
         return None
-    response.headers['Content-disposition'] = _content_disposition_header(
+    response.headers['Content-disposition'] = content_disposition_header(
         '%s_%s.csv' % tuple(request.vars.query.split('.')[:2])
     )
     return str(db(query, ignore_common_filters=True).select())

--- a/applications/admin/controllers/default.py
+++ b/applications/admin/controllers/default.py
@@ -17,6 +17,7 @@ import importlib
 from gluon.admin import *
 from gluon.admin import check_app_path, is_within_root, join_app_path
 from gluon.fileutils import abspath, read_file, write_file
+from gluon.globals import _content_disposition_header
 from gluon.restricted import safe_load, safe_loads, TicketStorage
 from gluon.utils import web2py_uuid
 from gluon.tools import Config, prevent_open_redirect
@@ -386,8 +387,7 @@ def pack():
 
     if filename:
         response.headers['Content-Type'] = 'application/w2p'
-        disposition = 'attachment; filename=%s' % fname
-        response.headers['Content-Disposition'] = disposition
+        response.headers['Content-Disposition'] = _content_disposition_header(fname)
         return safe_read(filename, 'rb')
     else:
         session.flash = T('internal error: %s', pferror)
@@ -401,8 +401,7 @@ def pack_plugin():
         filename = plugin_pack(app, request.args[1], request)
     if filename:
         response.headers['Content-Type'] = 'application/w2p'
-        disposition = 'attachment; filename=%s' % fname
-        response.headers['Content-Disposition'] = disposition
+        response.headers['Content-Disposition'] = _content_disposition_header(fname)
         return safe_read(filename, 'rb')
     else:
         session.flash = T('internal error')
@@ -428,7 +427,9 @@ def pack_exe(app, base, filenames=None):
         web2py_win.write(fname, arcname)
     web2py_win.close()
     response.headers['Content-Type'] = 'application/zip'
-    response.headers['Content-Disposition'] = 'attachment; filename=web2py.app.%s.zip' % app
+    response.headers['Content-Disposition'] = _content_disposition_header(
+        'web2py.app.%s.zip' % app
+    )
     out.seek(0)
     return response.stream(out)
 
@@ -458,8 +459,7 @@ def pack_custom():
                 filename = None
             if filename:
                 response.headers['Content-Type'] = 'application/w2p'
-                disposition = 'attachment; filename=%s' % fname
-                response.headers['Content-Disposition'] = disposition
+                response.headers['Content-Disposition'] = _content_disposition_header(fname)
                 return safe_read(filename, 'rb')
             else:
                 session.flash = T('internal error: %s', e)

--- a/applications/admin/controllers/default.py
+++ b/applications/admin/controllers/default.py
@@ -17,7 +17,7 @@ import importlib
 from gluon.admin import *
 from gluon.admin import check_app_path, is_within_root, join_app_path
 from gluon.fileutils import abspath, read_file, write_file
-from gluon.globals import _content_disposition_header
+from gluon.http import content_disposition_header
 from gluon.restricted import safe_load, safe_loads, TicketStorage
 from gluon.utils import web2py_uuid
 from gluon.tools import Config, prevent_open_redirect
@@ -387,7 +387,7 @@ def pack():
 
     if filename:
         response.headers['Content-Type'] = 'application/w2p'
-        response.headers['Content-Disposition'] = _content_disposition_header(fname)
+        response.headers['Content-Disposition'] = content_disposition_header(fname)
         return safe_read(filename, 'rb')
     else:
         session.flash = T('internal error: %s', pferror)
@@ -401,7 +401,7 @@ def pack_plugin():
         filename = plugin_pack(app, request.args[1], request)
     if filename:
         response.headers['Content-Type'] = 'application/w2p'
-        response.headers['Content-Disposition'] = _content_disposition_header(fname)
+        response.headers['Content-Disposition'] = content_disposition_header(fname)
         return safe_read(filename, 'rb')
     else:
         session.flash = T('internal error')
@@ -427,7 +427,7 @@ def pack_exe(app, base, filenames=None):
         web2py_win.write(fname, arcname)
     web2py_win.close()
     response.headers['Content-Type'] = 'application/zip'
-    response.headers['Content-Disposition'] = _content_disposition_header(
+    response.headers['Content-Disposition'] = content_disposition_header(
         'web2py.app.%s.zip' % app
     )
     out.seek(0)
@@ -459,7 +459,7 @@ def pack_custom():
                 filename = None
             if filename:
                 response.headers['Content-Type'] = 'application/w2p'
-                response.headers['Content-Disposition'] = _content_disposition_header(fname)
+                response.headers['Content-Disposition'] = content_disposition_header(fname)
                 return safe_read(filename, 'rb')
             else:
                 session.flash = T('internal error: %s', e)

--- a/applications/examples/controllers/appadmin.py
+++ b/applications/examples/controllers/appadmin.py
@@ -10,6 +10,7 @@ import copy
 import gluon.contenttype
 import gluon.fileutils
 import gluon.utils
+from gluon.globals import _content_disposition_header
 
 is_gae = request.env.web2py_runtime_gae or False
 
@@ -166,8 +167,9 @@ def csv():
     query = get_query(request)
     if not query:
         return None
-    response.headers['Content-disposition'] = 'attachment; filename=%s_%s.csv'\
-        % tuple(request.vars.query.split('.')[:2])
+    response.headers['Content-disposition'] = _content_disposition_header(
+        '%s_%s.csv' % tuple(request.vars.query.split('.')[:2])
+    )
     return str(db(query, ignore_common_filters=True).select())
 
 

--- a/applications/examples/controllers/appadmin.py
+++ b/applications/examples/controllers/appadmin.py
@@ -10,7 +10,7 @@ import copy
 import gluon.contenttype
 import gluon.fileutils
 import gluon.utils
-from gluon.globals import _content_disposition_header
+from gluon.http import content_disposition_header
 
 is_gae = request.env.web2py_runtime_gae or False
 
@@ -167,7 +167,7 @@ def csv():
     query = get_query(request)
     if not query:
         return None
-    response.headers['Content-disposition'] = _content_disposition_header(
+    response.headers['Content-disposition'] = content_disposition_header(
         '%s_%s.csv' % tuple(request.vars.query.split('.')[:2])
     )
     return str(db(query, ignore_common_filters=True).select())

--- a/applications/welcome/controllers/appadmin.py
+++ b/applications/welcome/controllers/appadmin.py
@@ -10,6 +10,7 @@ import copy
 import gluon.contenttype
 import gluon.fileutils
 import gluon.utils
+from gluon.globals import _content_disposition_header
 
 is_gae = request.env.web2py_runtime_gae or False
 
@@ -166,8 +167,9 @@ def csv():
     query = get_query(request)
     if not query:
         return None
-    response.headers['Content-disposition'] = 'attachment; filename=%s_%s.csv'\
-        % tuple(request.vars.query.split('.')[:2])
+    response.headers['Content-disposition'] = _content_disposition_header(
+        '%s_%s.csv' % tuple(request.vars.query.split('.')[:2])
+    )
     return str(db(query, ignore_common_filters=True).select())
 
 

--- a/applications/welcome/controllers/appadmin.py
+++ b/applications/welcome/controllers/appadmin.py
@@ -10,7 +10,7 @@ import copy
 import gluon.contenttype
 import gluon.fileutils
 import gluon.utils
-from gluon.globals import _content_disposition_header
+from gluon.http import content_disposition_header
 
 is_gae = request.env.web2py_runtime_gae or False
 
@@ -167,7 +167,7 @@ def csv():
     query = get_query(request)
     if not query:
         return None
-    response.headers['Content-disposition'] = _content_disposition_header(
+    response.headers['Content-disposition'] = content_disposition_header(
         '%s_%s.csv' % tuple(request.vars.query.split('.')[:2])
     )
     return str(db(query, ignore_common_filters=True).select())

--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -129,6 +129,7 @@ template_mapping_csp = {
 
 CSP_DIRECTIVE = re.compile(r"^[A-Za-z0-9-]+$")
 CSP_DIRECTIVE_TOKEN = re.compile(r"^[\x21-\x2B\x2D-\x3A\x3C-\x7E]+$")
+CONTENT_DISPOSITION_TYPE = re.compile(r"^[A-Za-z0-9!#$%&'*+.^_`|~-]+$")
 CSP_STANDARD_DIRECTIVES = frozenset(
     (
         "base-uri",
@@ -174,6 +175,15 @@ def _content_disposition_filename(filename):
     if isinstance(filename, bytes):
         return urllib_quote(filename, safe=b"")
     return urllib_quote(str(filename), safe="")
+
+
+def _content_disposition_header(filename, disposition="attachment"):
+    if not CONTENT_DISPOSITION_TYPE.fullmatch(disposition):
+        raise ValueError("invalid Content-Disposition type: %r" % disposition)
+    return '%s; filename="%s"' % (
+        disposition,
+        _content_disposition_filename(filename),
+    )
 
 
 # IMPORTANT:
@@ -913,8 +923,7 @@ class Response(Storage):
         # for attachment settings and backward compatibility
         keys = [item.lower() for item in headers]
         if attachment:
-            attname = _content_disposition_filename(filename)
-            headers["Content-Disposition"] = 'attachment; filename="%s"' % attname
+            headers["Content-Disposition"] = _content_disposition_header(filename)
 
         if not request:
             request = current.request
@@ -1002,11 +1011,8 @@ class Response(Storage):
         if download_filename is None:
             download_filename = filename
         if attachment:
-            # Browsers still don't have a simple uniform way to have non ascii
-            # characters in the filename so for now we are percent encoding it
-            download_filename = _content_disposition_filename(download_filename)
-            headers["Content-Disposition"] = (
-                'attachment; filename="%s"' % download_filename
+            headers["Content-Disposition"] = _content_disposition_header(
+                download_filename
             )
         return self.stream(stream, chunk_size=chunk_size, request=request)
 

--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -62,7 +62,6 @@ from io import BytesIO, StringIO
 from pickle import DICT, EMPTY_DICT, MARK, Pickler
 from urllib import parse as urlparse
 from urllib.parse import parse_qs
-from urllib.parse import quote as urllib_quote
 
 from pydal.contrib import portalocker
 from pydal.utils import utcnow
@@ -75,7 +74,7 @@ from gluon.restricted import safe_load, safe_loads
 from gluon.contrib.multipart import MultipartParser, ParserError, parse_options_header
 from gluon.fileutils import up
 from gluon.html import PRE, TABLE, TR, URL, xmlescape
-from gluon.http import HTTP, redirect
+from gluon.http import HTTP, content_disposition_header, redirect
 from gluon.serializers import custom_json, json
 from gluon.settings import global_settings
 from gluon.storage import List, Storage
@@ -129,7 +128,6 @@ template_mapping_csp = {
 
 CSP_DIRECTIVE = re.compile(r"^[A-Za-z0-9-]+$")
 CSP_DIRECTIVE_TOKEN = re.compile(r"^[\x21-\x2B\x2D-\x3A\x3C-\x7E]+$")
-CONTENT_DISPOSITION_TYPE = re.compile(r"^[A-Za-z0-9!#$%&'*+.^_`|~-]+$")
 CSP_STANDARD_DIRECTIVES = frozenset(
     (
         "base-uri",
@@ -165,25 +163,6 @@ CSP_STANDARD_DIRECTIVES = frozenset(
         "worker-src",
     )
 )
-
-
-def _content_disposition_filename(filename):
-    if filename is None:
-        filename = ""
-    # Keep historical semantics for normal values while ensuring dangerous
-    # bytes are encoded before insertion in a quoted header parameter.
-    if isinstance(filename, bytes):
-        return urllib_quote(filename, safe=b"")
-    return urllib_quote(str(filename), safe="")
-
-
-def _content_disposition_header(filename, disposition="attachment"):
-    if not CONTENT_DISPOSITION_TYPE.fullmatch(disposition):
-        raise ValueError("invalid Content-Disposition type: %r" % disposition)
-    return '%s; filename="%s"' % (
-        disposition,
-        _content_disposition_filename(filename),
-    )
 
 
 # IMPORTANT:
@@ -923,7 +902,7 @@ class Response(Storage):
         # for attachment settings and backward compatibility
         keys = [item.lower() for item in headers]
         if attachment:
-            headers["Content-Disposition"] = _content_disposition_header(filename)
+            headers["Content-Disposition"] = content_disposition_header(filename)
 
         if not request:
             request = current.request
@@ -1011,7 +990,7 @@ class Response(Storage):
         if download_filename is None:
             download_filename = filename
         if attachment:
-            headers["Content-Disposition"] = _content_disposition_header(
+            headers["Content-Disposition"] = content_disposition_header(
                 download_filename
             )
         return self.stream(stream, chunk_size=chunk_size, request=request)

--- a/gluon/http.py
+++ b/gluon/http.py
@@ -11,8 +11,18 @@ HTTP statuses helpers
 """
 
 import re
+from urllib.parse import quote as urllib_quote
 
-__all__ = ["HTTP", "redirect"]
+__all__ = [
+    "HTTP",
+    "redirect",
+    "content_disposition_filename",
+    "content_disposition_header",
+]
+
+# RFC 7230 token characters: the only bytes allowed in a Content-Disposition
+# disposition type (e.g. "attachment", "inline").
+CONTENT_DISPOSITION_TYPE = re.compile(r"^[A-Za-z0-9!#$%&'*+.^_`|~-]+$")
 
 defined_status = {
     200: "OK",
@@ -190,3 +200,22 @@ def redirect(location="", how=303, client_side=False, headers=None):
         if client_side and current.request.ajax:
             headers["web2py-component-command"] = "window.location.reload(true)"
             raise HTTP(200, **headers)
+
+
+def content_disposition_filename(filename):
+    if filename is None:
+        filename = ""
+    # Keep historical semantics for normal values while ensuring dangerous
+    # bytes are encoded before insertion in a quoted header parameter.
+    if isinstance(filename, bytes):
+        return urllib_quote(filename, safe=b"")
+    return urllib_quote(str(filename), safe="")
+
+
+def content_disposition_header(filename, disposition="attachment"):
+    if not CONTENT_DISPOSITION_TYPE.fullmatch(disposition):
+        raise ValueError("invalid Content-Disposition type: %r" % disposition)
+    return '%s; filename="%s"' % (
+        disposition,
+        content_disposition_filename(filename),
+    )

--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -32,7 +32,7 @@ from pydal.helpers.methods import _repr_ref, bar_encode, merge_tablemaps, smart_
 from pydal.objects import Expression, Field, Row, Rows, Set, Table
 
 import gluon.serializers as serializers
-from gluon.globals import _content_disposition_header, current
+from gluon.globals import current
 from gluon.html import (
     BR,
     CAT,
@@ -67,7 +67,7 @@ from gluon.html import (
     XmlComponent,
     truncate_string,
 )
-from gluon.http import HTTP, redirect
+from gluon.http import HTTP, content_disposition_header, redirect
 from gluon.storage import Storage
 from gluon.utils import md5_hash
 from gluon.validators import (
@@ -3164,7 +3164,7 @@ class SQLFORM(FORM):
                 # http layer only strips CR/LF, so `"` and `;` would survive.
                 # Reuse the shared Content-Disposition filename helper.
                 response.headers["Content-Type"] = oExp.content_type
-                response.headers["Content-Disposition"] = _content_disposition_header(
+                response.headers["Content-Disposition"] = content_disposition_header(
                     "%s.%s" % (export_filename, oExp.file_ext)
                 )
                 raise HTTP(200, oExp.export(), **response.headers)

--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -32,7 +32,7 @@ from pydal.helpers.methods import _repr_ref, bar_encode, merge_tablemaps, smart_
 from pydal.objects import Expression, Field, Row, Rows, Set, Table
 
 import gluon.serializers as serializers
-from gluon.globals import _content_disposition_filename, current
+from gluon.globals import _content_disposition_header, current
 from gluon.html import (
     BR,
     CAT,
@@ -3162,15 +3162,10 @@ class SQLFORM(FORM):
                 # attacker inject extra directives (e.g. a second `filename=`)
                 # by submitting `_export_filename=a";filename=evil.exe`. The
                 # http layer only strips CR/LF, so `"` and `;` would survive.
-                # Percent-encode via the same helper used by Response.stream
-                # / Response.download (see commit 3e656ed7).
-                filename = "%s.%s" % (
-                    _content_disposition_filename(export_filename),
-                    oExp.file_ext,
-                )
+                # Reuse the shared Content-Disposition filename helper.
                 response.headers["Content-Type"] = oExp.content_type
-                response.headers["Content-Disposition"] = (
-                    'attachment; filename="%s"' % filename
+                response.headers["Content-Disposition"] = _content_disposition_header(
+                    "%s.%s" % (export_filename, oExp.file_ext)
                 )
                 raise HTTP(200, oExp.export(), **response.headers)
 

--- a/gluon/tests/test_globals.py
+++ b/gluon/tests/test_globals.py
@@ -13,7 +13,7 @@ import unittest
 from io import BytesIO
 
 from gluon.html import XML, URL
-from gluon.globals import Request, Response, Session
+from gluon.globals import Request, Response, Session, _content_disposition_header
 from gluon.http import HTTP
 from gluon.rewrite import regex_url_in
 from gluon.streamer import stream_file_or_304_or_206
@@ -501,6 +501,24 @@ class testResponse(unittest.TestCase):
             response.headers["Content-Disposition"],
             'attachment; filename="caf%C3%A9.txt"',
         )
+
+    def test_content_disposition_header_encodes_admin_csv_filename(self):
+        filename = 'auth_user"; filename=evil.exe.csv'
+
+        disposition = _content_disposition_header(filename)
+
+        self.assertEqual(
+            disposition,
+            'attachment; filename="auth_user%22%3B%20filename%3Devil.exe.csv"',
+        )
+        self.assertEqual(disposition.count(";"), 1)
+        self.assertNotIn("filename=evil.exe", disposition)
+
+    def test_content_disposition_header_rejects_invalid_disposition_type(self):
+        with self.assertRaises(ValueError):
+            _content_disposition_header("report.csv", "attachment\r\nX-Evil: yes")
+        with self.assertRaises(ValueError):
+            _content_disposition_header("report.csv", 'attachment"; filename=evil')
 
     def test_stream_file_range(self):
         fd, path = tempfile.mkstemp()

--- a/gluon/tests/test_globals.py
+++ b/gluon/tests/test_globals.py
@@ -13,7 +13,7 @@ import unittest
 from io import BytesIO
 
 from gluon.html import XML, URL
-from gluon.globals import Request, Response, Session, _content_disposition_header
+from gluon.globals import Request, Response, Session
 from gluon.http import HTTP
 from gluon.rewrite import regex_url_in
 from gluon.streamer import stream_file_or_304_or_206
@@ -501,24 +501,6 @@ class testResponse(unittest.TestCase):
             response.headers["Content-Disposition"],
             'attachment; filename="caf%C3%A9.txt"',
         )
-
-    def test_content_disposition_header_encodes_admin_csv_filename(self):
-        filename = 'auth_user"; filename=evil.exe.csv'
-
-        disposition = _content_disposition_header(filename)
-
-        self.assertEqual(
-            disposition,
-            'attachment; filename="auth_user%22%3B%20filename%3Devil.exe.csv"',
-        )
-        self.assertEqual(disposition.count(";"), 1)
-        self.assertNotIn("filename=evil.exe", disposition)
-
-    def test_content_disposition_header_rejects_invalid_disposition_type(self):
-        with self.assertRaises(ValueError):
-            _content_disposition_header("report.csv", "attachment\r\nX-Evil: yes")
-        with self.assertRaises(ValueError):
-            _content_disposition_header("report.csv", 'attachment"; filename=evil')
 
     def test_stream_file_range(self):
         fd, path = tempfile.mkstemp()

--- a/gluon/tests/test_http.py
+++ b/gluon/tests/test_http.py
@@ -5,7 +5,7 @@
 
 import unittest
 
-from gluon.http import HTTP, defined_status
+from gluon.http import HTTP, content_disposition_header, defined_status
 
 
 class TestHTTP(unittest.TestCase):
@@ -36,3 +36,25 @@ class TestHTTP(unittest.TestCase):
             )
 
         # test wrong call detection
+
+
+class TestContentDisposition(unittest.TestCase):
+    """Tests http.content_disposition_header"""
+
+    def test_content_disposition_header_encodes_admin_csv_filename(self):
+        filename = 'auth_user"; filename=evil.exe.csv'
+
+        disposition = content_disposition_header(filename)
+
+        self.assertEqual(
+            disposition,
+            'attachment; filename="auth_user%22%3B%20filename%3Devil.exe.csv"',
+        )
+        self.assertEqual(disposition.count(";"), 1)
+        self.assertNotIn("filename=evil.exe", disposition)
+
+    def test_content_disposition_header_rejects_invalid_disposition_type(self):
+        with self.assertRaises(ValueError):
+            content_disposition_header("report.csv", "attachment\r\nX-Evil: yes")
+        with self.assertRaises(ValueError):
+            content_disposition_header("report.csv", 'attachment"; filename=evil')


### PR DESCRIPTION
## Summary

Centralize `Content-Disposition` filename handling and reuse the existing filename normalization behavior across export and download paths.

## Changes

* Added shared internal helper:

  * `_content_disposition_header()`
* Replaced duplicated manual `Content-Disposition` formatting in:

  * `Response.stream()`
  * `Response.download()`
  * SQLFORM export responses
  * admin/appadmin download/export handlers
* Reused the existing `_content_disposition_filename()` encoding behavior consistently across all paths.
* Added validation for disposition tokens before constructing headers.
* Added regression tests covering:

  * malformed duplicate `filename=` parameter construction
  * invalid disposition types

## Why

Some export/download paths manually interpolated filenames directly into `Content-Disposition` headers, while other framework paths already normalized filenames before insertion.

This change consolidates that behavior behind a shared helper so request-influenced filenames cannot produce malformed duplicate header parameters and filename handling remains consistent across the framework.