### PR TITLE
[codex] Harden Markmin unsafe URL scheme checks

### DIFF
--- a/gluon/contrib/markmin/markmin2html.py
+++ b/gluon/contrib/markmin/markmin2html.py
@@ -715,13 +715,20 @@ def replace_components(text, env):
     text = regex_env2.sub(u2, text)
     return text
 
+
+_UNSAFE_URL_SCHEMES = {"data", "javascript", "vbscript"}
+
+
 def is_unsafe(url):
-    # Remove HTML5 whitespace: space, tab, newline, carriage return, form feed
-    # This prevents bypasses like java\nscript: or java\tscript:
-    url_cleaned = (url or "").lower()
-    for ws_char in (' ', '\t', '\n', '\r', '\f'):
-        url_cleaned = url_cleaned.replace(ws_char, '')
-    return url_cleaned.startswith("javascript:")
+    # Browsers strip ASCII C0 controls and spaces while processing URLs.
+    # Remove them before checking the scheme so values like java\0script:
+    # cannot bypass the dangerous-scheme check.
+    url_cleaned = "".join(
+        c for c in (url or "") if ord(c) > 0x20 and ord(c) != 0x7F
+    ).lower()
+    scheme, has_scheme, _ = url_cleaned.partition(":")
+    return has_scheme and scheme in _UNSAFE_URL_SCHEMES
+
 
 def autolinks_simple(url):
     """

--- a/gluon/tests/test_html.py
+++ b/gluon/tests/test_html.py
@@ -1158,6 +1158,15 @@ class TestBareHelpers(unittest.TestCase):
         output = MARKMIN("[[link javascript:alert(1)]]").xml()
         self.assertIn("markmin_unsafe", output)
         self.assertNotIn("<a href=\"javascript:", output)
+
+        # Block other active-content URL schemes in explicit links.
+        output = MARKMIN("[[link data:text/html,<script>alert(1)</script>]]").xml()
+        self.assertIn("markmin_unsafe", output)
+        self.assertNotIn("<a href=\"data:", output)
+
+        output = MARKMIN("[[link vbscript:msgbox(1)]]").xml()
+        self.assertIn("markmin_unsafe", output)
+        self.assertNotIn("<a href=\"vbscript:", output)
         
         # Allow safe HTTP URLs
         output = MARKMIN("[[link http://example.com]]").xml()
@@ -1183,11 +1192,20 @@ class TestBareHelpers(unittest.TestCase):
         
         # javascript: with carriage return should be detected
         self.assertTrue(is_unsafe("java\rscript:alert(1)"))
+
+        # Other active-content schemes should be blocked too.
+        self.assertTrue(is_unsafe("vbscript:msgbox(1)"))
+        self.assertTrue(is_unsafe("data:text/html,<script>alert(1)</script>"))
+
+        # C0 controls should not bypass the scheme check.
+        self.assertTrue(is_unsafe("java\0script:alert(1)"))
+        self.assertTrue(is_unsafe("vb\x7fscript:msgbox(1)"))
         
         # Safe URLs should not be detected as unsafe
         self.assertFalse(is_unsafe("http://example.com"))
         self.assertFalse(is_unsafe("https://example.com"))
         self.assertFalse(is_unsafe("mailto:test@example.com"))
+        self.assertFalse(is_unsafe("/relative/path"))
 
     def test_MARKMIN_attribute_breakout_xss(self):
         # A double quote inside a link target/title/alt/anchor must be escaped,


### PR DESCRIPTION
## Summary
- normalize Markmin URL scheme checks before evaluating link targets
- block additional active-content URL schemes in Markmin links
- add regression coverage for dangerous schemes and control-character bypasses

## Validation
- `PYTHONPATH=. python3` importlib runner for `gluon/tests/test_html.py` (`Ran 77 tests ... OK`)