### PR TITLE
Sanitize dynamic XML element names to prevent XML structure injection

### DIFF
--- a/gluon/serializers.py
+++ b/gluon/serializers.py
@@ -95,13 +95,56 @@ def custom_json(o):
         raise TypeError(repr(o) + " is not JSON serializable")
 
 
+# Characters that are not valid in an XML element name (XML 1.0 "Name").
+# Besides keeping the document well-formed, stripping these also removes every
+# markup-significant character (<, >, /, ", ', =, &, whitespace) an attacker
+# could otherwise smuggle through a mapping key to break out of the
+# ``<name ...>`` tag and inject arbitrary elements (XML injection). ``\w`` with
+# re.UNICODE keeps ASCII identifiers, digits, ``_`` and the unicode letters that
+# are legal in XML names.
+_XML_NAME_INVALID = re.compile(r"[^\w.\-:]", re.UNICODE)
+
+
+def _is_xml_name_start(ch):
+    # an XML Name must start with a letter, '_' or ':' (never a digit, '-' or
+    # '.'); ``str.isalpha`` keeps the unicode letters that are legal name starts
+    return ch in "_:" or ch.isalpha()
+
+
+def xml_tag_name(key, default="item"):
+    """Coerce an arbitrary mapping key into a safe XML element name.
+
+    ``xml_rec`` escapes element *values* with ``xmlescape`` but used dict keys
+    verbatim as tag names, so a key such as ``"a><script>"`` produced raw,
+    unescaped markup in the serialized output (XML injection). A tag name cannot
+    simply be html-escaped (``&lt;`` is itself illegal inside a name), so instead
+    we drop characters that are not valid in an XML Name and guarantee a valid
+    name-start character. The result is always well-formed and cannot escape the
+    surrounding tag.
+    """
+    # an empty key means "no wrapper element" (TAG[""]); preserve that behaviour
+    if key == "":
+        return ""
+    name = _XML_NAME_INVALID.sub("", str(key))
+    if not name or not _is_xml_name_start(name[0]):
+        name = default if not name else "%s_%s" % (default, name)
+    return name
+
+
 def xml_rec(value, key, quote=True):
     if hasattr(value, "custom_xml") and callable(value.custom_xml):
         return value.custom_xml()
     elif isinstance(value, (dict, Storage)):
-        return TAG[key](*[TAG[k](xml_rec(v, "", quote)) for k, v in value.items()])
+        return TAG[xml_tag_name(key)](
+            *[
+                TAG[xml_tag_name(k)](xml_rec(v, "", quote))
+                for k, v in value.items()
+            ]
+        )
     elif isinstance(value, list):
-        return TAG[key](*[TAG.item(xml_rec(item, "", quote)) for item in value])
+        return TAG[xml_tag_name(key)](
+            *[TAG.item(xml_rec(item, "", quote)) for item in value]
+        )
     elif hasattr(value, "as_list") and callable(value.as_list):
         return str(xml_rec(value.as_list(), "", quote))
     elif hasattr(value, "as_dict") and callable(value.as_dict):

--- a/gluon/tests/test_serializers.py
+++ b/gluon/tests/test_serializers.py
@@ -103,6 +103,38 @@ class TestSerializers(unittest.TestCase):
         self.assertEqual(len([ln for ln in out.split("\n") if ln.startswith("ATTENDEE")]), 0)
         self.assertIn("URL:http://x/1ATTENDEE:mailto:victim@example.com", out)
 
+    def testXMLEscapesUntrustedKeys(self):
+        # xml() escapes element *values* but used dict keys verbatim as tag
+        # names; an attacker-influenced key must not be able to break out of the
+        # surrounding tag and inject arbitrary markup (XML injection). This is
+        # the path used by the generic.xml view: XML(xml(response._vars)).
+        payload = "</document><script>alert(1)</script><x"
+        out = xml({payload: "v"}, quote=False)
+        self.assertNotIn("<script", out)
+        self.assertNotIn("</document><script", out)
+        # the closing </document> only appears once: the real one at the end
+        self.assertEqual(out.count("</document>"), 1)
+        # an attribute-breakout attempt in a key is neutralised too: the quote
+        # and space are stripped, so no new attribute / event handler is formed
+        # (the leftover letters are inert inside the single tag name)
+        out = xml({'a"oncopy="alert(1)': "v"}, quote=False)
+        self.assertNotIn('oncopy="', out)
+        self.assertIn(">v<", out)  # value stays element content, not an attribute
+
+    def testXMLPreservesValidKeys(self):
+        # legitimate keys (incl. unicode letters legal in XML names) are
+        # unchanged; only injection-relevant / invalid characters are stripped
+        self.assertEqual(
+            xml({"a": {"b": [1, 2]}}),
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            "<document><a><b><item>1</item><item>2</item></b></a></document>",
+        )
+        self.assertIn("<è>1</è>", xml({"è": 1}))
+        # names cannot legally start with a digit -> made valid, not dropped
+        self.assertIn("<item_123>", xml({"123": "v"}))
+        # non-string keys no longer crash the serializer
+        self.assertIn("<item_5>x</item_5>", xml({5: "x"}))
+
     def testJSON(self):
         # the main and documented "way" is to use the json() function
         # it has a few corner-cases that make json() be somewhat


### PR DESCRIPTION
Sanitize dynamically generated XML element names in `gluon/serializers.py` to prevent XML structure injection through untrusted dictionary keys.

The XML serializer escaped element values but used mapping keys directly as XML tag names. An attacker-controlled key containing markup characters could therefore alter the structure of the generated XML document and inject arbitrary elements into the output.

## Vulnerability

Before this change, dictionary keys were passed directly to `TAG[...]` during XML serialization:

```python
xml({"</document><script>alert(1)</script><x": "hello"}, quote=False)
```

This resulted in attacker-controlled markup being emitted into the serialized XML document, allowing document breakout and element injection.

The issue occurs within the framework's serializer implementation rather than application code, affecting callers that correctly delegate XML generation to the framework.

## Fix

Introduce `xml_tag_name()` and apply it to all dynamically generated element names.

The helper:

* Removes unsafe and invalid characters from element names.
* Eliminates markup-significant characters such as `<`, `>`, `/`, `"`, `'`, `=`, `&`, and whitespace.
* Ensures the resulting name begins with a valid XML name-start character.
* Preserves valid identifiers, including Unicode letter-based names.
* Safely handles non-string keys.

This guarantees that serialized output remains well-formed and that untrusted keys cannot escape the surrounding element context.

## Tests

Added regression coverage for:

* XML injection payloads embedded in dictionary keys.
* Attribute-breakout style payloads.
* Preservation of valid element names.
* Unicode identifier preservation.
* Numeric and non-string keys.
* Existing nested dictionary and list serialization behavior.

The tests verify that injected markup is no longer reflected in the output while legitimate XML structures remain unchanged.