### PR TITLE
Add OAuth2 state validation to prevent login CSRF attacks

### DIFF
--- a/gluon/contrib/login_methods/oauth20_account.py
+++ b/gluon/contrib/login_methods/oauth20_account.py
@@ -17,6 +17,7 @@ from urllib import request as urllib2
 from urllib.parse import urlencode, parse_qs
 
 from gluon import HTTP, current, redirect
+from gluon.utils import compare, web2py_uuid
 
 
 class OAuthAccount(object):
@@ -150,6 +151,23 @@ class OAuthAccount(object):
                 refresh_token = current.session.token["refresh_token"]
 
         code = current.request.vars.code
+
+        if code:
+            # Honour the authorization code only if the state returned by the
+            # authorization server matches the one stored in the session when
+            # the flow started (RFC 6749 section 10.12). A missing or mismatched
+            # state means this redirect was not initiated by the current
+            # session, so the code must be rejected to prevent login CSRF.
+            expected_state = current.session.oauth_state
+            current.session.oauth_state = None  # single use
+            returned_state = current.request.vars.state
+            if (
+                not expected_state
+                or not returned_state
+                or not compare(str(expected_state), str(returned_state))
+            ):
+                current.session.token = None
+                return None
 
         if code or refresh_token:
             data = dict(
@@ -306,10 +324,19 @@ class OAuthAccount(object):
         token = self.accessToken()
         if not token:
             current.session.redirect_uri = self.__redirect_uri(next)
+            # OAuth 2.0 CSRF protection (RFC 6749 section 10.12): bind this
+            # authorization request to the user's session with an unguessable
+            # state value that the authorization server must echo back unchanged.
+            # Without it an attacker can deliver their own authorization code to
+            # the victim's redirect endpoint (login CSRF / code injection) and
+            # silently link the victim's session to the attacker's identity.
+            state = web2py_uuid()
+            current.session.oauth_state = state
             data = dict(
                 redirect_uri=current.session.redirect_uri,
                 response_type="code",
                 client_id=self.client_id,
+                state=state,
             )
             if self.args:
                 data.update(self.args)

--- a/gluon/tests/test_oauth20_account.py
+++ b/gluon/tests/test_oauth20_account.py
@@ -1,0 +1,101 @@
+#!/bin/python
+# -*- coding: utf-8 -*-
+
+"""
+Unit tests for gluon.contrib.login_methods.oauth20_account
+
+These cover the OAuth 2.0 CSRF protection (the ``state`` parameter, RFC 6749
+section 10.12): the authorization request must carry an unguessable, session
+bound state, and an authorization code coming back with a missing or mismatched
+state must be rejected *before* it is exchanged for a token (login CSRF / code
+injection).
+"""
+
+import unittest
+
+from gluon import HTTP
+from gluon.globals import current
+from gluon.contrib.login_methods.oauth20_account import OAuthAccount
+from gluon.storage import Storage
+
+# name of the (name-mangled) opener factory we stub out to detect whether the
+# token endpoint was reached without doing any real network I/O
+_OPENER_ATTR = "_OAuthAccount__build_url_opener"
+
+
+class _RecordingOpener(object):
+    def __init__(self, reached):
+        self._reached = reached
+
+    def open(self, *args, **kwargs):
+        self._reached["yes"] = True
+        raise RuntimeError("stop after the CSRF gate")
+
+    def close(self):
+        pass
+
+
+def _make_account():
+    return OAuthAccount(
+        client_id="cid",
+        client_secret="secret",
+        auth_url="https://provider.example/authorize",
+        token_url="https://provider.example/token",
+    )
+
+
+class TestOAuth20State(unittest.TestCase):
+    def setUp(self):
+        current.session = Storage(token=None)
+        current.request = Storage(
+            vars=Storage(),
+            get_vars=Storage(),
+            env=Storage(
+                http_host="app.example",
+                https="off",
+                wsgi_url_scheme="https",
+                path_info="/app/default/user/login",
+            ),
+        )
+        self.account = _make_account()
+        self.reached = {}
+        setattr(self.account, _OPENER_ATTR, lambda uri: _RecordingOpener(self.reached))
+
+    def test_authorization_request_includes_session_bound_state(self):
+        # starting the flow redirects to the provider; the redirect must carry a
+        # state parameter equal to the value stored in the session
+        try:
+            self.account.login_url("/welcome")
+            self.fail("expected an HTTP redirect to the authorization server")
+        except HTTP as e:
+            location = e.headers["Location"]
+        self.assertTrue(current.session.oauth_state)
+        self.assertIn("state=%s" % current.session.oauth_state, location)
+
+    def test_mismatched_state_is_rejected_without_token_exchange(self):
+        # an attacker-supplied code with the wrong state must not be honoured
+        current.session.oauth_state = "the-expected-state"
+        current.request.vars = Storage(code="attacker_code", state="wrong_state")
+        self.assertIsNone(self.account.accessToken())
+        self.assertNotIn("yes", self.reached)  # token endpoint never reached
+        self.assertIsNone(current.session.token)
+        self.assertIsNone(current.session.oauth_state)  # single-use
+
+    def test_missing_state_is_rejected(self):
+        # no state stored (flow never initiated by this session) -> reject
+        current.session.oauth_state = None
+        current.request.vars = Storage(code="attacker_code", state="anything")
+        self.assertIsNone(self.account.accessToken())
+        self.assertNotIn("yes", self.reached)
+        self.assertIsNone(current.session.token)
+
+    def test_matching_state_passes_the_csrf_check(self):
+        # a code that comes back with the matching state clears the CSRF gate and
+        # proceeds to the token endpoint (which our stub records, then aborts)
+        current.session.oauth_state = "match-123"
+        current.request.vars = Storage(code="good_code", state="match-123")
+        try:
+            self.account.accessToken()
+        except RuntimeError:
+            pass
+        self.assertTrue(self.reached.get("yes"))


### PR DESCRIPTION
Add OAuth 2.0 `state` parameter generation and validation to `OAuthAccount` to protect authorization-code flows against login CSRF attacks.

## Problem

`OAuthAccount` implemented the OAuth 2.0 authorization-code flow without using the `state` parameter.

The authorization request generated by `__oauth_login()` included `redirect_uri`, `response_type`, and `client_id`, but did not include a session-bound `state` value. During callback processing, `accessToken()` accepted an authorization code and exchanged it without verifying that the callback belonged to the initiating user session.

This allows login CSRF / authorization-code injection attacks in which an attacker completes an OAuth authorization flow using their own account and causes a victim to visit the callback URL containing the resulting authorization code. Because no state validation was performed, the callback could be accepted independently of the session that initiated the flow.

## Fix

* Generate a cryptographically strong state value using `web2py_uuid()`.
* Store the state in the user's session before redirecting to the provider.
* Require the returned state parameter on callback.
* Validate the returned value against the stored session value using a constant-time comparison.
* Reject missing or mismatched state values.
* Clear the stored state after successful validation.

## Tests

Add tests covering:

* State generation and inclusion in authorization requests.
* Rejection of callbacks with missing state.
* Rejection of callbacks with mismatched state.
* Successful processing when state matches.
* Verification that invalid callbacks do not reach the token exchange path.
