### PR TITLE
escape urls in autolinks before embedding in html

### DIFF
--- a/gluon/contrib/autolinks.py
+++ b/gluon/contrib/autolinks.py
@@ -92,20 +92,20 @@ EMBED_MAPS = [
 
 
 def image(url):
-    return '<img src="%s" style="max-width:100%%"/>' % url
+    return '<img src="%s" style="max-width:100%%"/>' % html.escape(url, quote=True)
 
 
 def audio(url):
     return (
         '<audio controls="controls" style="max-width:100%%"><source src="%s" /></audio>'
-        % url
+        % html.escape(url, quote=True)
     )
 
 
 def video(url):
     return (
         '<video controls="controls" style="max-width:100%%"><source src="%s" /></video>'
-        % url
+        % html.escape(url, quote=True)
     )
 
 
@@ -120,7 +120,7 @@ def web2py_component(url):
     code = str(uuid.uuid4())
     return '<div id="%s"></div><script>\nweb2py_component("%s","%s");\n</script>' % (
         code,
-        url,
+        html.escape(url, quote=True),
         code,
     )
 
@@ -180,7 +180,8 @@ def extension(url):
 def expand_one(url, cdict):
     # try ombed but first check in cache
     if "@" in url and not "://" in url:
-        return '<a href="mailto:%s">%s</a>' % (url, url)
+        esc = html.escape(url, quote=True)
+        return '<a href="mailto:%s">%s</a>' % (esc, esc)
     if cdict and url in cdict:
         r = cdict[url]
     else:
@@ -201,7 +202,7 @@ def expand_one(url, cdict):
     if ext in EXTENSION_MAPS:
         return EXTENSION_MAPS[ext](url)
     # else regular link
-    return '<a href="%(u)s">%(u)s</a>' % dict(u=url)
+    return '<a href="%(u)s">%(u)s</a>' % dict(u=html.escape(url, quote=True))
 
 
 def expand_html(html, cdict=None):

--- a/gluon/tests/test_contribs.py
+++ b/gluon/tests/test_contribs.py
@@ -93,3 +93,24 @@ class TestContribs(unittest.TestCase):
         with self.assertRaises(HTTP) as ctx:
             _resolve_pdf_image_path("/welcome/static/../../private/secret.txt", request)
         self.assertEqual(ctx.exception.status, 403)
+
+    def test_autolinks_escapes_url_in_markup(self):
+        from gluon.contrib import autolinks
+
+        # a url carrying a double quote must not be able to break out of the
+        # attribute / script context it gets dropped into
+        link = autolinks.expand_one('http://x.com/"onmouseover="alert(1)', {})
+        self.assertNotIn('"onmouseover="', link)
+        self.assertIn("&quot;", link)
+
+        img = autolinks.image('http://x.com/"onerror="alert(1).png')
+        self.assertNotIn('"onerror="', img)
+
+        comp = autolinks.web2py_component('http://x/"+alert(1)+"')
+        self.assertNotIn('"+alert(1)+"', comp)
+
+        # legitimate urls are left intact
+        self.assertIn(
+            'href="http://good.com/page"',
+            autolinks.expand_one("http://good.com/page", {"http://good.com/page": {}}),
+        )


### PR DESCRIPTION
autolinks builds the embed markup for a matched url by dropping it straight into an href/src attribute (and into the web2py_component script string), and because the link regex is https?://\S+ a url that carries a double quote can close the attribute and inject an event handler, so user content rendered through expand_html ends up as reflected xss. the same unescaped interpolation is in image, audio, video, web2py_component and the plain-link branch of expand_one. this escapes the url with html.escape(quote=True) at each of those sinks, which lines up with the html.escape already used for the oembed query string just above.