### PR TITLE
Fix attribute-breakout XSS in Markmin link and media rendering

### DIFF
--- a/gluon/contrib/markmin/markmin2html.py
+++ b/gluon/contrib/markmin/markmin2html.py
@@ -1413,11 +1413,14 @@ def render(
         t, a, k, p, w = m.group("t", "a", "k", "p", "w")
         if not k:
             return m.group(0)
-        k = local_html_escape(k)
+        # quote=True: k is emitted inside src="..."/href="..."; without escaping
+        # the double quote an attacker URL like http://x"onerror="alert(1) would
+        # break out of the attribute and inject an event handler (XSS).
+        k = local_html_escape(k, quote=True)
         t = t or ""
         style = "width:%s" % w if w else ""
         title = (
-            ' title="%s"' % local_html_escape(a).replace(META, DISABLED_META)
+            ' title="%s"' % local_html_escape(a, quote=True).replace(META, DISABLED_META)
             if a
             else ""
         )
@@ -1459,7 +1462,9 @@ def render(
                 % dict(p=p, title=title, style=style, k=k, t=t)
             )
         alt = (
-            ' alt="%s"' % local_html_escape(t).replace(META, DISABLED_META) if t else ""
+            ' alt="%s"' % local_html_escape(t, quote=True).replace(META, DISABLED_META)
+            if t
+            else ""
         )
         return '%(begin)s<img src="%(k)s"%(alt)s%(title)s%(style)s />%(end)s' % dict(
             begin=p_begin, k=k, alt=alt, title=title, style=style, end=p_end
@@ -1472,12 +1477,15 @@ def render(
         if is_unsafe(k):
             return f'<span class="markmin_unsafe">{html_module.escape(t)}</span>'
         t = t or ""
-        a = local_html_escape(a) if a else ""
+        # quote=True: a is emitted inside title="..." and k inside href="...".
+        # Escaping the double quote prevents attribute breakout / event-handler
+        # injection (XSS) from attacker-controlled link targets and titles.
+        a = local_html_escape(a, quote=True) if a else ""
         if k:
             if "#" in k and ":" not in k.split("#")[0]:
                 # wikipage, not external url
                 k = k.replace("#", "#" + id_prefix)
-            k = local_html_escape(k)
+            k = local_html_escape(k, quote=True)
             title = ' title="%s"' % a.replace(META, DISABLED_META) if a else ""
             target = ' target="_blank"' if p == "popup" else ""
             t = (
@@ -1504,7 +1512,7 @@ def render(
         if t == "NEWLINE" and not a:
             return "<br />" + pp
         return '<span class="anchor" id="%s">%s</span>' % (
-            local_html_escape(id_prefix + t),
+            local_html_escape(id_prefix + t, quote=True),
             render(
                 a,
                 {},

--- a/gluon/tests/test_html.py
+++ b/gluon/tests/test_html.py
@@ -1189,6 +1189,36 @@ class TestBareHelpers(unittest.TestCase):
         self.assertFalse(is_unsafe("https://example.com"))
         self.assertFalse(is_unsafe("mailto:test@example.com"))
 
+    def test_MARKMIN_attribute_breakout_xss(self):
+        # A double quote inside a link target/title/alt/anchor must be escaped,
+        # otherwise it closes the surrounding "..." attribute and lets an
+        # attacker inject an event handler (XSS) -- a bypass of the
+        # javascript:-only is_unsafe() check. The quote belongs in markup, not
+        # attribute syntax, so it must come out as &quot; everywhere.
+
+        # image src: <img onerror=...> fires automatically (no user interaction)
+        output = MARKMIN('[[alt http://x"onerror="alert(1) img]]').xml()
+        self.assertNotIn('"onerror="alert(1)', output)
+        self.assertIn("&quot;onerror=&quot;alert(1)", output)
+
+        # link href
+        output = MARKMIN('[[click http://x"onmouseover="alert(1)]]').xml()
+        self.assertNotIn('"onmouseover="alert(1)', output)
+        self.assertIn("&quot;onmouseover=&quot;alert(1)", output)
+
+        # link title (the [extra] field)
+        output = MARKMIN('[[click [t"onmouseover="alert(1)] http://x]]').xml()
+        self.assertNotIn('"onmouseover="alert(1)', output)
+        self.assertIn('href="http://x"', output)
+
+        # anchor id
+        output = MARKMIN('[[name"onmouseover="alert(1)]]').xml()
+        self.assertNotIn('"onmouseover="alert(1)', output)
+
+        # legitimate links keep working unchanged
+        output = MARKMIN("[[web2py http://web2py.com]]").xml()
+        self.assertIn('<a href="http://web2py.com">web2py</a>', output)
+
     def test_ASSIGNJS(self):
         # empty assignation
         self.assertEqual(ASSIGNJS().xml(), "")


### PR DESCRIPTION
Fix a stored XSS vulnerability in Markmin's HTML renderer caused by incomplete escaping of user-controlled values inserted into HTML attributes.

Several rendering paths emitted attacker-controlled values inside double-quoted HTML attributes while using `local_html_escape()` with its default `quote=False` behavior. This escaped `<`, `>`, and `&`, but did not escape double quotes, allowing attribute breakout and injection of arbitrary HTML attributes such as event handlers.

## Vulnerability

Affected sinks included:

* Link `href`
* Image `src`
* Image `title`
* Image `alt`
* Anchor `id`

Example payload:

```python
MARKMIN('[[alt http://x"onerror="alert(1) img]]')
```

Before:

```html
<p><img src="http://x"onerror="alert(1)" alt="alt" /></p>
```

The injected `onerror` handler becomes a live attribute and executes when the image fails to load.

This impacts Markmin-rendered user content, including wiki pages rendered through `Wiki.markmin_render()`.

## Fix

Use:

```python
local_html_escape(..., quote=True)
```

for all values emitted inside HTML attribute contexts.

This ensures double quotes are encoded as `&quot;`, preventing attribute breakout while preserving existing rendering behavior.

## Tests

Added regression coverage for:

* Image `src` attribute breakout
* Link `href` attribute breakout
* Link `title` attribute breakout
* Anchor `id` attribute breakout
* Normal link rendering
