### PR TITLE
Mitigate CSV/TSV Formula Injection in SQLFORM.grid and Service Exports

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -69,7 +69,7 @@ from gluon.html import (
 )
 from gluon.http import HTTP, content_disposition_header, redirect
 from gluon.storage import Storage
-from gluon.utils import md5_hash
+from gluon.utils import csv_safe_text, md5_hash
 from gluon.validators import (
     IS_DATE,
     IS_DATETIME,
@@ -4402,7 +4402,7 @@ class ExporterTSV(ExportClass):
             self.rows.export_to_csv_file(
                 s, represent=True, delimiter="\t", newline="\n"
             )
-            return s.getvalue()
+            return csv_safe_text(s.getvalue(), delimiter="\t")
         else:
             return None
 
@@ -4419,7 +4419,7 @@ class ExporterTSV_hidden(ExportClass):
         if self.rows:
             s = io.StringIO()
             self.rows.export_to_csv_file(s, delimiter="\t", newline="\n")
-            return s.getvalue()
+            return csv_safe_text(s.getvalue(), delimiter="\t")
         else:
             return None
 
@@ -4437,7 +4437,7 @@ class ExporterCSV(ExportClass):
         if self.rows:
             s = io.StringIO()
             self.rows.export_to_csv_file(s, represent=True)
-            return s.getvalue()
+            return csv_safe_text(s.getvalue())
         else:
             return None
 
@@ -4453,7 +4453,7 @@ class ExporterCSV_hidden(ExportClass):
 
     def export(self):
         if self.rows:
-            return self.rows.as_csv()
+            return csv_safe_text(self.rows.as_csv())
         else:
             return ""
 

--- a/gluon/tests/test_sqlhtml.py
+++ b/gluon/tests/test_sqlhtml.py
@@ -9,7 +9,8 @@ import os
 import sys
 import unittest
 
-from gluon.sqlhtml import SQLFORM, SQLTABLE, safe_int
+from gluon.sqlhtml import (SQLFORM, SQLTABLE, ExporterCSV, ExporterCSV_hidden,
+                           ExporterTSV, ExporterTSV_hidden, safe_int)
 
 DEFAULT_URI = os.getenv("DB", "sqlite:memory")
 
@@ -51,6 +52,42 @@ class Test_safe_int(unittest.TestCase):
         self.assertEqual(safe_int("1x"), 0)
         # not safe int (alternate default)
         self.assertEqual(safe_int("1x", 1), 1)
+
+
+class TestGridExportFormulaInjection(unittest.TestCase):
+    # The grid's CSV/TSV "export" buttons serve attacker-storable DB values to
+    # spreadsheet software. A cell starting with =, +, -, @, TAB or CR is run as
+    # a formula when opened (CSV/formula injection, CWE-1236); the exporters
+    # must neutralize it while leaving genuine numbers and structure intact.
+    def setUp(self):
+        self.db = DAL("sqlite:memory")
+        self.db.define_table("t", Field("name"), Field("score", "integer"))
+        self.db.t.insert(name="=cmd|'/C calc'!A0", score=-5)
+        self.db.t.insert(name="@SUM(1+1)", score=10)
+        self.db.t.insert(name="plain, comma", score=3)
+        self.rows = self.db(self.db.t).select()
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_csv_exporters_neutralize_formulas(self):
+        for cls in (ExporterCSV, ExporterCSV_hidden):
+            out = cls(self.rows).export()
+            self.assertIn("'=cmd|'/C calc'!A0", out)
+            self.assertIn("'@SUM(1+1)", out)
+            self.assertNotIn(",=cmd", out)
+            # genuine negative number is preserved (not quoted as text)
+            self.assertIn(",-5", out)
+            # value containing the delimiter still round-trips
+            self.assertIn('"plain, comma"', out)
+
+    def test_tsv_exporters_neutralize_formulas(self):
+        for cls in (ExporterTSV, ExporterTSV_hidden):
+            out = cls(self.rows).export()
+            self.assertIn("\t'=cmd|'/C calc'!A0", out)
+            self.assertIn("\t'@SUM(1+1)", out)
+            self.assertNotIn("\t=cmd", out)
+            self.assertIn("\t-5", out)
 
 
 # class Test_safe_float(unittest.TestCase):

--- a/gluon/tests/test_tools.py
+++ b/gluon/tests/test_tools.py
@@ -1639,6 +1639,34 @@ class TestService(unittest.TestCase):
                     "unescaped formula cell: %r" % cell,
                 )
 
+    def test_serve_csv_rows_branch_neutralizes_formula_injection(self):
+        # a @service.csv function may return DAL Rows; those go through
+        # pydal's export_to_csv_file() and must be defused on the serialized
+        # text, while genuine numeric columns keep their value (not '-5).
+        db = DAL(DEFAULT_URI, check_reserved=["all"])
+        try:
+            db.define_table("evil_rows", Field("name"), Field("amount", "integer"))
+            db.evil_rows.insert(name="=cmd|'/c calc'!A1", amount=-5)
+            db.commit()
+
+            service = tools.Service()
+
+            @service.csv
+            def evil():
+                return db(db.evil_rows).select()
+
+            current.request = Storage(args=["evil"], vars=Storage())
+            current.response = Storage(headers={})
+
+            out = service.serve_csv()
+
+            self.assertIn("'=cmd", out)  # string formula neutralized
+            self.assertIn(",-5", out)  # genuine number preserved
+            self.assertNotIn("'-5", out)
+        finally:
+            db.evil_rows.drop()
+            db.close()
+
 
 # TODO: class TestPluginManager(unittest.TestCase):
 

--- a/gluon/tests/test_tools.py
+++ b/gluon/tests/test_tools.py
@@ -25,8 +25,8 @@ from gluon.globals import Request, Response, Session
 from gluon.http import HTTP
 from gluon.languages import TranslatorFactory
 from gluon.storage import Storage
-from gluon.tools import (Auth, Expose, Mail, Recaptcha2, csv_safe, prettydate,
-                         prevent_open_redirect)
+from gluon.tools import (Auth, Expose, Mail, Recaptcha2, csv_safe,
+                         csv_safe_text, prettydate, prevent_open_redirect)
 
 IS_IMAP = "imap" in DEFAULT_URI
 
@@ -1665,6 +1665,26 @@ class TestToolsFunctions(unittest.TestCase):
         self.assertEqual(csv_safe(-5), -5)
         self.assertEqual(csv_safe(3.14), 3.14)
         self.assertEqual(csv_safe(None), None)
+
+    def test_csv_safe_text_neutralizes_serialized_rows(self):
+        # text emitted by a writer we do not control (e.g. pydal's
+        # export_to_csv_file) is re-parsed and dangerous cells get quoted
+        src = "id,name\r\n1,=cmd|'/C calc'!A0\r\n2,@SUM(1+1)\r\n"
+        out = csv_safe_text(src)
+        self.assertIn("'=cmd|'/C calc'!A0", out)
+        self.assertIn("'@SUM(1+1)", out)
+        self.assertNotIn(",=cmd", out)
+        # genuine numbers keep their type/meaning, structure is preserved
+        out = csv_safe_text("a,b\r\n-5,3.14\r\n")
+        self.assertIn("-5,3.14", out)
+        self.assertNotIn("'-5", out)
+        # a value carrying the delimiter still round-trips (quoting preserved)
+        self.assertIn('"x, y"', csv_safe_text('h\r\n"x, y"\r\n'))
+        # TSV uses a tab delimiter
+        self.assertIn("\t'=evil", csv_safe_text("h\tk\r\nok\t=evil\r\n", delimiter="\t"))
+        # empty / falsy input is returned untouched
+        self.assertEqual(csv_safe_text(""), "")
+        self.assertEqual(csv_safe_text(None), None)
 
     def test_prettydate(self):
         # plain

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -62,7 +62,7 @@ from gluon.contrib.markmin.markmin2html import (
 )
 from gluon.fileutils import check_credentials, read_file
 from gluon.storage import Messages, Settings, Storage, StorageList
-from gluon.utils import compare, web2py_uuid
+from gluon.utils import compare, csv_safe, csv_safe_text, web2py_uuid
 
 Table = DAL.Table
 Field = DAL.Field
@@ -184,24 +184,9 @@ def prevent_open_redirect(url, host=None):
     return original
 
 
-# Leading characters that make spreadsheet software (Excel, LibreOffice,
-# Google Sheets, ...) treat a CSV/TSV cell as a formula. A value beginning
-# with one of these can execute arbitrary spreadsheet expressions when the
-# exported file is opened -- this is "CSV/formula injection" (CWE-1236).
-CSV_INJECTION_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
-
-
-def csv_safe(value):
-    """Neutralize a single CSV/TSV cell against formula injection.
-
-    A string cell that starts with a formula-triggering character is prefixed
-    with a single quote so spreadsheet software renders it as literal text.
-    Non-string values (numbers, dates, ...) are returned unchanged, so genuine
-    numeric cells such as ``-5`` keep their type and meaning.
-    """
-    if isinstance(value, str) and value.startswith(CSV_INJECTION_PREFIXES):
-        return "'" + value
-    return value
+# ``csv_safe`` and ``csv_safe_text`` are defined in gluon.utils (security
+# utilities, reused by gluon.sqlhtml's grid exporters) and re-exported here for
+# backward compatibility.
 
 
 class Mail(object):
@@ -5893,7 +5878,11 @@ class Service(object):
             )
             s = StringIO()
             if hasattr(r, "export_to_csv_file"):
+                # DAL Rows are written by pydal's csv writer, which we cannot
+                # neutralize cell-by-cell; sanitize the serialized text instead
+                # so this path is protected like the dict/list branches below.
                 r.export_to_csv_file(s)
+                return csv_safe_text(s.getvalue())
             elif (
                 r
                 and not isinstance(r, types.GeneratorType)

--- a/gluon/utils.py
+++ b/gluon/utils.py
@@ -13,9 +13,11 @@ This file specifically includes utilities for security.
 
 import ast
 import base64
+import csv
 import hashlib
 import hmac
 import inspect
+import io
 import logging
 import os
 import pickle
@@ -96,6 +98,62 @@ def compare(a, b):
 def md5_hash(text):
     """Generate an md5 hash with the given text."""
     return hashlib.md5(text.encode("utf8")).hexdigest()
+
+
+# Leading characters that make spreadsheet software (Excel, LibreOffice,
+# Google Sheets, ...) treat a CSV/TSV cell as a formula. A value beginning
+# with one of these can execute arbitrary spreadsheet expressions when the
+# exported file is opened -- this is "CSV/formula injection" (CWE-1236).
+CSV_INJECTION_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
+
+
+def csv_safe(value):
+    """Neutralize a single CSV/TSV cell against formula injection.
+
+    A string cell that starts with a formula-triggering character is prefixed
+    with a single quote so spreadsheet software renders it as literal text.
+    Non-string values (numbers, dates, ...) are returned unchanged, so genuine
+    numeric cells such as ``-5`` keep their type and meaning.
+    """
+    if isinstance(value, str) and value.startswith(CSV_INJECTION_PREFIXES):
+        return "'" + value
+    return value
+
+
+def _csv_safe_cell_text(cell):
+    """:func:`csv_safe` for a cell that has already been stringified.
+
+    At the text level every cell is a string, so :func:`csv_safe` could no
+    longer tell a genuine negative/positive number (``-5``, ``+3.14``) from a
+    formula and would wrongly quote it. Numeric literals can never be formulas,
+    so they are left untouched; anything else starting with a formula-triggering
+    character is prefixed with a single quote.
+    """
+    if cell.startswith(CSV_INJECTION_PREFIXES):
+        try:
+            float(cell)
+        except ValueError:
+            return "'" + cell
+    return cell
+
+
+def csv_safe_text(text, delimiter=","):
+    """Neutralize already-serialized CSV/TSV text against formula injection.
+
+    Some export paths hand the row data to a writer we do not control (e.g.
+    pydal's ``Rows.export_to_csv_file``), so the cells cannot be passed through
+    :func:`csv_safe` individually. Re-parsing the produced text and re-emitting
+    every cell keeps the exact CSV structure (same delimiter, quoting and line
+    endings) while making dangerous cells render as literal text. ``text`` may be
+    empty/None, in which case it is returned as-is.
+    """
+    if not text:
+        return text
+    out = io.StringIO()
+    writer = csv.writer(out, delimiter=delimiter)
+    for row in csv.reader(io.StringIO(text), delimiter=delimiter):
+        writer.writerow([_csv_safe_cell_text(cell) for cell in row])
+    return out.getvalue()
 
 
 def get_callable_argspec(fn):


### PR DESCRIPTION
This PR mitigates CSV/TSV formula injection (CWE-1236) in web2py's user-facing export functionality.

While formula injection protections were previously added for some CSV responses, additional spreadsheet-facing export paths remained vulnerable. Attackers could store values beginning with spreadsheet formula prefixes (`=`, `+`, `-`, `@`, tab, carriage return) and have them exported verbatim. When opened in spreadsheet software such as Excel, LibreOffice Calc, or Google Sheets, these values could be interpreted as formulas.

## Affected Paths

* `SQLFORM.grid` CSV export
* `SQLFORM.grid` CSV export with hidden columns
* `SQLFORM.grid` TSV export
* `SQLFORM.grid` TSV export with hidden columns
* `Service.serve_csv()` DAL `Rows` export path

## Changes

### Centralized CSV Safety Utilities

Moved CSV formula-injection protections into `gluon.utils`:

* `csv_safe()` for individual cell values
* `csv_safe_text()` for already-serialized CSV/TSV content

### Grid Export Protection

All `SQLFORM.grid` CSV/TSV exporters now sanitize serialized output before returning it to the user.

### Service Export Protection

The `Rows.export_to_csv_file()` path in `Service.serve_csv()` now sanitizes generated CSV output, closing a gap that bypassed existing protections.

### Backward Compatibility

`csv_safe` and `csv_safe_text` remain available through `gluon.tools` to avoid breaking existing imports.

## Design Considerations

### Preserve Backup/Restore Behavior

PyDAL's CSV export routines are also used for backup and restore workflows. Modifying export behavior globally could alter stored data and break round-trip imports.

To avoid this, protections are applied only to user-facing export endpoints.

### Preserve Numeric Values

At the serialized-text stage, all cells are represented as strings. A naïve implementation would incorrectly treat legitimate numeric values such as:

* `-5`
* `+3.14`

as formulas.

`csv_safe_text()` preserves valid numeric literals while neutralizing dangerous spreadsheet expressions.

## Tests

Added coverage for:

* CSV exporter formula neutralization
* TSV exporter formula neutralization
* Service export formula neutralization
* Numeric value preservation
* Delimiter and quoting preservation
* Backward-compatible helper imports