### PR TITLE
Fix Expose private file disclosure and privacy checks

### DIFF
--- a/gluon/tests/test_tools.py
+++ b/gluon/tests/test_tools.py
@@ -1998,6 +1998,22 @@ class TestExpose(unittest.TestCase):
         expose = self.make_expose(base=pjoin("private", "pub"), show="")
         self.assertIn("visible.txt", expose.filenames)
 
+    def test_isprivate_fails_closed_when_relpath_raises(self):
+        # When the path cannot be made relative to base (e.g. a different
+        # drive on Windows raises ValueError), isprivate() must fail closed
+        # and treat the entry as private.
+        expose = self.make_expose(base="inside", show="")
+        real_relpath = os.path.relpath
+
+        def boom(*args, **kwargs):
+            raise ValueError("path is on mount '%s', start on '%s'" % args[:2])
+
+        os.path.relpath = boom
+        try:
+            self.assertTrue(expose.isprivate(pjoin(self.base_dir, "inside", "x")))
+        finally:
+            os.path.relpath = real_relpath
+
 
 class Test_OpenRedirectPrevention(unittest.TestCase):
     def test_open_redirect(self):

--- a/gluon/tests/test_tools.py
+++ b/gluon/tests/test_tools.py
@@ -1958,6 +1958,46 @@ class TestExpose(unittest.TestCase):
         with self.assertRaises(HTTP):
             self.make_expose(base="inside", show="link_to_file3")
 
+    def test_private_entries_hidden_from_listing(self):
+        # Guard that the relative-path isprivate() keeps filtering "private"
+        # components and editor backups (*~) out of the listing (dotfiles are
+        # also excluded by glob itself).
+        inside = pjoin(self.base_dir, "inside")
+        for name in (".hidden", ".env", "secret.txt~"):
+            with open(pjoin(inside, name), "a"):
+                pass
+        os.mkdir(pjoin(inside, ".git"))
+        os.mkdir(pjoin(inside, "private"))
+        expose = self.make_expose(base="inside", show="")
+        self.assertNotIn(".hidden", expose.filenames)
+        self.assertNotIn(".env", expose.filenames)
+        self.assertNotIn("secret.txt~", expose.filenames)
+        self.assertNotIn(".git", expose.folders)
+        self.assertNotIn("private", expose.folders)
+        # non-private entries must still be listed
+        self.assertIn("README", expose.filenames)
+        self.assertEqual(sorted(expose.folders), ["dir1", "dir2"])
+
+    def test_private_file_not_downloadable(self):
+        # Regression: the direct-download branch never applied isprivate(), so
+        # a file hidden from the listing was still served on a direct request.
+        inside = pjoin(self.base_dir, "inside")
+        with open(pjoin(inside, ".env"), "w") as fp:
+            fp.write("SECRET=1")
+        with self.assertRaises(HTTP) as ctx:
+            self.make_expose(base="inside", show=".env")
+        self.assertEqual(ctx.exception.status, 404)
+
+    def test_base_with_private_component_lists_files(self):
+        # Regression: "private" in <absolute path> previously hid every file
+        # when the base directory itself contained a "private" component.
+        os.mkdir(pjoin(self.base_dir, "private"))
+        os.mkdir(pjoin(self.base_dir, "private", "pub"))
+        with open(pjoin(self.base_dir, "private", "pub", "visible.txt"), "a"):
+            pass
+        expose = self.make_expose(base=pjoin("private", "pub"), show="")
+        self.assertIn("visible.txt", expose.filenames)
+
 
 class Test_OpenRedirectPrevention(unittest.TestCase):
     def test_open_redirect(self):

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -6565,6 +6565,12 @@ class Expose(object):
         if not self.in_base(filename):
             raise HTTP(401, "NOT AUTHORIZED")
         if allow_download and not os.path.isdir(filename):
+            # Files hidden from the directory listing by isprivate() (dotfiles,
+            # "private" components, editor backups) must not be retrievable by
+            # requesting them directly either, otherwise the filtering only
+            # provides a false sense of protection.
+            if self.isprivate(filename):
+                raise HTTP(404, "FILE NOT FOUND")
             current.response.headers["Content-Type"] = contenttype(filename)
             raise HTTP(200, open(filename, "rb"), **current.response.headers)
         self.path = path = os.path.join(filename, "*")
@@ -6636,12 +6642,26 @@ class Expose(object):
         """True if f is a symlink and is pointing outside of self.base"""
         return os.path.islink(f) and not self.in_base(f)
 
-    @staticmethod
-    def isprivate(f):
-        # remove '/private' prefix to deal with symbolic links on OSX
-        if f.startswith("/private/"):
-            f = f[8:]
-        return "private" in f or f.startswith(".") or f.endswith("~")
+    def isprivate(self, f):
+        # A file/folder is considered private when any of its path components
+        # *below base* is a dotfile, an editor backup ("~"), or named
+        # "private". Only the portion under base is examined: the previous
+        # implementation tested the absolute path, which meant
+        #   - f.startswith(".") was dead code (an absolute path never starts
+        #     with "."), so dotfiles such as ".git" or ".env" were exposed; and
+        #   - "private" in f / the macOS "/private" prefix could match a
+        #     component of the base directory and hide everything.
+        try:
+            rel = os.path.relpath(f, self.base)
+        except ValueError:
+            # e.g. different drive on Windows: not under base, treat as private
+            return True
+        parts = rel.replace("\\", "/").split("/")
+        return any(
+            part == "private" or part.startswith(".") or part.endswith("~")
+            for part in parts
+            if part not in ("", ".", "..")
+        )
 
     @staticmethod
     def isimage(f):


### PR DESCRIPTION
This PR fixes an information disclosure issue in `gluon.tools.Expose` where files considered private by the directory listing filter could still be downloaded directly.

Additionally, it corrects the implementation of `isprivate()` to evaluate path components relative to the configured base directory rather than the absolute filesystem path.

## Problem

`Expose` uses `isprivate()` to hide private files and directories from directory listings. However, the direct-download path did not apply the same check.

As a result, files hidden from listings could still be retrieved by requesting them directly.

Examples include:

* Dotfiles such as `.env`
* Hidden directories such as `.git`
* Editor backup files ending in `~`
* Paths containing a `private` component

The previous implementation of `isprivate()` also operated on absolute paths, which introduced two issues:

1. Dotfile detection was ineffective because absolute paths do not begin with `"."`.
2. Any occurrence of `"private"` in the absolute path could cause unintended filtering, including when the base directory itself contained a component named `private`.

## Changes

* Apply `isprivate()` validation in the direct-download branch and return `404` for private files.
* Rewrite `isprivate()` to inspect path components relative to `self.base`.
* Remove reliance on absolute-path string matching and the associated macOS-specific `/private` handling.
* Preserve filtering of:

  * Dotfiles and dot-directories
  * Editor backup files ending with `~`
  * Components named `private`

## Tests

Added regression coverage for:

* Hidden files and directories being excluded from listings.
* Direct requests for private files returning `404`.
* Correct behavior when the configured base path contains a `private` component.

All existing Expose tests continue to pass, and the new security-focused tests fail against the previous implementation while passing with this fix.

## Security Impact

This change eliminates a discrepancy between directory listing visibility and direct file access, ensuring that files classified as private by `Expose` cannot be retrieved through direct download requests.
