### PR TITLE
fix exponential backtracking in multipart option-value regex

### DIFF
--- a/gluon/contrib/multipart.py
+++ b/gluon/contrib/multipart.py
@@ -221,8 +221,9 @@ _re_hname = re.compile(_hname, re.ASCII)
 # In the slow-qs branch a backslash must be consumed by the escape
 # alternative (\\.) only; letting [^"] also match it makes the two
 # alternatives overlap, so an unterminated value full of backslashes
-# backtracks exponentially (ReDoS). [^"\\] keeps them disjoint.
-_value = r'"[^\\"]*"|%s|"(?:\\.|[^"\\])*"' % _token
+# backtracks exponentially (ReDoS). [^\\"] keeps them disjoint.
+# Backport of upstream defnull/multipart commit 30ad444 (1.4-dev).
+_value = r'"[^\\"]*"|%s|"(?:\\.|[^\\"])*"' % _token
 # A "; key=value" pair from content-disposition header
 _option = r"; *(%s) *= *(%s)" % (_hname, _value)
 _re_option = re.compile(_option)

--- a/gluon/contrib/multipart.py
+++ b/gluon/contrib/multipart.py
@@ -217,8 +217,12 @@ _token = "[a-zA-Z0-9-!#$%&'*+.^_`|~]+"
 _re_token = re.compile(_token, re.ASCII)
 _hname = "[a-zA-Z0-9-_]+"
 _re_hname = re.compile(_hname, re.ASCII)
-# A token or quoted-string (simple qs | token | slow qs)
-_value = r'"[^\\"]*"|%s|"(?:\\.|[^"])*"' % _token
+# A token or quoted-string (simple qs | token | slow qs).
+# In the slow-qs branch a backslash must be consumed by the escape
+# alternative (\\.) only; letting [^"] also match it makes the two
+# alternatives overlap, so an unterminated value full of backslashes
+# backtracks exponentially (ReDoS). [^"\\] keeps them disjoint.
+_value = r'"[^\\"]*"|%s|"(?:\\.|[^"\\])*"' % _token
 # A "; key=value" pair from content-disposition header
 _option = r"; *(%s) *= *(%s)" % (_hname, _value)
 _re_option = re.compile(_option)

--- a/gluon/tests/test_globals.py
+++ b/gluon/tests/test_globals.py
@@ -818,3 +818,17 @@ class testFileUpload(unittest.TestCase):
         )
         r = self._make_request(body)
         self.assertEqual(r.post_vars.get("ok"), "good")
+
+    def test_malicious_content_type_does_not_redos(self):
+        # The Content-Type header is parsed (parse_options_header) on every
+        # multipart POST before any authentication. An unterminated quoted
+        # boundary value made of backslashes used to backtrack exponentially
+        # in the option-value regex, so a tiny header could burn minutes of
+        # CPU. Parsing such a header must now stay fast.
+        import time
+
+        content_type = "multipart/form-data; boundary=" + '"' + "\\" * 64
+        start = time.time()
+        r = self._make_request_with_content_type(b"whatever", content_type)
+        self.assertEqual(dict(r.post_vars), {})
+        self.assertLess(time.time() - start, 5)


### PR DESCRIPTION
parse_options_header runs on the Content-Type header of every multipart POST before any authentication, and the quoted-string branch of its option-value regex lets a backslash be consumed by either the escape alternative or the non-quote alternative. an unterminated boundary value made of backslashes then backtracks exponentially, so a header of around 40 bytes can burn tens of seconds of CPU per request. limiting the non-quote alternative so a backslash is only matched by the escape rule keeps the two disjoint and makes matching linear, with no change to which values parse.