### PR TITLE
escape double quotes in translated strings used as attribute values

### DIFF
--- a/gluon/languages.py
+++ b/gluon/languages.py
@@ -420,7 +420,7 @@ class lazyT(object):
         return len(str(self))
 
     def xml(self):
-        return str(self) if self.M else xmlescape(str(self), quote=False)
+        return str(self) if self.M else xmlescape(str(self), quote=True)
 
     def encode(self, *a, **b):
         return str(self)

--- a/gluon/tests/test_languages.py
+++ b/gluon/tests/test_languages.py
@@ -12,7 +12,7 @@ import tempfile
 import unittest
 
 from gluon import languages
-from gluon.html import SPAN
+from gluon.html import INPUT, SPAN
 from gluon.storage import Messages
 
 MP_WORKING = 0
@@ -311,3 +311,12 @@ class TestHTMLTag(unittest.TestCase):
         elem = SPAN(T("Cannot be empty", language="ru"))
         self.assertEqual(elem.xml(), "<span>Пустое значение недопустимо</span>")
         self.assertEqual(elem.flatten(), "Пустое значение недопустимо")
+
+    def test_attribute_quote_escaping(self):
+        # A lazyT used as an attribute value must escape double quotes,
+        # otherwise a symbol carrying a '"' breaks out of the attribute.
+        T = languages.TranslatorFactory(self.langpath, self.http_accept_language)
+        payload = 'Bob" onmouseover="alert(1)'
+        elem = INPUT(_value=T("Hello %(name)s", dict(name=payload)))
+        self.assertNotIn('value="Hello Bob" onmouseover=', elem.xml())
+        self.assertIn("&quot;", elem.xml())


### PR DESCRIPTION
lazyT.xml() escapes a translated string with quote=False, so it handles < > & but leaves double quotes alone. HTML helpers auto-escape attribute values through xmlescape(value, True), but xmlescape hands off to value.xml() whenever the value exposes one, which drops the quote=True it was asked for. A lazyT used as an attribute value, e.g. INPUT(_value=T('Hello %(name)s', dict(name=request.vars.name))), then emits the raw quote and an attacker-controlled symbol closes the attribute and adds an event handler. No angle brackets are involved, so the existing < > & escaping never catches it.

Switching lazyT.xml() to quote=True closes the breakout where the string becomes markup, which is the one place that sees both the value and its attribute context. Text rendering looks the same in a browser since &quot; displays as a quote, and the T.M() markmin branch keeps its own escaping. The regression test covers the attribute case and fails on the current code.