### PR TITLE
Complete CSV formula neutralization in grid and service exports

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -4323,6 +4323,16 @@ class SQLTABLE(TABLE):
 form_factory = SQLFORM.factory  # for backward compatibility, deprecated
 
 
+def _csv_safe_rows(rows):
+    # Neutralize CSV/formula injection (CWE-1236) on the typed Row values
+    # before they are serialized, so string cells are defused while numeric
+    # columns keep their type. Lazy import avoids a gluon.tools <-> sqlhtml
+    # import cycle.
+    from gluon.tools import csv_safe_rows
+
+    return csv_safe_rows(rows)
+
+
 class ExportClass(object):
     label = None
     file_ext = None
@@ -4398,6 +4408,7 @@ class ExporterTSV(ExportClass):
 
     def export(self):  # export TSV with field.represent
         if self.rows:
+            _csv_safe_rows(self.rows)
             s = io.StringIO()
             self.rows.export_to_csv_file(
                 s, represent=True, delimiter="\t", newline="\n"
@@ -4417,6 +4428,7 @@ class ExporterTSV_hidden(ExportClass):
 
     def export(self):
         if self.rows:
+            _csv_safe_rows(self.rows)
             s = io.StringIO()
             self.rows.export_to_csv_file(s, delimiter="\t", newline="\n")
             return s.getvalue()
@@ -4435,6 +4447,7 @@ class ExporterCSV(ExportClass):
 
     def export(self):  # export CSV with field.represent
         if self.rows:
+            _csv_safe_rows(self.rows)
             s = io.StringIO()
             self.rows.export_to_csv_file(s, represent=True)
             return s.getvalue()
@@ -4453,6 +4466,7 @@ class ExporterCSV_hidden(ExportClass):
 
     def export(self):
         if self.rows:
+            _csv_safe_rows(self.rows)
             return self.rows.as_csv()
         else:
             return ""

--- a/gluon/tests/test_sqlhtml.py
+++ b/gluon/tests/test_sqlhtml.py
@@ -534,3 +534,51 @@ class TestSQLTABLE(unittest.TestCase):
 
 #     def test_represented(self):
 #         pass
+
+
+class TestCSVExportFormulaInjection(unittest.TestCase):
+    """SQLFORM.grid CSV/TSV exports must defuse formula cells (CWE-1236) from
+    attacker-controlled string values, while preserving numeric columns."""
+
+    def setUp(self):
+        self.db = DAL(DEFAULT_URI, check_reserved=["all"])
+        self.db.define_table("doc", Field("name"), Field("amount", "integer"))
+        self.db.doc.insert(name="=cmd|'/c calc'!A1", amount=-5)
+        self.db.doc.insert(name="plain", amount=3)
+        self.db.commit()
+
+    def tearDown(self):
+        self.db.doc.drop()
+        self.db.close()
+
+    def test_grid_exporters_defuse_strings_keep_numbers(self):
+        from gluon.sqlhtml import (
+            ExporterCSV,
+            ExporterCSV_hidden,
+            ExporterTSV,
+            ExporterTSV_hidden,
+        )
+
+        for exporter, sep in (
+            (ExporterCSV, ","),
+            (ExporterCSV_hidden, ","),
+            (ExporterTSV, "\t"),
+            (ExporterTSV_hidden, "\t"),
+        ):
+            rows = self.db(self.db.doc).select()  # fresh rows per exporter
+            out = exporter(rows).export()
+            # string formula neutralized
+            self.assertIn("'=cmd", out, exporter.__name__)
+            # genuine negative number preserved, not turned into text
+            self.assertNotIn("'-5", out, exporter.__name__)
+            self.assertTrue(
+                ("%s-5" % sep) in out or out.strip().endswith("-5") or "-5%s" % sep in out,
+                "%s dropped numeric -5: %r" % (exporter.__name__, out),
+            )
+            for line in out.replace("\r", "").split("\n"):
+                for cell in line.split(sep):
+                    cell = cell.strip().strip('"')
+                    self.assertFalse(
+                        cell[:1] in ("=", "+", "@"),
+                        "%s leaked formula: %r" % (exporter.__name__, cell),
+                    )

--- a/gluon/tests/test_tools.py
+++ b/gluon/tests/test_tools.py
@@ -1639,6 +1639,55 @@ class TestService(unittest.TestCase):
                     "unescaped formula cell: %r" % cell,
                 )
 
+    def test_serve_csv_rows_branch_defuses_strings_keeps_numbers(self):
+        # serve_csv delegates DAL Rows to Rows.export_to_csv_file(); that path
+        # must defuse string formula cells WITHOUT corrupting numeric columns
+        # (csv_safe(-5) -> -5, not '-5).
+        db = DAL(DEFAULT_URI, check_reserved=["all"])
+        try:
+            db.define_table("evil_rows", Field("name"), Field("amount", "integer"))
+            db.evil_rows.insert(name="=cmd|'/c calc'!A1", amount=-5)
+            db.commit()
+            service = tools.Service()
+
+            @service.csv
+            def evil():
+                return db(db.evil_rows).select()
+
+            current.request = Storage(args=["evil"], vars=Storage())
+            current.response = Storage(headers={})
+            out = service.serve_csv()
+
+            self.assertIn("'=cmd", out)  # string formula neutralized
+            self.assertIn(",-5", out)  # genuine number preserved (NOT '-5)
+            self.assertNotIn("'-5", out)
+        finally:
+            db.evil_rows.drop()
+            db.close()
+
+
+class TestCsvSafeRows(unittest.TestCase):
+    def test_csv_safe_rows_is_type_aware(self):
+        from gluon.tools import csv_safe_rows
+
+        db = DAL(DEFAULT_URI, check_reserved=["all"])
+        try:
+            db.define_table("cell", Field("label"), Field("n", "integer"))
+            db.cell.insert(label="=cmd", n=-5)
+            db.commit()
+            rows = db(db.cell).select()
+            csv_safe_rows(rows)
+            rec = rows[0]
+            self.assertEqual(rec["label"], "'=cmd")  # string defused
+            self.assertEqual(rec["n"], -5)  # int preserved, still an int
+            self.assertIsInstance(rec["n"], int)
+            # re-applying is harmless (no double quoting)
+            csv_safe_rows(rows)
+            self.assertEqual(rows[0]["label"], "'=cmd")
+        finally:
+            db.cell.drop()
+            db.close()
+
 
 # TODO: class TestPluginManager(unittest.TestCase):
 

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -204,6 +204,29 @@ def csv_safe(value):
     return value
 
 
+def csv_safe_rows(rows):
+    """Neutralize CSV/formula injection in a DAL ``Rows`` in place, before it
+    is serialized by ``Rows.export_to_csv_file()`` / ``as_csv()``.
+
+    Only string cells are passed through :func:`csv_safe`, so genuine numeric
+    and date columns keep their type and value (``csv_safe(-5)`` stays ``-5``).
+    Joined selects, whose records hold one per-table ``Row`` per joined table,
+    are handled one level deep. Re-applying is harmless (a quoted cell no
+    longer starts with a trigger). Returns *rows* for convenience.
+    """
+    for record in rows:
+        if not hasattr(record, "items"):
+            continue
+        for key, value in record.items():
+            if isinstance(value, str):
+                record[key] = csv_safe(value)
+            elif hasattr(value, "items"):  # nested per-table Row (joined select)
+                for k, v in value.items():
+                    if isinstance(v, str):
+                        value[k] = csv_safe(v)
+    return rows
+
+
 class Mail(object):
     """
     Class for configuring and sending emails with alternative text / html
@@ -5893,6 +5916,7 @@ class Service(object):
             )
             s = StringIO()
             if hasattr(r, "export_to_csv_file"):
+                csv_safe_rows(r)
                 r.export_to_csv_file(s)
             elif (
                 r


### PR DESCRIPTION
## Summary

The recent CSV formula-injection hardening added `csv_safe()` protection to the `csv.writer()` paths in `Service.serve_csv()`, but Rows-backed exports still bypass that protection.

This affects:

* `Service.serve_csv()` when returning DAL `Rows`
* `ExporterCSV`
* `ExporterTSV`
* `ExporterCSV_hidden`
* `ExporterTSV_hidden`

All of these paths serialize through `Rows.export_to_csv_file()` / `as_csv()` and can emit spreadsheet formulas unchanged.

## Changes

* Add `csv_safe_rows()` to apply the existing `csv_safe()` logic to typed `Rows` values before CSV/TSV serialization.
* Apply it to Rows-backed exports in:

  * `Service.serve_csv()`
  * `ExporterCSV`
  * `ExporterTSV`
  * `ExporterCSV_hidden`
  * `ExporterTSV_hidden`
* Reuse the existing `csv_safe()` behavior instead of introducing a separate sanitization mechanism.

## Behavior

String values beginning with spreadsheet formula triggers are neutralized:

```text
=cmd|'/c calc'!A1
```

becomes:

```text
'=cmd|'/c calc'!A1
```

Numeric values retain their original type and output:

```text
-5
```

remains:

```text
-5
```

## Tests

Added coverage for:

* Rows-backed `Service.serve_csv()` exports.
* CSV exporter paths.
* TSV exporter paths.
* Type-aware behavior (`'=cmd` is neutralized while numeric `-5` is preserved).
* Idempotent application of `csv_safe_rows()`.