### PR TITLE
reject reserved registration_key values in verify_email

### DIFF
--- a/gluon/tests/test_tools.py
+++ b/gluon/tests/test_tools.py
@@ -452,6 +452,57 @@ class TestAuthJWT(unittest.TestCase):
         self.assertEqual(err.exception.status, 400)
 
 
+class TestAuthVerifyEmail(unittest.TestCase):
+    def setUp(self):
+        self.request = Request(env={})
+        self.request.application = "a"
+        self.request.controller = "c"
+        self.request.function = "f"
+        self.request.folder = "applications/admin"
+        self.response = Response()
+        self.session = Session()
+        self.T = TranslatorFactory("", "en")
+        self.session.connect(self.request, self.response)
+        current.request = self.request
+        current.response = self.response
+        current.session = self.session
+        current.T = self.T
+        self.db = DAL(DEFAULT_URI, check_reserved=["all"])
+        self.auth = Auth(self.db)
+        self.auth.define_tables(username=True, signature=False)
+
+    def _verify_email_with_arg(self, arg):
+        from gluon.storage import List
+
+        self.request.args = List(["verify_email", arg])
+        try:
+            self.auth.verify_email()
+        except HTTP:
+            pass
+
+    def test_reserved_key_does_not_activate_account(self):
+        # a reserved registration_key must not be accepted as a
+        # verification token, otherwise verify_email/<state> would clear it
+        for state in ("disabled", "blocked", "pending"):
+            uid = self.db.auth_user.insert(
+                username="u_" + state, password="x", registration_key=state
+            )
+            self.db.commit()
+            self._verify_email_with_arg(state)
+            self.assertEqual(self.db.auth_user[uid].registration_key, state)
+
+    def test_valid_key_verifies_account(self):
+        from gluon.utils import web2py_uuid
+
+        key = web2py_uuid()
+        uid = self.db.auth_user.insert(
+            username="legit", password="x", registration_key=key
+        )
+        self.db.commit()
+        self._verify_email_with_arg(key)
+        self.assertEqual(self.db.auth_user[uid].registration_key, "")
+
+
 @unittest.skipIf(IS_IMAP, "TODO: Imap raises 'Connection refused'")
 # class TestAuth(unittest.TestCase):
 #

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -3653,6 +3653,15 @@ class Auth(AuthAPI):
 
         key = getarg(-1)
         table_user = self.table_user()
+        # registration_key also holds the reserved states "", "pending",
+        # "disabled" and "blocked". Only the random token issued at
+        # registration is a genuine verification key, so refuse these
+        # values here; otherwise a request for verify_email/disabled (or
+        # /blocked, /pending) would match such an account and clear its key,
+        # re-activating an account an administrator disabled or one still
+        # awaiting approval.
+        if not key or key in ("pending", "disabled", "blocked"):
+            redirect(self.settings.login_url)
         user = table_user(registration_key=key)
         if not user:
             redirect(self.settings.login_url)


### PR DESCRIPTION
verify_email looks up the account with table_user(registration_key=key) using the last URL segment as the key, but registration_key also holds the reserved states "", pending, disabled and blocked. An unauthenticated request to verify_email/disabled (or /blocked, /pending) therefore matches a disabled, blocked or approval-pending account and clears its key to "", quietly re-activating it. This refuses the empty and reserved key values before the lookup so only the random token issued at registration is accepted, and adds a regression test covering both the reserved values and a genuine token.