### PR TITLE
escape markmin meta attribute values in code, colour and cite

### DIFF
--- a/gluon/contrib/markmin/markmin2html.py
+++ b/gluon/contrib/markmin/markmin2html.py
@@ -1577,7 +1577,7 @@ def render(
                 "["
                 + ",".join(
                     '<a href="#%s" class="%s">%s</a>' % (id_prefix + d, b, d)
-                    for d in local_html_escape(code).split(",")
+                    for d in local_html_escape(code, quote=True).split(",")
                 )
                 + "]"
             )
@@ -1602,7 +1602,7 @@ def render(
                 ),
             )
         elif b in ("c", "color") and p:
-            c = p.split(":")
+            c = local_html_escape(p, quote=True).split(":")
             fg = "color: %s;" % c[0] if c[0] else ""
             bg = "background-color: %s;" % c[1] if len(c) > 1 and c[1] else ""
             return '<span style="%s%s">%s</span>' % (
@@ -1624,7 +1624,7 @@ def render(
                 ),
             )
         cls = ' class="%s%s"' % (class_prefix, b) if b and b != "id" else ""
-        id = ' id="%s%s"' % (id_prefix, local_html_escape(p)) if p else ""
+        id = ' id="%s%s"' % (id_prefix, local_html_escape(p, quote=True)) if p else ""
         beg = code[:1] == "\n"
         end = [None, -1][code[-1:] == "\n"]
         if beg and end:

--- a/gluon/tests/test_html.py
+++ b/gluon/tests/test_html.py
@@ -1263,6 +1263,44 @@ class TestBareHelpers(unittest.TestCase):
             output,
         )
 
+    def test_MARKMIN_code_meta_attribute_breakout_xss(self):
+        # The optional [id] part of a ``code``:cls[id] meta is captured as
+        # [^\]]*, so it can contain a double quote. That value ends up inside
+        # HTML attributes in three places of the meta/code rendering path
+        # (the <code> id, the colour <span> style, and the cite <a> href), so
+        # the quote must be escaped or it breaks out of the attribute and lets
+        # an attacker inject an event handler (XSS), just like the link/media
+        # paths already guard against.
+
+        # code block id attribute
+        output = MARKMIN('``hi``:cls[x" onmouseover="alert(1)]').xml()
+        self.assertNotIn('" onmouseover="alert(1)', output)
+        self.assertIn("&quot; onmouseover=&quot;alert(1)", output)
+
+        # colour span style attribute
+        output = MARKMIN('``hi``:c[red" onmouseover="alert(2)]').xml()
+        self.assertNotIn('" onmouseover="alert(2)', output)
+        self.assertIn("&quot; onmouseover=&quot;alert(2)", output)
+
+        # cite href attribute
+        output = MARKMIN('``x" onclick="alert(3)``:cite').xml()
+        self.assertNotIn('" onclick="alert(3)', output)
+        self.assertIn("&quot; onclick=&quot;alert(3)", output)
+
+        # legitimate metas keep rendering unchanged
+        self.assertIn(
+            '<code class="python" id="markmin_myid">hello</code>',
+            MARKMIN("``hello``:python[myid]").xml(),
+        )
+        self.assertIn(
+            '<span style="color: red;">red text</span>',
+            MARKMIN("``red text``:c[red]").xml(),
+        )
+        self.assertIn(
+            '<a href="#markmin_a" class="cite">a</a>',
+            MARKMIN("``a,b``:cite").xml(),
+        )
+
     def test_ASSIGNJS(self):
         # empty assignation
         self.assertEqual(ASSIGNJS().xml(), "")


### PR DESCRIPTION
the optional id part of a code meta like ``text``:cls[id] is captured as [^]]* so it can contain a double quote, and that value is placed unescaped into three attributes of the code and meta rendering path: the <code> id, the colour <span> style, and the cite <a> href. a quote there closes the attribute and lets an attacker add an event handler, so any app that renders user-supplied markmin (comments, wiki pages, MARKMIN()) is exposed to stored xss, for instance ``hi``:cls[x" onmouseover="alert(1)] renders a live onmouseover handler. this escapes those values with quote=True, the same guard the link and media rendering already use, and adds a regression test alongside the existing markmin xss tests.