### PR TITLE
Block archive extraction through pre-existing symlink directories

### DIFF
--- a/gluon/admin.py
+++ b/gluon/admin.py
@@ -35,16 +35,15 @@ from gluon.fileutils import (
 from gluon.http import HTTP
 from gluon.restricted import RestrictedError
 from gluon.settings import global_settings
+from gluon.utils import safe_path_join
 
 
 def _safe_extract_path(base_dir, member_name):
     """Return an absolute safe extraction path inside base_dir."""
-    target = os.path.normpath(os.path.join(base_dir, member_name))
-    root = os.path.abspath(base_dir)
-    target_abspath = os.path.abspath(target)
-    if not (target_abspath == root or target_abspath.startswith(root + os.sep)):
+    try:
+        return safe_path_join(base_dir, member_name)
+    except ValueError:
         raise RuntimeError("Attempted path traversal in zip file")
-    return target_abspath
 
 
 # TODO: move into add_path_first

--- a/gluon/fileutils.py
+++ b/gluon/fileutils.py
@@ -225,7 +225,11 @@ def _extractall(filename, path=".", members=None):
         for member in members or tar.getmembers():
             # Check for path traversal and absolute paths
             target = os.path.abspath(os.path.join(path, member.name))
-            if os.path.isabs(member.name) or not _is_within_path(target, path):
+            if os.path.isabs(member.name):
+                raise RuntimeError("Attempted path traversal in tar file")
+            try:
+                safe_path_join(path, member.name)
+            except ValueError:
                 raise RuntimeError("Attempted path traversal in tar file")
 
             # Check for unsafe special files (devices, FIFOs)

--- a/gluon/tests/test_compileapp.py
+++ b/gluon/tests/test_compileapp.py
@@ -99,3 +99,26 @@ class TestPack(unittest.TestCase):
             self.assertFalse(os.path.exists(os.path.join(tmpdir, "evil2.txt")))
         finally:
             shutil.rmtree(tmpdir)
+
+    def test_admin_unzip_rejects_preexisting_escaping_symlink_directory(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            extract_to = os.path.join(tmpdir, "web2py")
+            outside = os.path.join(tmpdir, "outside")
+            os.mkdir(extract_to)
+            os.mkdir(outside)
+            try:
+                os.symlink(outside, os.path.join(extract_to, "models"))
+            except OSError:
+                self.skipTest("Symlink creation requires additional privileges")
+            zip_path = os.path.join(tmpdir, "evil.zip")
+            with zipfile.ZipFile(zip_path, "w") as zf:
+                zf.writestr("web2py/models/evil.py", "bad")
+
+            from gluon.admin import unzip
+
+            with self.assertRaises(RuntimeError):
+                unzip(zip_path, extract_to, subfolder="web2py")
+            self.assertFalse(os.path.exists(os.path.join(outside, "evil.py")))
+        finally:
+            shutil.rmtree(tmpdir)

--- a/gluon/tests/test_fileutils.py
+++ b/gluon/tests/test_fileutils.py
@@ -82,6 +82,23 @@ class TestFileUtils(unittest.TestCase):
             if os.path.islink(os.path.join(extract_to, "models", "link")):
                 self.assertTrue(os.path.exists(os.path.join(extract_to, "models", "link")))
 
+    def test_untar_rejects_preexisting_escaping_symlink_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tarname = os.path.join(tmpdir, "link_directory.tar")
+            extract_to = os.path.join(tmpdir, "app")
+            outside = os.path.join(tmpdir, "outside")
+            os.mkdir(extract_to)
+            os.mkdir(outside)
+            try:
+                os.symlink(outside, os.path.join(extract_to, "models"))
+            except OSError:
+                self.skipTest("Symlink creation requires additional privileges")
+            self._make_tar(tarname, [self._regular_member("models/evil.py")])
+
+            with self.assertRaises(RuntimeError):
+                untar(tarname, extract_to)
+            self.assertFalse(os.path.exists(os.path.join(outside, "evil.py")))
+
     def test_untar_rejects_parent_traversal_member(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             tarname = os.path.join(tmpdir, "traversal.tar")


### PR DESCRIPTION
## Summary

Prevent archive extraction from writing outside the intended extraction root through pre-existing symlink directories or junctions.

## Changes

- Route zip extraction path validation through `safe_path_join()`.
- Route tar member destination validation through `safe_path_join()`.
- Enforce resolved-path containment instead of relying solely on lexical path checks.
- Preserve existing archive extraction behavior and link handling semantics.

## Tests

- Added a regression test covering tar extraction through a pre-existing escaping symlink directory.
- Added a regression test covering zip extraction through a pre-existing escaping symlink directory.
- Verified extraction is rejected and no file is written outside the extraction root.
- Existing archive-related tests continue to pass.

## Impact

- Prevents outside writes through pre-existing symlink directories and junctions.
- Applies to application installation, plugin installation, and framework upgrade extraction paths.
- Reuses existing path validation logic for consistent containment checks.