### PR TITLE
Escape redirect URL in generated HTML body

### DIFF
--- a/gluon/http.py
+++ b/gluon/http.py
@@ -12,6 +12,7 @@ HTTP statuses helpers
 
 import re
 from urllib.parse import quote as urllib_quote
+from xml.sax.saxutils import escape as xml_escape
 
 __all__ = [
     "HTTP",
@@ -192,7 +193,10 @@ def redirect(location="", how=303, client_side=False, headers=None):
         else:
             headers["Location"] = loc
             raise HTTP(
-                how, 'You are being redirected <a href="%s">here</a>' % loc, **headers
+                how,
+                'You are being redirected <a href="%s">here</a>'
+                % xml_escape(loc, {'"': "&quot;"}),
+                **headers,
             )
     else:
         from gluon.globals import current

--- a/gluon/tests/test_http.py
+++ b/gluon/tests/test_http.py
@@ -5,7 +5,7 @@
 
 import unittest
 
-from gluon.http import HTTP, content_disposition_header, defined_status
+from gluon.http import HTTP, content_disposition_header, defined_status, redirect
 
 
 class TestHTTP(unittest.TestCase):
@@ -58,3 +58,39 @@ class TestContentDisposition(unittest.TestCase):
             content_disposition_header("report.csv", "attachment\r\nX-Evil: yes")
         with self.assertRaises(ValueError):
             content_disposition_header("report.csv", 'attachment"; filename=evil')
+
+
+class TestRedirect(unittest.TestCase):
+    """Tests http.redirect body escaping.
+
+    redirect() reflects the target URL into an ``<a href="...">`` element in
+    the response body. The value must be HTML-attribute encoded so an
+    externally-influenced location cannot break out of the attribute and
+    inject markup, while the ``Location`` header keeps the raw URL form.
+    """
+
+    def _redirect_http(self, location):
+        try:
+            redirect(location)
+        except HTTP as e:
+            return e
+        self.fail("redirect did not raise HTTP")
+
+    def test_redirect_escapes_location_in_body(self):
+        # A same-origin URL that passes open-redirect validation but carries
+        # attribute-breakout characters in the query string.
+        payload = 'https://myhost/a?next="><script>alert(1)</script>'
+        e = self._redirect_http(payload)
+        # The Location header keeps the raw (URL-form) value unchanged.
+        self.assertEqual(e.headers["Location"], payload)
+        # The reflected body must be HTML-escaped: no attribute breakout and
+        # no injected element.
+        self.assertNotIn('"><script>', e.body)
+        self.assertNotIn("<script>", e.body)
+        self.assertIn("&quot;&gt;&lt;script&gt;", e.body)
+
+    def test_redirect_preserves_benign_location(self):
+        # A normal URL is reflected verbatim (no semantic change).
+        e = self._redirect_http("/app/default/index")
+        self.assertEqual(e.headers["Location"], "/app/default/index")
+        self.assertIn('<a href="/app/default/index">here</a>', e.body)


### PR DESCRIPTION
## Summary

Escape redirect target URLs before reflecting them into the HTML body generated by `redirect()`.

## Changes

- HTML-escape redirect locations when rendering the fallback `<a href="...">` link in the response body.
- Preserve the original `Location` header value without modification.
- Reuse the standard library escaping utility already used elsewhere in the codebase.
- Add regression tests covering attribute-breakout characters in redirect targets.
- Verify normal redirect URLs continue to render unchanged.

## Benefits

- Ensures framework-generated HTML safely encodes redirect targets.
- Prevents redirect URLs from breaking out of the generated `href` attribute.
- Aligns `redirect()` with recent escaping improvements across other HTML-generation paths.
- Maintains existing redirect behavior and compatibility.