### PR TITLE
handling of HTTP suffix byte ranges

### DIFF
--- a/gluon/streamer.py
+++ b/gluon/streamer.py
@@ -22,6 +22,7 @@ from gluon.utils import unlocalised_http_header_date
 
 regex_start_range = re.compile(r"\d+(?=\-)")
 regex_stop_range = re.compile(r"(?<=\-)\d+")
+regex_suffix_range = re.compile(r"^bytes=-(\d+)$")
 
 DEFAULT_CHUNK_SIZE = 64 * 1024
 
@@ -85,7 +86,7 @@ def stream_file_or_304_or_206(
 
         elif request and request.env.http_range:
             range_header = request.env.http_range
-            suffix_range = re.match(r"^bytes=-(\d+)$", range_header)
+            suffix_range = regex_suffix_range.match(range_header)
             if suffix_range:
                 suffix_length = int(suffix_range.group(1))
                 part = (max(fsize - suffix_length, 0), fsize - 1, fsize)

--- a/gluon/streamer.py
+++ b/gluon/streamer.py
@@ -84,13 +84,19 @@ def stream_file_or_304_or_206(
             raise HTTP(304, **{"Content-Type": headers["Content-Type"]})
 
         elif request and request.env.http_range:
-            start_items = regex_start_range.findall(request.env.http_range)
-            if not start_items:
-                start_items = [0]
-            stop_items = regex_stop_range.findall(request.env.http_range)
-            if not stop_items or int(stop_items[0]) > fsize - 1:
-                stop_items = [fsize - 1]
-            part = (int(start_items[0]), int(stop_items[0]), fsize)
+            range_header = request.env.http_range
+            suffix_range = re.match(r"^bytes=-(\d+)$", range_header)
+            if suffix_range:
+                suffix_length = int(suffix_range.group(1))
+                part = (max(fsize - suffix_length, 0), fsize - 1, fsize)
+            else:
+                start_items = regex_start_range.findall(range_header)
+                if not start_items:
+                    start_items = [0]
+                stop_items = regex_stop_range.findall(range_header)
+                if not stop_items or int(stop_items[0]) > fsize - 1:
+                    stop_items = [fsize - 1]
+                part = (int(start_items[0]), int(stop_items[0]), fsize)
             if part[0] > part[1]:
                 headers["Content-Range"] = "bytes */%i" % fsize
                 raise HTTP(416, **headers)

--- a/gluon/tests/test_globals.py
+++ b/gluon/tests/test_globals.py
@@ -529,6 +529,15 @@ class testResponse(unittest.TestCase):
             self.assertEqual(ctx.exception.headers.get("Content-Length"), "5")
             b"".join(ctx.exception.body)  # exhaust the streamer so its finally: stream.close() runs cleanly
 
+            # Suffix byte ranges request the last N bytes.
+            request.env.http_range = "bytes=-4"
+            with self.assertRaises(HTTP) as ctx:
+                stream_file_or_304_or_206(path, request=request, headers={})
+            self.assertEqual(ctx.exception.status, 206)
+            self.assertEqual(ctx.exception.headers.get("Content-Range"), "bytes 6-9/10")
+            self.assertEqual(ctx.exception.headers.get("Content-Length"), "4")
+            self.assertEqual(b"".join(ctx.exception.body), b"6789")
+
         finally:
             try:
                 os.close(fd)

--- a/gluon/tests/test_globals.py
+++ b/gluon/tests/test_globals.py
@@ -538,6 +538,15 @@ class testResponse(unittest.TestCase):
             self.assertEqual(ctx.exception.headers.get("Content-Length"), "4")
             self.assertEqual(b"".join(ctx.exception.body), b"6789")
 
+            # A suffix larger than the file is clamped to the whole file.
+            request.env.http_range = "bytes=-9999"
+            with self.assertRaises(HTTP) as ctx:
+                stream_file_or_304_or_206(path, request=request, headers={})
+            self.assertEqual(ctx.exception.status, 206)
+            self.assertEqual(ctx.exception.headers.get("Content-Range"), "bytes 0-9/10")
+            self.assertEqual(ctx.exception.headers.get("Content-Length"), "10")
+            self.assertEqual(b"".join(ctx.exception.body), b"0123456789")
+
         finally:
             try:
                 os.close(fd)


### PR DESCRIPTION
## Summary

Fix handling of HTTP suffix byte ranges in `stream_file_or_304_or_206()`.

## Problem

Requests using suffix byte ranges (for example, `Range: bytes=-4`) are currently interpreted as starting at byte `0`.

For a 10-byte file:

```text
Range: bytes=-4
```

Current response:

```text
Content-Range: bytes 0-4/10
Body: 01234
```

Expected response:

```text
Content-Range: bytes 6-9/10
Body: 6789
```

## Root Cause

The range parser treats a missing start position as `0`, causing suffix ranges to be processed as normal byte ranges from the beginning of the file.

## Fix

* Detect suffix byte ranges (`bytes=-N`) explicitly.
* Calculate the correct start and end offsets for the last `N` bytes of the file.
* Preserve existing handling for standard ranges such as:

  * `bytes=0-4`
  * `bytes=4-`