### PR TITLE
percent-encode request.url in routes_onerror error redirects

### DIFF
--- a/gluon/rewrite.py
+++ b/gluon/rewrite.py
@@ -281,7 +281,7 @@ def try_rewrite_on_error(http_response, request, environ, ticket=None):
                     status,
                     ticket,
                     quote_plus(request.env.request_uri),
-                    request.url,
+                    quote_plus(request.url),
                 )
                 if uri.startswith("http://") or uri.startswith("https://"):
                     # make up a response
@@ -323,7 +323,7 @@ def try_redirect_on_error(http_object, request, ticket=None):
                         status,
                         ticket,
                         quote_plus(request.env.request_uri),
-                        request.url,
+                        quote_plus(request.url),
                     )
                 else:
                     url = "%s?code=%s&ticket=%s&requested_uri=%s&request_url=%s" % (
@@ -331,7 +331,7 @@ def try_redirect_on_error(http_object, request, ticket=None):
                         status,
                         ticket,
                         quote_plus(request.env.request_uri),
-                        request.url,
+                        quote_plus(request.url),
                     )
                 return HTTP(
                     303,

--- a/gluon/tests/test_routes.py
+++ b/gluon/tests/test_routes.py
@@ -9,7 +9,13 @@ import unittest
 
 from gluon.html import URL
 from gluon.http import HTTP
-from gluon.rewrite import filter_err, filter_url, load, regex_filter_out
+from gluon.rewrite import (
+    filter_err,
+    filter_url,
+    load,
+    regex_filter_out,
+    try_redirect_on_error,
+)
 from gluon.settings import global_settings
 from gluon.storage import Storage
 
@@ -238,6 +244,22 @@ default_application = 'defapp'
         self.assertEqual(filter_err(200), 200)
         self.assertEqual(filter_err(399), 399)
         self.assertEqual(filter_err(400), 400)
+
+    def test_routes_onerror_encodes_request_url(self):
+        """
+        request.url comes from PATH_INFO and must be percent-encoded before
+        it is embedded in the error-redirect URL, like requested_uri already is.
+        """
+        load(data="routes_onerror=[('*/*', '/app/default/error')]")
+        request = Storage()
+        request.application = "app"
+        request.url = '/app/x"onmouseover="alert(1)'
+        request.env = Storage(request_uri="/app/x%22onmouseover%3D%22alert(1)")
+        result = try_redirect_on_error(HTTP(404), request, ticket="tkt")
+        location = result.headers["Location"]
+        self.assertIn("request_url=%2Fapp%2Fx%22onmouseover", location)
+        self.assertNotIn('"', location)
+        self.assertNotIn('"onmouseover="alert(1)', result.body)
 
     def test_routes_args(self):
         """


### PR DESCRIPTION
When routes_onerror is configured, try_rewrite_on_error and try_redirect_on_error build the error handler redirect by dropping request.url straight into the request_url query parameter, even though the requested_uri value right next to it already goes through quote_plus. request.url is set from the url-decoded PATH_INFO, so a request path with a double quote breaks out of the href attribute in the "you are being redirected" body and an unescaped ampersand lets extra parameters be smuggled into the onerror handler URL. Encoding it with quote_plus at the three sites, matching requested_uri, keeps the value as data. I have added a regression test under test_routes that drives try_redirect_on_error with a quote-bearing path.