### PR TITLE
Handle malformed multipart input without internal server errors

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -71,7 +71,7 @@ from gluon import recfile
 from gluon.cache import CacheInRam
 from gluon.contenttype import contenttype
 from gluon.restricted import safe_load, safe_loads
-from gluon.contrib.multipart import MultipartParser, ParserError, parse_options_header
+from gluon.contrib.multipart import MultipartParser, MultipartError, parse_options_header
 from gluon.fileutils import up
 from gluon.html import PRE, TABLE, TR, URL, xmlescape
 from gluon.http import HTTP, content_disposition_header, redirect
@@ -385,11 +385,20 @@ class Request(Storage):
                 ct, opts = parse_options_header(content_type)
                 boundary = opts.get("boundary")
                 charset = opts.get("charset", "utf-8")
-                parser = iter(
-                    MultipartParser(
-                        body, boundary, content_length=content_length, charset=charset
+                # The boundary is a required Content-Type parameter. Without it
+                # the parser cannot be constructed (and would raise TypeError),
+                # so a missing boundary simply yields no parseable parts.
+                if boundary:
+                    parser = iter(
+                        MultipartParser(
+                            body,
+                            boundary,
+                            content_length=content_length,
+                            charset=charset,
+                        )
                     )
-                )
+                else:
+                    parser = iter([])
                 while True:
                     try:
                         part = next(parser)
@@ -410,7 +419,15 @@ class Request(Storage):
                                 if part.name not in post_vars
                                 else listify(post_vars[part.name]) + [value]
                             )
-                    except (StopIteration, ParserError):
+                    except StopIteration:
+                        break
+                    except (MultipartError, UnicodeError, LookupError):
+                        # A malformed multipart body, a reached parser limit
+                        # (e.g. too many parts), or an invalid/unknown charset in
+                        # a part header. Stop parsing and keep whatever was
+                        # decoded so far, instead of letting the parser exception
+                        # escape parse_post_vars as an HTTP 500. This matches the
+                        # lenient behaviour previously applied to ParserError.
                         break
                 body.seek(0)
             # Handle application/x-www-form-urlencoded

--- a/gluon/tests/test_globals.py
+++ b/gluon/tests/test_globals.py
@@ -754,3 +754,67 @@ class testFileUpload(unittest.TestCase):
         filenames = [u.filename for u in uploads]
         self.assertIn("a.txt", filenames)
         self.assertIn("b.txt", filenames)
+
+    def _make_request_with_content_type(self, body, content_type):
+        env = {
+            "request_method": "POST",
+            "CONTENT_TYPE": content_type,
+            "CONTENT_LENGTH": str(len(body)),
+            "wsgi.input": BytesIO(body),
+        }
+        r = Request(env)
+        self.addCleanup(lambda: r._body.close() if r._body is not None else None)
+        return r
+
+    def test_missing_boundary_does_not_raise(self):
+        # A multipart/form-data Content-Type with no boundary parameter must not
+        # blow up the request parser (previously raised TypeError -> HTTP 500).
+        r = self._make_request_with_content_type(
+            b"whatever", "multipart/form-data"
+        )
+        self.assertEqual(dict(r.post_vars), {})
+
+    def test_invalid_part_charset_does_not_raise(self):
+        # An attacker-controlled, unknown charset in a part header must not
+        # escape as a LookupError -> HTTP 500. Parsing degrades gracefully.
+        boundary = self.BOUNDARY
+        body = (
+            b"--" + boundary + b"\r\n"
+            b'Content-Disposition: form-data; name="a"\r\n'
+            b"Content-Type: text/plain; charset=bogus-enc\r\n\r\nhello\r\n"
+            b"--" + boundary + b"--\r\n"
+        )
+        r = self._make_request(body)
+        # access must not raise; the undecodable part is simply dropped
+        self.assertNotIn("a", r.post_vars)
+
+    def test_too_many_parts_does_not_raise(self):
+        # Exceeding the parser's part limit raises ParserLimitReached (a sibling
+        # of ParserError), which previously escaped as HTTP 500. The request now
+        # degrades to the parts decoded before the limit was hit.
+        boundary = self.BOUNDARY
+        body = b""
+        for i in range(200):
+            body += (
+                b"--" + boundary + b"\r\n"
+                b'Content-Disposition: form-data; name="f' + str(i).encode() + b'"\r\n'
+                b"\r\nv\r\n"
+            )
+        body += b"--" + boundary + b"--\r\n"
+        r = self._make_request(body)
+        # no exception; some fields were captured before the limit was reached
+        self.assertTrue(len(r.post_vars) > 0)
+
+    def test_truncated_body_keeps_partial_fields(self):
+        # A body that ends before the closing boundary raises a ParserError on
+        # close; the historical lenient behaviour (keep what was parsed) must be
+        # preserved.
+        boundary = self.BOUNDARY
+        body = (
+            b"--" + boundary + b"\r\n"
+            b'Content-Disposition: form-data; name="ok"\r\n\r\ngood\r\n'
+            b"--" + boundary + b"\r\n"
+            b'Content-Disposition: form-data; name="truncated"\r\n\r\nincomp'
+        )
+        r = self._make_request(body)
+        self.assertEqual(r.post_vars.get("ok"), "good")


### PR DESCRIPTION
## Summary

Prevent malformed `multipart/form-data` requests from triggering internal server errors during request parsing.

## Changes

- Handle multipart parser failures consistently at the request parsing boundary.
- Prevent uncaught multipart parsing exceptions from propagating as HTTP 500 errors.
- Gracefully handle requests with missing multipart boundaries.
- Gracefully handle multipart parts that specify invalid or unknown charsets.
- Handle multipart parser limit violations without crashing request processing.
- Preserve the existing behavior of keeping successfully parsed fields when parsing stops due to malformed input.

## Validation

Added regression tests covering:

- Missing multipart boundary parameter.
- Invalid charset specified in a multipart part.
- Multipart requests exceeding parser limits.
- Truncated multipart bodies while preserving already parsed fields.

## Impact

Malformed multipart requests no longer cause framework-level HTTP 500 responses and are contained within the multipart parsing boundary.