### PR TITLE
Harden test workflow permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,9 @@ on:
     branches: ["master"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This tightens the GitHub Actions test workflow permissions without changing the test matrix.

The workflow only needs repository read access for checkout and test execution, so this sets the default `GITHUB_TOKEN` permission to `contents: read`.

I verified the workflow YAML still parses, `git diff --check` passes, and `zizmor` no longer reports the previous excessive-permissions finding. The remaining findings are action pinning warnings, which I left out of this focused change.
