### PR TITLE
Neutralize CSV Formula Injection in Service.serve_csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Other security fixes in this range:
 - Hardened `Content-Disposition` filenames (attachments and SQLFORM.grid export)
 - Hardened temporary plugin filename handling in `plugin_install()`
 - CAS service allowlist validation
+- Neutralized CSV/formula injection in `Service.serve_csv` exports (and restored
+  its missing `StringIO` import, which had broken every `@service.csv` endpoint)
 - `secrets` module used for secure password generation
 
 ## 2.99 - 3.0.X

--- a/gluon/tests/test_tools.py
+++ b/gluon/tests/test_tools.py
@@ -25,7 +25,7 @@ from gluon.globals import Request, Response, Session
 from gluon.http import HTTP
 from gluon.languages import TranslatorFactory
 from gluon.storage import Storage
-from gluon.tools import (Auth, Expose, Mail, Recaptcha2, prettydate,
+from gluon.tools import (Auth, Expose, Mail, Recaptcha2, csv_safe, prettydate,
                          prevent_open_redirect)
 
 IS_IMAP = "imap" in DEFAULT_URI
@@ -1608,6 +1608,37 @@ class TestService(unittest.TestCase):
         self.assertEqual(set(service.jsonrpc_procedures), {"legacy"})
         self.assertEqual(set(service.jsonrpc2_procedures), {"modern"})
 
+    def test_serve_csv_neutralizes_formula_injection(self):
+        service = tools.Service()
+
+        @service.csv
+        def evil():
+            # attacker-controlled values that reached the database / response
+            return [
+                {"name": "=cmd|'/c calc'!A1", "note": "ok"},
+                {"name": "+danger", "note": "-2+3"},
+            ]
+
+        current.request = Storage(args=["evil"], vars=Storage())
+        current.response = Storage(headers={})
+
+        out = service.serve_csv()
+
+        # the dangerous leading characters must be defused with a leading quote
+        self.assertIn("'=cmd", out)
+        self.assertIn("'+danger", out)
+        self.assertIn("'-2+3", out)
+        # a benign value is preserved verbatim
+        self.assertIn("ok", out)
+        # and no raw formula survives at the start of a field
+        for field in out.replace("\r", "").split("\n"):
+            for cell in field.split(","):
+                cell = cell.strip().strip('"')
+                self.assertFalse(
+                    cell[:1] in ("=", "+", "-", "@"),
+                    "unescaped formula cell: %r" % cell,
+                )
+
 
 # TODO: class TestPluginManager(unittest.TestCase):
 
@@ -1622,6 +1653,18 @@ class TestToolsFunctions(unittest.TestCase):
     """
     Test suite for all the tools.py functions
     """
+
+    def test_csv_safe_neutralizes_formula_prefixes(self):
+        # string cells starting with a formula trigger get quoted ...
+        for payload in ("=1+1", "+1", "-1+cmd", "@SUM(A1)", "\tx", "\rx"):
+            self.assertEqual(csv_safe(payload), "'" + payload)
+        # ... while harmless strings and non-strings are left untouched
+        self.assertEqual(csv_safe("hello"), "hello")
+        self.assertEqual(csv_safe("a=b"), "a=b")
+        self.assertEqual(csv_safe(""), "")
+        self.assertEqual(csv_safe(-5), -5)
+        self.assertEqual(csv_safe(3.14), 3.14)
+        self.assertEqual(csv_safe(None), None)
 
     def test_prettydate(self):
         # plain

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -30,6 +30,7 @@ import smtplib
 import sys
 import time
 import traceback
+from io import StringIO
 from email import encoders as Encoders
 from email import message_from_string
 from email.charset import QP as charset_QP
@@ -181,6 +182,26 @@ def prevent_open_redirect(url, host=None):
     elif parsed.path.startswith("~") or parsed.path.startswith(":~"):
         return None
     return original
+
+
+# Leading characters that make spreadsheet software (Excel, LibreOffice,
+# Google Sheets, ...) treat a CSV/TSV cell as a formula. A value beginning
+# with one of these can execute arbitrary spreadsheet expressions when the
+# exported file is opened -- this is "CSV/formula injection" (CWE-1236).
+CSV_INJECTION_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
+
+
+def csv_safe(value):
+    """Neutralize a single CSV/TSV cell against formula injection.
+
+    A string cell that starts with a formula-triggering character is prefixed
+    with a single quote so spreadsheet software renders it as literal text.
+    Non-string values (numbers, dates, ...) are returned unchanged, so genuine
+    numeric cells such as ``-5`` keep their type and meaning.
+    """
+    if isinstance(value, str) and value.startswith(CSV_INJECTION_PREFIXES):
+        return "'" + value
+    return value
 
 
 class Mail(object):
@@ -5881,15 +5902,17 @@ class Service(object):
                 import csv
 
                 writer = csv.writer(s)
-                writer.writerow(list(r[0].keys()))
+                writer.writerow([csv_safe(k) for k in r[0].keys()])
                 for line in r:
-                    writer.writerow([none_exception(v) for v in line.values()])
+                    writer.writerow(
+                        [csv_safe(none_exception(v)) for v in line.values()]
+                    )
             else:
                 import csv
 
                 writer = csv.writer(s)
                 for line in r:
-                    writer.writerow(line)
+                    writer.writerow([csv_safe(v) for v in line])
             return s.getvalue()
         self.error()
 


### PR DESCRIPTION
This PR mitigates CSV/Formula Injection (CWE-1236) in `Service.serve_csv`.

Values returned by `@service.csv` procedures are serialized directly into CSV output. If attacker-controlled content begins with spreadsheet formula trigger characters (`=`, `+`, `-`, `@`, TAB, or CR), opening the exported file in spreadsheet software such as Excel, LibreOffice Calc, or Google Sheets can result in formula evaluation.

In addition, this PR restores the missing `StringIO` import required by `Service.serve_csv`, fixing a regression that caused CSV exports to fail with a `NameError`.

## Changes

* Added a reusable `csv_safe()` helper to neutralize formula-triggering CSV cells.
* Introduced `CSV_INJECTION_PREFIXES` containing known spreadsheet formula prefixes.
* Prefixed dangerous string values with a leading apostrophe (`'`) so spreadsheet applications treat them as literal text.
* Preserved non-string values unchanged to avoid altering numeric, date, or other typed fields.
* Applied protection to:

  * CSV header rows
  * Dictionary-based row exports
  * Generic iterable row exports
* Restored `from io import StringIO` for `Service.serve_csv`.

## Tests

Added test coverage for:

* Formula-triggering prefixes (`=`, `+`, `-`, `@`, TAB, `CR`) being neutralized.
* Benign strings remaining unchanged.
* Non-string values being preserved.
* End-to-end verification that `@service.csv` safely exports attacker-controlled content.
* Validation that no exported cell begins with an unescaped formula trigger.

## Security Impact

Prevents CSV/Formula Injection attacks in framework-generated CSV exports by ensuring spreadsheet applications interpret attacker-controlled values as text rather than executable formulas.