### PR TITLE
escape username in ldap cn/uid bind dn construction

### DIFF
--- a/gluon/contrib/login_methods/ldap_auth.py
+++ b/gluon/contrib/login_methods/ldap_auth.py
@@ -8,6 +8,7 @@ import sys
 
 try:
     import ldap
+    import ldap.dn
     import ldap.filter
 
     ldap.set_option(ldap.OPT_REFERRALS, 0)
@@ -307,7 +308,7 @@ def ldap_auth(
                 # OpenLDAP (CN)
                 if ldap_binddn and ldap_bindpw:
                     con.simple_bind_s(ldap_binddn, ldap_bindpw)
-                dn = "cn=" + username + "," + ldap_basedn
+                dn = "cn=" + ldap.dn.escape_dn_chars(username) + "," + ldap_basedn
                 con.simple_bind_s(dn, password)
                 if manage_user:
                     result = con.search_s(
@@ -321,7 +322,7 @@ def ldap_auth(
                 # OpenLDAP (UID)
                 if ldap_binddn and ldap_bindpw:
                     con.simple_bind_s(ldap_binddn, ldap_bindpw)
-                    dn = "uid=" + username + "," + ldap_basedn
+                    dn = "uid=" + ldap.dn.escape_dn_chars(username) + "," + ldap_basedn
                     dn = con.search_s(
                         ldap_basedn,
                         ldap.SCOPE_SUBTREE,
@@ -329,7 +330,7 @@ def ldap_auth(
                         [""],
                     )[0][0]
                 else:
-                    dn = "uid=" + username + "," + ldap_basedn
+                    dn = "uid=" + ldap.dn.escape_dn_chars(username) + "," + ldap_basedn
                 con.simple_bind_s(dn, password)
                 if manage_user:
                     result = con.search_s(

--- a/gluon/tests/test_login_methods.py
+++ b/gluon/tests/test_login_methods.py
@@ -17,6 +17,20 @@ def _rfc4515_escape(value, escape_mode=0):
     return "".join(repl.get(c, c) for c in value)
 
 
+def _rfc4514_dn_escape(value):
+    # reference implementation of ldap.dn.escape_dn_chars (RFC 4514 2.4)
+    if not value:
+        return value
+    for ch in ("\\", ",", "+", '"', "<", ">", ";", "="):
+        value = value.replace(ch, "\\" + ch)
+    value = value.replace("\000", "\\\000")
+    if value[0] in ("#", " "):
+        value = "\\" + value
+    if value[-1] == " ":
+        value = value[:-1] + "\\ "
+    return value
+
+
 def _make_fake_ldap(captured):
     """Build a minimal fake ``ldap`` module so ldap_auth can be imported and
     driven without python-ldap / a live directory server."""
@@ -56,7 +70,11 @@ def _make_fake_ldap(captured):
     filter_mod = types.ModuleType("ldap.filter")
     filter_mod.escape_filter_chars = _rfc4515_escape
     ldap_mod.filter = filter_mod
-    return ldap_mod, filter_mod
+
+    dn_mod = types.ModuleType("ldap.dn")
+    dn_mod.escape_dn_chars = _rfc4514_dn_escape
+    ldap_mod.dn = dn_mod
+    return ldap_mod, filter_mod, dn_mod
 
 
 class TestLdapAuthFilterInjection(unittest.TestCase):
@@ -71,14 +89,16 @@ class TestLdapAuthFilterInjection(unittest.TestCase):
         self.captured = {}
         self._saved = {
             k: sys.modules.get(k)
-            for k in ("ldap", "ldap.filter", self._MODNAME)
+            for k in ("ldap", "ldap.filter", "ldap.dn", self._MODNAME)
         }
-        ldap_mod, filter_mod = _make_fake_ldap(self.captured)
+        ldap_mod, filter_mod, dn_mod = _make_fake_ldap(self.captured)
         sys.modules["ldap"] = ldap_mod
         sys.modules["ldap.filter"] = filter_mod
+        sys.modules["ldap.dn"] = dn_mod
         sys.modules.pop(self._MODNAME, None)
         self.mod = importlib.import_module(self._MODNAME)
         self.escape = filter_mod.escape_filter_chars
+        self.escape_dn = dn_mod.escape_dn_chars
 
     def tearDown(self):
         for k, v in self._saved.items():
@@ -105,3 +125,24 @@ class TestLdapAuthFilterInjection(unittest.TestCase):
         # the raw injection (a second, attacker-controlled clause) is gone
         self.assertNotIn("(uid=*)(uid=*", self.captured["filter"])
         self.assertNotIn("*", self.captured["filter"])
+
+    def test_cn_mode_escapes_username_in_bind_dn(self):
+        # In "cn" mode the bind DN is built as "cn=<username>,<base_dn>". A
+        # username carrying DN metacharacters (comma/equals) must be escaped
+        # with escape_dn_chars so it stays a single RDN value and cannot
+        # rewrite the DN structure (LDAP DN injection, CWE-90).
+        auth = self.mod.ldap_auth(
+            mode="cn",
+            server="ldap.example",
+            base_dn="dc=x",
+            manage_user=False,
+        )
+        malicious = "evil,ou=Admins"
+        auth(malicious, "pw")
+        binds = self.captured.get("binds", [])
+        self.assertTrue(binds, "no bind was attempted")
+        bind_dn = binds[-1][0]
+        # the username reaches the bind DN only in escaped form ...
+        self.assertEqual(bind_dn, "cn=%s,dc=x" % self.escape_dn(malicious))
+        # ... so the injected RDN cannot appear unescaped
+        self.assertNotIn("cn=evil,ou=Admins", bind_dn)


### PR DESCRIPTION
The cn and uid login modes in ldap_auth.py build the bind DN by concatenating the raw login username (`cn=<username>,<basedn>` / `uid=<username>,<basedn>`) and hand it to simple_bind_s. The search filters here already go through escape_filter_chars, but the DN does not, so a username containing DN metacharacters like a comma or equals sign (e.g. `admin,ou=Admins`) rewrites the RDN structure of the bind DN instead of being treated as a single value. Escape the username with ldap.dn.escape_dn_chars at the three DN-building sites so it stays one RDN component.