### PR TITLE
restrict SQLFORM.grid orderby to its sortable columns

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -2872,6 +2872,15 @@ class SQLFORM(FORM):
                             f.tablename = table._tablename
                             fields.append(f)
                             columns.append(f)
+        # the grid only offers sort links for readable, non-virtual columns;
+        # request.vars.order must be constrained to that same set so a crafted
+        # value cannot order by (and leak the ordering of) an undisplayed column
+        # or reference an unrelated table and raise an unhandled 500
+        sortable_fields = set(
+            str(f)
+            for f in columns
+            if isinstance(f, Field) and not isinstance(f, Field.Virtual) and f.readable
+        )
         if not field_id:
             if groupby is None:
                 field_id = tables[0]._id
@@ -3087,7 +3096,7 @@ class SQLFORM(FORM):
         if export_type:
             order = request.vars.order or ""
             if sortable:
-                if order:
+                if order and order.split("~")[-1] in sortable_fields:
                     otablename, ofieldname = order.split("~")[-1].split(".", 1)
                     sort_field = db[otablename][ofieldname]
                     orderby = sort_field if order[:1] != "~" else ~sort_field
@@ -3268,7 +3277,7 @@ class SQLFORM(FORM):
         order = request.vars.order or ""
         asc_icon, desc_icon = sorter_icons
         if sortable:
-            if order:
+            if order and order.split("~")[-1] in sortable_fields:
                 otablename, ofieldname = order.split("~")[-1].split(".", 1)
                 sort_field = db[otablename][ofieldname]
                 orderby = sort_field if order[:1] != "~" else ~sort_field

--- a/gluon/tests/test_sqlhtml.py
+++ b/gluon/tests/test_sqlhtml.py
@@ -383,6 +383,37 @@ class TestSQLFORM(unittest.TestCase):
         grid_form = SQLFORM.grid(self.db.auth_user)
         self.assertEqual(grid_form.xml()[:4], "<div")
 
+    def test_grid_order_limited_to_sortable_columns(self):
+        # request.vars.order must be constrained to the grid's sortable
+        # columns. A crafted value must not sort by an undisplayed column
+        # (which leaks its ordering) nor reference an unrelated table (which
+        # raised an unhandled 500).
+        from gluon.globals import current
+
+        self.db.define_table(
+            "gitem",
+            Field("name"),
+            Field("secret", readable=False, writable=False),
+        )
+        self.db.gitem.insert(name="alpha", secret="zzz")
+        self.db.gitem.insert(name="bravo", secret="aaa")
+        self.db.commit()
+
+        def name_order(order):
+            current.request.vars.order = order
+            xml = SQLFORM.grid(self.db.gitem, sortable=True).xml()
+            return "alpha,bravo" if xml.find(">alpha<") < xml.find(">bravo<") else "bravo,alpha"
+
+        default = name_order("")
+        # sorting by the hidden readable=False column is refused
+        self.assertEqual(name_order("gitem.secret"), default)
+        # malformed and foreign-table order values are ignored, not fatal
+        self.assertEqual(name_order("boom"), default)
+        self.assertEqual(name_order("nosuchtable.x"), default)
+        # a real displayed column can still be sorted
+        self.assertEqual(name_order("~gitem.name"), "bravo,alpha")
+        current.request.vars.order = ""
+
     def test_smartgrid(self):
         smartgrid_form = SQLFORM.smartgrid(self.db.auth_user)
         self.assertEqual(smartgrid_form.xml()[:4], "<div")


### PR DESCRIPTION
SQLFORM.grid turns request.vars.order into the ORDER BY without checking the field is one it actually displays, so a crafted order sorts by an undisplayed readable=False column (leaking its ordering through the paged listing) or names an unrelated table and raises an unhandled 500. The grid signs only the path and args, not query vars (URL.verify hash_vars=False), so order stays attacker-controlled even on a user_signature grid. Constrain order at the listing and export sites to the readable, non-virtual columns the grid already builds sort links for.