### PR TITLE
escape username in ldap uid-mode search filter

### DIFF
--- a/gluon/contrib/login_methods/ldap_auth.py
+++ b/gluon/contrib/login_methods/ldap_auth.py
@@ -323,7 +323,10 @@ def ldap_auth(
                     con.simple_bind_s(ldap_binddn, ldap_bindpw)
                     dn = "uid=" + username + "," + ldap_basedn
                     dn = con.search_s(
-                        ldap_basedn, ldap.SCOPE_SUBTREE, "(uid=%s)" % username, [""]
+                        ldap_basedn,
+                        ldap.SCOPE_SUBTREE,
+                        "(uid=%s)" % ldap.filter.escape_filter_chars(username),
+                        [""],
                     )[0][0]
                 else:
                     dn = "uid=" + username + "," + ldap_basedn


### PR DESCRIPTION
the uid login mode in ldap_auth builds its directory lookup as "(uid=%s)" % username, where username is the value typed into the login form. that goes straight into an rfc4515 search filter with no escaping, so a login like *)(uid=*) reshapes the filter and can make it match entries the caller never intended (wildcards, extra clauses, an always-true branch), which is the usual ldap filter injection. it stood out because every other branch in the same file already wraps the username in ldap.filter.escape_filter_chars before interpolating it, the ad, company, uid_r and custom searches as well as the group lookups, so this one site was just missed. i confirmed the difference by rendering the filter for an attacker-style username: unescaped it becomes (uid=*)(uid=*))(|(uid=*), escaped it collapses to a single inert literal. the change escapes username the same way the surrounding code does, kept inside the uid branch so nothing else shifts.