### PR TITLE
Apply consistent escaping to tuple-valued asset includes

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -830,6 +830,13 @@ class Response(Storage):
                         files[i] = call_minify()
 
         def static_map(s, item):
+            def template_values(file_type, values):
+                if not isinstance(values, tuple):
+                    values = (values,)
+                if not file_type.endswith(":inline"):
+                    values = tuple(xmlescape(value) for value in values)
+                return values
+
             if isinstance(item, str):
                 f = item.lower().split("?")[0]
                 ext = f.rpartition(".")[2]
@@ -858,17 +865,9 @@ class Response(Storage):
                     tmpl = template_mapping.get(f)
                 if tmpl:
                     if self._csp_enabled:
-                        if isinstance(item[1], tuple):
-                            s.append(tmpl % ((self.nonce,) + item[1]))
-                        else:
-                            value = item[1] if f.endswith(":inline") else xmlescape(item[1])
-                            s.append(tmpl % (self.nonce, value))
+                        s.append(tmpl % ((self.nonce,) + template_values(f, item[1])))
                     else:
-                        if isinstance(item[1], tuple):
-                            s.append(tmpl % item[1])
-                        else:
-                            value = item[1] if f.endswith(":inline") else xmlescape(item[1])
-                            s.append(tmpl % value)
+                        s.append(tmpl % template_values(f, item[1]))
 
         s = []
         for item in files:

--- a/gluon/tests/test_globals.py
+++ b/gluon/tests/test_globals.py
@@ -97,6 +97,8 @@ class testResponse(unittest.TestCase):
             raise self.failureException(msg)
 
     def test_include_files(self):
+        setup_clean_session()
+
         def return_includes(response, extensions=None):
             response.include_files(extensions)
             return response.body.getvalue()
@@ -230,6 +232,8 @@ class testResponse(unittest.TestCase):
         )
 
     def test_include_files_escapes_url_attributes(self):
+        setup_clean_session()
+
         def return_includes(response):
             response.include_files()
             return response.body.getvalue()
@@ -255,6 +259,24 @@ class testResponse(unittest.TestCase):
         response = Response()
         response.enable_csp()
         response.files.append(("js", malicious))
+        content = return_includes(response)
+        self.assertIn('nonce="%s"' % response.nonce, content)
+        self.assertIn(
+            "https://cdn.example.com/app.js?x=&quot; onerror=&quot;alert(1)", content
+        )
+        self.assertNotIn('onerror="alert(1)', content)
+
+        response = Response()
+        response.files.append(("js", (malicious,)))
+        content = return_includes(response)
+        self.assertIn(
+            "https://cdn.example.com/app.js?x=&quot; onerror=&quot;alert(1)", content
+        )
+        self.assertNotIn('onerror="alert(1)', content)
+
+        response = Response()
+        response.enable_csp()
+        response.files.append(("js", (malicious,)))
         content = return_includes(response)
         self.assertIn('nonce="%s"' % response.nonce, content)
         self.assertIn(


### PR DESCRIPTION
## Summary

This change applies the same escaping behavior to tuple-valued asset includes that is already used for standard asset includes.

## Changes

- Add a shared helper for preparing template values.
- Apply escaping consistently for non-inline asset URLs.
- Preserve existing `:inline` behavior.
- Preserve existing CSP nonce handling.
- Remove duplicated tuple/non-tuple rendering logic.