### PR TITLE
Fix XSS in Markmin media auto-link title handling

### DIFF
--- a/gluon/contrib/markmin/markmin2html.py
+++ b/gluon/contrib/markmin/markmin2html.py
@@ -1436,8 +1436,14 @@ def render(
             p_end = "</p>" + pp
         elif p in ("left", "right"):
             style = ("float:%s" % p) + (";%s" % style if style else "")
-        if t and regex_auto.match(t):
-            p_begin = p_begin + '<a href="%s">' % t
+        if t and regex_auto.match(t) and not is_unsafe(t):
+            # t is an auto-url reused as the wrapping link target. regex_auto
+            # is matched with re.match (not anchored at the end), so a value
+            # like http://x" onmouseover="alert(1) still satisfies the guard;
+            # escape it (quote=True) so it cannot break out of href="..." and
+            # inject an event handler (XSS), and reject javascript: targets the
+            # same way sub_link does.
+            p_begin = p_begin + '<a href="%s">' % local_html_escape(t, quote=True)
             p_end = "</a>" + p_end
             t = ""
         if style:

--- a/gluon/tests/test_html.py
+++ b/gluon/tests/test_html.py
@@ -1219,6 +1219,32 @@ class TestBareHelpers(unittest.TestCase):
         output = MARKMIN("[[web2py http://web2py.com]]").xml()
         self.assertIn('<a href="http://web2py.com">web2py</a>', output)
 
+    def test_MARKMIN_media_autolink_title_xss(self):
+        # When a media item's title is itself an auto-url, it is reused as the
+        # target of a wrapping <a href="...">. The guard uses re.match (not
+        # anchored at the end), so a value like http://x" onmouseover="alert(1)
+        # still satisfies it; the title must be escaped so the double quote
+        # cannot break out of href="..." and inject an event handler (XSS).
+        output = MARKMIN(
+            '[[http://x.com" onmouseover="alert(1) http://img.com/a.png img]]'
+        ).xml()
+        self.assertNotIn('" onmouseover="alert(1)', output)
+        self.assertIn("&quot; onmouseover=&quot;alert(1)", output)
+
+        # A javascript: pseudo-url title must not become a clickable link;
+        # sub_media must reject it like sub_link does for the link target.
+        output = MARKMIN(
+            "[[javascript://%0aalert(1) http://img.com/a.png img]]"
+        ).xml()
+        self.assertNotIn('href="javascript:', output)
+
+        # legitimate auto-url title still wraps the image in a link
+        output = MARKMIN("[[http://example.com http://img.com/a.png img]]").xml()
+        self.assertIn(
+            '<a href="http://example.com"><img src="http://img.com/a.png" /></a>',
+            output,
+        )
+
     def test_ASSIGNJS(self):
         # empty assignation
         self.assertEqual(ASSIGNJS().xml(), "")


### PR DESCRIPTION
Fix a cross-site scripting (XSS) vulnerability in Markmin's media rendering path when a media title is recognized as an auto-URL and reused as the target of a wrapping `<a href>` element.

## Vulnerability

In `gluon/contrib/markmin/markmin2html.py`, `sub_media()` contains the following logic:

```python
if t and regex_auto.match(t):
    p_begin = p_begin + '<a href="%s">' % t
```

The title (`t`) is interpolated directly into an HTML attribute without escaping.

Two issues arise:

1. **Attribute breakout**

   * `regex_auto.match()` only validates a matching prefix.
   * Input such as:

     ```text
     http://x.com" onmouseover="alert(1)
     ```

     satisfies the guard because the URL prefix matches.
   * The full unescaped value is then inserted into `href`, allowing attribute injection and XSS.

2. **Unsafe URL schemes**

   * Unlike `sub_link()`, `sub_media()` does not reject `javascript:` URLs.
   * A title such as:

     ```text
     javascript://%0aalert(1)
     ```

     becomes a clickable JavaScript link.

### Example (before fix)

```text
[[http://x.com" onmouseover="alert(1) http://img.com/a.png img]]
```

Rendered as:

```html
<a href="http://x.com" onmouseover="alert(1)">
    <img src="http://img.com/a.png" />
</a>
```

This creates a live event handler and results in XSS.

## Fix

* Escape the auto-linked title using:

  ```python
  local_html_escape(t, quote=True)
  ```

  before inserting it into `href`.

* Reject unsafe URL schemes by applying:

  ```python
  not is_unsafe(t)
  ```

  consistent with the existing `sub_link()` behavior.

## Tests

Added `test_MARKMIN_media_autolink_title_xss()` covering:

* Attribute injection via unescaped quotes.
* `javascript:` URL rejection.
* Preservation of legitimate auto-URL image links.
