### PR TITLE
percent-encode untrusted ticket and token in login validation urls

### DIFF
--- a/gluon/contrib/login_methods/cas_auth.py
+++ b/gluon/contrib/login_methods/cas_auth.py
@@ -10,6 +10,7 @@ Tinkered by Szabolcs Gyuris < szimszo n @ o regpreshaz dot eu>
 """
 import xml.dom.minidom as dom
 import xml.parsers.expat as expat
+from urllib.parse import quote as urllib_quote
 from urllib.request import urlopen
 
 from gluon import URL, current, redirect
@@ -108,10 +109,13 @@ class CasAuth(object):
         if not current.request.vars.ticket:
             redirect("%s?service=%s" % (self.cas_login_url, self.cas_my_url))
         else:
+            # ticket comes from the request; percent-encode it so it cannot
+            # inject extra parameters into the CAS validation request whose
+            # response is trusted to authenticate the user.
             url = "%s?service=%s&ticket=%s" % (
                 self.cas_check_url,
                 self.cas_my_url,
-                self.ticket,
+                urllib_quote(self.ticket, safe=""),
             )
             data = urlopen(url).read()
             if data.startswith("yes") or data.startswith("no"):

--- a/gluon/contrib/login_methods/loginradius_account.py
+++ b/gluon/contrib/login_methods/loginradius_account.py
@@ -12,6 +12,7 @@
 
 import json
 import os
+from urllib.parse import quote as urllib_quote
 
 from gluon import *
 from gluon.storage import Storage
@@ -63,8 +64,14 @@ class LoginRadiusAccount(object):
         user = None
         if request.vars.token:
             try:
+                # token comes from the request; percent-encode it so it stays a
+                # single path segment and cannot inject extra path/query into
+                # the profile lookup below.
                 auth_url = (
-                    self.auth_base_url + self.api_secret + "/" + request.vars.token
+                    self.auth_base_url
+                    + self.api_secret
+                    + "/"
+                    + urllib_quote(request.vars.token, safe="")
                 )
                 json_data = fetch(
                     auth_url, headers={"User-Agent": "LoginRadius - Python - SDK"}

--- a/gluon/tests/test_login_methods.py
+++ b/gluon/tests/test_login_methods.py
@@ -9,6 +9,10 @@ import importlib
 import sys
 import types
 import unittest
+from urllib.parse import quote as urllib_quote
+
+from gluon.globals import current
+from gluon.storage import Storage
 
 
 def _rfc4515_escape(value, escape_mode=0):
@@ -146,3 +150,66 @@ class TestLdapAuthFilterInjection(unittest.TestCase):
         self.assertEqual(bind_dn, "cn=%s,dc=x" % self.escape_dn(malicious))
         # ... so the injected RDN cannot appear unescaped
         self.assertNotIn("cn=evil,ou=Admins", bind_dn)
+
+
+class TestOutboundURLTokenEncoding(unittest.TestCase):
+    # loginradius_account / cas_auth build the outbound provider-validation URL
+    # by interpolating an attacker-supplied request value (token / ticket) into
+    # it. Without percent-encoding, "/", "&", "#" or "?" let the caller inject
+    # extra path or query into that request -- the same defect the sibling
+    # providers (janrain/rpx/loginza) already avoid via urlencode.
+    _MALICIOUS = "abc/../x?a=1&b=2#frag"
+
+    def test_loginradius_encodes_token(self):
+        mod = importlib.import_module(
+            "gluon.contrib.login_methods.loginradius_account"
+        )
+        captured = {}
+
+        def fake_fetch(url, **kwargs):
+            captured["url"] = url
+            return "{}"
+
+        orig = mod.fetch
+        mod.fetch = fake_fetch
+        try:
+            req = Storage(vars=Storage(token=self._MALICIOUS))
+            account = mod.LoginRadiusAccount(req, api_key="k", api_secret="s")
+            account.get_user()
+        finally:
+            mod.fetch = orig
+        expected = urllib_quote(self._MALICIOUS, safe="")
+        self.assertTrue(captured["url"].endswith("/" + expected))
+        self.assertNotIn(self._MALICIOUS, captured["url"])
+
+    def test_cas_encodes_ticket(self):
+        mod = importlib.import_module("gluon.contrib.login_methods.cas_auth")
+        captured = {}
+
+        class FakeResp(object):
+            def read(self):
+                return "no\n"
+
+        def fake_urlopen(url, *a, **k):
+            captured["url"] = url
+            return FakeResp()
+
+        orig = mod.urlopen
+        saved_request = getattr(current, "request", None)
+        mod.urlopen = fake_urlopen
+        current.request = Storage(vars=Storage(ticket=self._MALICIOUS))
+        try:
+            cas = mod.CasAuth.__new__(mod.CasAuth)
+            cas.cas_check_url = "https://cas.example/cas/validate"
+            cas.cas_login_url = "https://cas.example/cas/login"
+            cas.cas_my_url = "https://app.example/user/cas"
+            cas._CAS_login()
+        finally:
+            mod.urlopen = orig
+            if saved_request is None:
+                current.request = None
+            else:
+                current.request = saved_request
+        expected = urllib_quote(self._MALICIOUS, safe="")
+        self.assertIn("ticket=" + expected, captured["url"])
+        self.assertNotIn(self._MALICIOUS, captured["url"])


### PR DESCRIPTION
loginradius_account and cas_auth build the outbound provider-validation URL by interpolating request.vars.token / request.vars.ticket straight into it, so a value carrying /, &, # or ? injects extra path or query into a request whose response is trusted to authenticate the user. The sibling providers (janrain, rpx, loginza) already run the token through urlencode before the call. Percent-encode the untrusted value at both sites and add a regression test that fails on the current code.