### PR TITLE
incorrect handling of HTTP suffix byte ranges

### DIFF
--- a/gluon/streamer.py
+++ b/gluon/streamer.py
@@ -84,16 +84,25 @@ def stream_file_or_304_or_206(
             raise HTTP(304, **{"Content-Type": headers["Content-Type"]})
 
         elif request and request.env.http_range:
-            start_items = regex_start_range.findall(request.env.http_range)
-            if not start_items:
-                start_items = [0]
-            stop_items = regex_stop_range.findall(request.env.http_range)
-            if not stop_items or int(stop_items[0]) > fsize - 1:
-                stop_items = [fsize - 1]
-            part = (int(start_items[0]), int(stop_items[0]), fsize)
-            if part[0] > part[1]:
-                headers["Content-Range"] = "bytes */%i" % fsize
-                raise HTTP(416, **headers)
+            range_header = request.env.http_range
+            suffix = re.match(r"^bytes=-(\d+)$", range_header)
+            if suffix:
+                length = int(suffix.group(1))
+                if length > 0:
+                    part = (max(fsize - length, 0), fsize - 1, fsize)
+                else:
+                    suffix = None
+            if not suffix:
+                start_items = regex_start_range.findall(range_header)
+                if not start_items:
+                    start_items = [0]
+                stop_items = regex_stop_range.findall(range_header)
+                if not stop_items or int(stop_items[0]) > fsize - 1:
+                    stop_items = [fsize - 1]
+                part = (int(start_items[0]), int(stop_items[0]), fsize)
+                if part[0] > part[1]:
+                    headers["Content-Range"] = "bytes */%i" % fsize
+                    raise HTTP(416, **headers)
             bytes = part[1] - part[0] + 1
             try:
                 stream = open(static_file, "rb")

--- a/gluon/tests/test_globals.py
+++ b/gluon/tests/test_globals.py
@@ -529,6 +529,14 @@ class testResponse(unittest.TestCase):
             self.assertEqual(ctx.exception.headers.get("Content-Length"), "5")
             b"".join(ctx.exception.body)  # exhaust the streamer so its finally: stream.close() runs cleanly
 
+            request.env.http_range = "bytes=-4"
+            with self.assertRaises(HTTP) as ctx:
+                stream_file_or_304_or_206(path, request=request, headers={})
+            self.assertEqual(ctx.exception.status, 206)
+            self.assertEqual(ctx.exception.headers.get("Content-Range"), "bytes 6-9/10")
+            self.assertEqual(ctx.exception.headers.get("Content-Length"), "4")
+            self.assertEqual(b"".join(ctx.exception.body), b"6789")
+
         finally:
             try:
                 os.close(fd)


### PR DESCRIPTION
## Summary

Fix incorrect handling of HTTP suffix byte ranges in `stream_file_or_304_or_206()`.

A request such as:

```http
Range: bytes=-4
```

should return the last 4 bytes of the file. The current implementation interprets it as `bytes 0-4`, returning the first 5 bytes instead.

## Changes

* Add dedicated handling for suffix byte ranges (`bytes=-N`).
* Preserve existing range parsing behavior for all other range formats.
* Keep existing validation and error handling unchanged.