### PR TITLE
Use GITHUB_TOKEN for authenticated submodule checkout to avoid rate l…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/gluon/scheduler.py
+++ b/gluon/scheduler.py
@@ -1054,17 +1054,31 @@ class Scheduler(threading.Thread):
                         if not self.w_stats.status == DISABLED:
                             self.w_stats.status = ACTIVE
                 else:
+                    # We popped no task, but that doesn't mean we are idle:
+                    # there may be tasks already due (e.g. a failed task
+                    # re-queued for retry with next_run_time = last_run +
+                    # period) that simply haven't been (re)assigned yet. A
+                    # worker with pending due work must not self-terminate via
+                    # max_empty_runs, otherwise retries can be dropped under
+                    # load. Future-scheduled tasks (next_run_time > now) do not
+                    # count, so normal idle shutdown is preserved.
+                    has_due_work = self.has_pending_due_tasks()
                     with self.w_stats_lock:
-                        self.w_stats.empty_runs += 1
-                        if self.max_empty_runs != 0:
-                            logger.debug(
-                                "empty runs %s/%s",
-                                self.w_stats.empty_runs,
-                                self.max_empty_runs,
-                            )
-                            if self.w_stats.empty_runs >= self.max_empty_runs:
-                                logger.info("empty runs limit reached, killing myself")
-                                self.die()
+                        if has_due_work:
+                            self.w_stats.empty_runs = 0
+                        else:
+                            self.w_stats.empty_runs += 1
+                            if self.max_empty_runs != 0:
+                                logger.debug(
+                                    "empty runs %s/%s",
+                                    self.w_stats.empty_runs,
+                                    self.max_empty_runs,
+                                )
+                                if self.w_stats.empty_runs >= self.max_empty_runs:
+                                    logger.info(
+                                        "empty runs limit reached, killing myself"
+                                    )
+                                    self.die()
                     if self.is_a_ticker and self.greedy:
                         # there could be other tasks ready to be assigned
                         logger.info("TICKER: greedy loop")
@@ -1074,6 +1088,35 @@ class Scheduler(threading.Thread):
         except (KeyboardInterrupt, SystemExit):
             logger.info("catched")
             self.die()
+
+    def has_pending_due_tasks(self):
+        """Return True if there are enabled tasks already due to run.
+
+        Used to avoid self-terminating (`max_empty_runs`) while there is work
+        pending but not yet (re)assigned to this worker, e.g. a failed task
+        waiting for its retry. Only tasks that are already due
+        (`next_run_time <= now`) for this worker's groups are considered, so
+        far-future scheduled tasks still allow normal idle shutdown.
+        """
+        db = self.db
+        st = db.scheduler_task
+        now = self.now()
+        try:
+            pending = (
+                db(
+                    (st.status.belongs((QUEUED, ASSIGNED)))
+                    & (st.next_run_time <= now)
+                    & (st.enabled == True)
+                    & (st.group_name.belongs(self.group_names))
+                ).count()
+                > 0
+            )
+            db.commit()
+            return pending
+        except Exception:
+            logger.exception("    error checking for pending due tasks")
+            try_rollback(db)
+            return False
 
     def wrapped_pop_task(self):
         """Commodity function to call `pop_task` and trap exceptions.


### PR DESCRIPTION
…imits

Also fixed a flaky scheduler test due to an empty pop_task always couting towards max_empty_runs