### PR TITLE
restrict SQLFORM.grid view/edit/delete to its own tables

### DIFF
--- a/gluon/sqlhtml.py
+++ b/gluon/sqlhtml.py
@@ -2938,6 +2938,8 @@ class SQLFORM(FORM):
         create_form = update_form = view_form = search_form = None
 
         if create and request.args(-2) == "new":
+            if request.args[-1] not in tablenames:
+                redirect(referrer)
             table = db[request.args[-1]]
             sqlformargs = dict(
                 ignore_rw=ignore_rw, formstyle=formstyle, _class="web2py_form"
@@ -2961,6 +2963,8 @@ class SQLFORM(FORM):
             return res
 
         elif details and request.args(-3) == "view":
+            if request.args[-2] not in tablenames:
+                redirect(referrer)
             table = db[request.args[-2]]
             record = table(request.args[-1]) or redirect(referrer)
             if represent_none is not None:
@@ -2990,6 +2994,8 @@ class SQLFORM(FORM):
             res.rows = None
             return res
         elif editable and request.args(-3) == "edit":
+            if request.args[-2] not in tablenames:
+                redirect(referrer)
             table = db[request.args[-2]]
             record = table(request.args[-1]) or redirect(URL("error"))
             deletable_ = deletable(record) if callable(deletable) else deletable
@@ -3025,6 +3031,8 @@ class SQLFORM(FORM):
             res.rows = None
             return res
         elif deletable and request.args(-3) == "delete":
+            if request.args[-2] not in tablenames:
+                redirect(referrer)
             table = db[request.args[-2]]
             if not callable(deletable):
                 if ondelete:

--- a/gluon/tests/test_sqlhtml.py
+++ b/gluon/tests/test_sqlhtml.py
@@ -414,6 +414,34 @@ class TestSQLFORM(unittest.TestCase):
         self.assertEqual(name_order("~gitem.name"), "bravo,alpha")
         current.request.vars.order = ""
 
+    def test_grid_view_limited_to_own_tables(self):
+        # The view/edit/delete/new action must only reference a table the grid
+        # was built on. The table name is taken from the URL (request.args), and
+        # the "view" action is reachable without a signature for anonymous
+        # visitors, so an unchecked name lets anyone read a record of an
+        # unrelated table (e.g. auth_user) through a grid on a public table.
+        from gluon.globals import current
+        from gluon.storage import List
+
+        self.db.define_table("product", Field("name"))
+        self.db.product.insert(name="widget")
+        self.db.commit()
+
+        # anonymous visitor requesting /f/view/auth_user/1 on a grid over product
+        current.request.args = List(["view", "auth_user", "1"])
+        try:
+            xml = SQLFORM.grid(self.db.product).xml()
+        except HTTP as e:
+            self.assertEqual(e.status, 303)
+        else:
+            self.assertNotIn("user1@test.com", xml)
+
+        # a legitimate view of the grid's own table still renders
+        current.request.args = List(["view", "product", "1"])
+        xml = SQLFORM.grid(self.db.product).xml()
+        self.assertIn("widget", xml)
+        current.request.args = List([])
+
     def test_smartgrid(self):
         smartgrid_form = SQLFORM.smartgrid(self.db.auth_user)
         self.assertEqual(smartgrid_form.xml()[:4], "<div")


### PR DESCRIPTION
The grid's new/view/edit/delete branches take the target table name from request.args and load db[request.args[-2]] without checking it against the tables the grid was built on. The view action is reachable without a signature for anonymous visitors, so a grid over a public table lets anyone request /f/view/auth_user/1 and read rows of unrelated tables (auth_user email/username and any other readable field, ignoring the grid's own query). This rejects any action whose URL table name is not one of the grid's tablenames, at all four sites.