### PR TITLE
handling of HTTP suffix byte ranges

### DIFF
--- a/gluon/streamer.py
+++ b/gluon/streamer.py
@@ -84,10 +84,14 @@ def stream_file_or_304_or_206(
             raise HTTP(304, **{"Content-Type": headers["Content-Type"]})
 
         elif request and request.env.http_range:
-            start_items = regex_start_range.findall(request.env.http_range)
-            if not start_items:
+            range_header = request.env.http_range
+            start_items = regex_start_range.findall(range_header)
+            stop_items = regex_stop_range.findall(range_header)
+            if not start_items and stop_items and range_header.startswith("bytes=-"):
+                start_items = [max(fsize - int(stop_items[0]), 0)]
+                stop_items = [fsize - 1]
+            elif not start_items:
                 start_items = [0]
-            stop_items = regex_stop_range.findall(request.env.http_range)
             if not stop_items or int(stop_items[0]) > fsize - 1:
                 stop_items = [fsize - 1]
             part = (int(start_items[0]), int(stop_items[0]), fsize)

--- a/gluon/tests/test_globals.py
+++ b/gluon/tests/test_globals.py
@@ -529,6 +529,15 @@ class testResponse(unittest.TestCase):
             self.assertEqual(ctx.exception.headers.get("Content-Length"), "5")
             b"".join(ctx.exception.body)  # exhaust the streamer so its finally: stream.close() runs cleanly
 
+            # Suffix byte ranges request the last N bytes of the representation.
+            request.env.http_range = "bytes=-5"
+            with self.assertRaises(HTTP) as ctx:
+                stream_file_or_304_or_206(path, request=request, headers={})
+            self.assertEqual(ctx.exception.status, 206)
+            self.assertEqual(ctx.exception.headers.get("Content-Range"), "bytes 5-9/10")
+            self.assertEqual(ctx.exception.headers.get("Content-Length"), "5")
+            self.assertEqual(b"".join(ctx.exception.body), b"56789")
+
         finally:
             try:
                 os.close(fd)


### PR DESCRIPTION
## Summary

Fix handling of HTTP suffix byte ranges in `stream_file_or_304_or_206()`.

## Problem

Suffix byte ranges such as:

```text
Range: bytes=-5
```

are currently interpreted as starting at byte `0`.

For a 10-byte file:

```text
Current:
Content-Range: bytes 0-5/10
Body: 012345

Expected:
Content-Range: bytes 5-9/10
Body: 56789
```

## Root Cause

When no start offset is present, the current logic falls back to `0`, causing suffix byte ranges (`bytes=-N`) to be treated as regular ranges from the beginning of the file.

## Fix

* Detect suffix byte ranges (`bytes=-N`) before applying the default start offset.
* Calculate the correct range for the last `N` bytes of the file.
* Preserve existing behavior for standard range requests.
