### PR TITLE
Prevent XML structure injection from dictionary keys in serializers.xml

### DIFF
--- a/gluon/serializers.py
+++ b/gluon/serializers.py
@@ -95,11 +95,32 @@ def custom_json(o):
         raise TypeError(repr(o) + " is not JSON serializable")
 
 
+# A dict key is emitted as an XML element tag by xml_rec(). Replace only the
+# characters that let a key break out of its start tag -- '<', '>', '/' and
+# whitespace -- with '_', so an attacker-influenced key (e.g. "x><script>")
+# cannot close the tag or introduce attributes and inject markup. All other
+# characters are left untouched, which keeps existing output (including the
+# trailing-'_' self-closing TAG convention) unchanged for non-malicious keys.
+_REGEX_XML_TAG_BREAKOUT = re.compile(r"[<>/\s]")
+
+
+def _xml_safe_tag(key):
+    """Return *key* with XML start-tag breakout characters replaced by '_'.
+
+    Element values are already escaped via xmlescape(); this gives dict keys
+    used as element names comparable protection against markup injection. A
+    key containing no breakout character is returned unchanged.
+    """
+    return _REGEX_XML_TAG_BREAKOUT.sub("_", str(key))
+
+
 def xml_rec(value, key, quote=True):
     if hasattr(value, "custom_xml") and callable(value.custom_xml):
         return value.custom_xml()
     elif isinstance(value, (dict, Storage)):
-        return TAG[key](*[TAG[k](xml_rec(v, "", quote)) for k, v in value.items()])
+        return TAG[key](
+            *[TAG[_xml_safe_tag(k)](xml_rec(v, "", quote)) for k, v in value.items()]
+        )
     elif isinstance(value, list):
         return TAG[key](*[TAG.item(xml_rec(item, "", quote)) for item in value])
     elif hasattr(value, "as_list") and callable(value.as_list):

--- a/gluon/tests/test_serializers.py
+++ b/gluon/tests/test_serializers.py
@@ -103,6 +103,37 @@ class TestSerializers(unittest.TestCase):
         self.assertEqual(len([ln for ln in out.split("\n") if ln.startswith("ATTENDEE")]), 0)
         self.assertIn("URL:http://x/1ATTENDEE:mailto:victim@example.com", out)
 
+    def testXMLNeutralizesMarkupInKeys(self):
+        # a dict key is emitted as an element tag; an attacker-influenced key
+        # must not be able to close the tag or add attributes and inject markup
+        out = xml({"x><script>alert(1)</script><y": "data"})
+        self.assertNotIn("<script", out)
+        self.assertNotIn("</script", out)
+        self.assertNotIn(">alert(1)<", out)
+
+    def testXMLNeutralizesAttributeInjectionInKeys(self):
+        # without surviving whitespace, a key cannot grow an event-handler attr
+        out = xml({"a onmouseover=alert(1) b": "v"})
+        self.assertNotIn(" onmouseover", out)
+
+    def testXMLNeutralizesMarkupInNestedKeys(self):
+        # the same protection must apply to keys at any depth
+        out = xml({"outer": {'q"><b on=1>': "v"}})
+        self.assertNotIn("<b on=1>", out)
+        self.assertNotIn('"><', out)
+
+    def testXMLPreservesExistingKeyBehaviour(self):
+        # keys with no breakout character are emitted byte-for-byte as before,
+        # including web2py's trailing-'_' self-closing TAG convention
+        self.assertEqual(
+            xml({"user_id": 1}),
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            "<document><user_id>1</user_id></document>",
+        )
+        self.assertIn("<created.on>x</created.on>", xml({"created.on": "x"}))
+        # trailing underscore still triggers <tag /> style (unchanged behaviour)
+        self.assertIn("<class />", xml({"class_": "x"}))
+
     def testJSON(self):
         # the main and documented "way" is to use the json() function
         # it has a few corner-cases that make json() be somewhat


### PR DESCRIPTION
## Summary

When serializing dictionaries to XML, `xml_rec()` emits dictionary keys directly as XML element names through `TAG[k]`.

While element values are escaped via `xmlescape()`, keys are inserted without any protection. Keys containing XML start-tag breakout characters (`<`, `>`, `/`, or whitespace) can alter the generated XML structure.

This change replaces only those breakout characters before emitting the element name, preventing keys from closing the current tag or introducing attributes.

## Changes

* Add `_xml_safe_tag()` helper for XML element names derived from dictionary keys.
* Replace XML start-tag breakout characters (`<`, `>`, `/`, whitespace) with `_`.
* Apply the helper when serializing dictionary keys in `xml_rec()`.
* Preserve all existing behavior for keys that do not contain breakout characters.
* Preserve the existing trailing `_` self-closing `TAG` convention.

## Examples

Before:

```xml
<x><script>alert(1)</script><y>data</x>
```

After:

```xml
<x__script_alert(1)__script__y>data</x__script_alert(1)__script__y>
```

## Tests

Added coverage for:

* Markup injection through dictionary keys.
* Attribute injection through dictionary keys.
* Nested dictionary key handling.
* Preservation of existing serializer behavior for normal keys.
* Preservation of the trailing `_` self-closing tag convention.