### PR TITLE
Apply cookie security attributes to cookie-backed session data cookies

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -1465,14 +1465,8 @@ class Session(Storage):
             else:
                 response.session_new = True
 
-    def _fixup_before_save(self):
-        response = current.response
-        rcookies = response.cookies
-        scookies = rcookies.get(response.session_id_name)
-        if not scookies:
-            return
+    def _set_cookie_security_attrs(self, scookies):
         if self._forget:
-            del rcookies[response.session_id_name]
             return
         if self.get("httponly_cookies", True):
             scookies["HttpOnly"] = True
@@ -1488,6 +1482,20 @@ class Session(Storage):
                 # Python version 3.7 and lower needs this
                 Cookie.Morsel._reserved["samesite"] = "SameSite"
             scookies["samesite"] = self._same_site
+
+    def _fixup_before_save(self):
+        response = current.response
+        rcookies = response.cookies
+        scookies = rcookies.get(response.session_id_name)
+        if self._forget:
+            if scookies:
+                del rcookies[response.session_id_name]
+            return
+        if scookies:
+            self._set_cookie_security_attrs(scookies)
+        data_cookie = rcookies.get(response.session_data_name)
+        if data_cookie:
+            self._set_cookie_security_attrs(data_cookie)
 
     def clear_session_cookies(self):
         request = current.request

--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -1466,8 +1466,6 @@ class Session(Storage):
                 response.session_new = True
 
     def _set_cookie_security_attrs(self, scookies):
-        if self._forget:
-            return
         if self.get("httponly_cookies", True):
             scookies["HttpOnly"] = True
         if self._secure:

--- a/gluon/tests/test_globals.py
+++ b/gluon/tests/test_globals.py
@@ -36,6 +36,24 @@ def setup_clean_session():
     return current
 
 
+def setup_clean_cookie_session():
+    request = Request(env={})
+    request.application = "a"
+    request.controller = "c"
+    request.function = "f"
+    request.folder = "applications/admin"
+    response = Response()
+    session = Session()
+
+    from gluon.globals import current
+
+    current.request = request
+    current.response = response
+    current.session = session
+    session.connect(request, response, cookie_key="secret")
+    return current
+
+
 class testRequest(unittest.TestCase):
     def setUp(self):
         from gluon.globals import current
@@ -429,6 +447,36 @@ class testResponse(unittest.TestCase):
         current.session._fixup_before_save()
         cookie = str(current.response.cookies)
         self.assertTrue("samesite=strict" in cookie.lower())
+
+    def test_cookie_session_data_cookie_gets_security_attributes(self):
+        current = setup_clean_cookie_session()
+        current.session.user_id = 1
+
+        self.assertTrue(
+            current.session._try_store_in_cookie_or_file(
+                current.request, current.response
+            )
+        )
+        current.session._fixup_before_save()
+
+        cookie = str(
+            current.response.cookies[current.response.session_data_name]
+        ).lower()
+        self.assertIn("httponly", cookie)
+        self.assertIn("samesite=lax", cookie)
+
+    def test_cookie_session_data_cookie_gets_secure_attribute(self):
+        current = setup_clean_cookie_session()
+        current.session.user_id = 1
+        current.session.secure()
+
+        current.session._try_store_in_cookie_or_file(current.request, current.response)
+        current.session._fixup_before_save()
+
+        cookie = str(
+            current.response.cookies[current.response.session_data_name]
+        ).lower()
+        self.assertIn("secure", cookie)
 
     def test_stream_attachment_filename_encodes_quote(self):
         response = Response()

--- a/gluon/tests/test_globals.py
+++ b/gluon/tests/test_globals.py
@@ -478,6 +478,19 @@ class testResponse(unittest.TestCase):
         ).lower()
         self.assertIn("secure", cookie)
 
+    def test_forget_deletes_session_id_cookie(self):
+        current = setup_clean_session()
+        current.session._fixup_before_save()
+        self.assertIn(
+            current.response.session_id_name, current.response.cookies
+        )
+
+        current.session.forget()
+        current.session._fixup_before_save()
+        self.assertNotIn(
+            current.response.session_id_name, current.response.cookies
+        )
+
     def test_stream_attachment_filename_encodes_quote(self):
         response = Response()
         request = Request(env={})


### PR DESCRIPTION
### Summary

Cookie-backed sessions store the encrypted session payload in the `session_data_*` cookie. While cookie security attributes were applied through `_fixup_before_save()`, they were only applied to `session_id_*` cookies.

As a result, `session_data_*` cookies could be emitted without the configured `HttpOnly`, `Secure`, and `SameSite` attributes.

### Changes

* Extract cookie security attribute handling into a shared helper.
* Apply configured cookie security attributes to both:

  * `session_id_*`
  * `session_data_*`
* Preserve existing `_forget` behavior.