### PR TITLE
Enforce admin app boundaries in multi-user mode

### DIFF
--- a/applications/admin/controllers/default.py
+++ b/applications/admin/controllers/default.py
@@ -140,6 +140,13 @@ def get_app(name=None):
     redirect(URL('site'))
 
 
+def get_app_file_path(name=None, filename=None, absolute=False):
+    app = get_app(name)
+    filename = filename if filename is not None else '/'.join(request.args)
+    path = abspath(filename) if absolute else apath(filename, r=request)
+    return app, filename, check_app_path(request, app, path)
+
+
 def index():
     """ Index handler """
 
@@ -553,8 +560,7 @@ def remove_compiled_app():
 
 def delete():
     """ Object delete handler """
-    app = get_app()
-    filename = '/'.join(request.args)
+    app, filename, full_path = get_app_file_path()
     sender = request.vars.sender
 
     if isinstance(sender, list):  # ## fix a problem with Vista
@@ -565,7 +571,6 @@ def delete():
 
     if dialog.accepted:
         try:
-            full_path = apath(filename, r=request)
             lineno = count_lines(safe_open(full_path, 'r').read())
             os.unlink(full_path)
             log_progress(app, 'DELETE', filename, progress=-lineno)
@@ -594,12 +599,8 @@ def enable():
 
 def peek():
     """ Visualize object code """
-    app = get_app(request.vars.app)
-    filename = '/'.join(request.args)
-    if request.vars.app:
-        path = abspath(filename)
-    else:
-        path = apath(filename, r=request)
+    app, filename, path = get_app_file_path(
+        request.vars.app, absolute=bool(request.vars.app))
     try:
         data = safe_read(path).replace('\r', '')
     except IOError:
@@ -654,7 +655,6 @@ def edit():
     """ File edit handler """
     # Load json only if it is ajax edited...
     app = get_app(request.vars.app)
-    app_path = apath(app, r=request)
     preferences = {'theme': 'web2py', 'editor': 'default', 'closetag': 'true', 'codefolding': 'false', 'tabwidth': '4', 'indentwithtabs': 'false', 'linenumbers': 'true', 'highlightline': 'true'}
     config = Config(os.path.join(request.folder, 'settings.cfg'),
                     section='editor', default_values={})
@@ -684,13 +684,9 @@ def edit():
 
     """ File edit handler """
     # Load json only if it is ajax edited...
-    app = get_app(request.vars.app)
-    filename = '/'.join(request.args)
+    app, filename, path = get_app_file_path(
+        request.vars.app, absolute=bool(request.vars.app))
     realfilename = request.args[-1]
-    if request.vars.app:
-        path = abspath(filename)
-    else:
-        path = apath(filename, r=request)
     # Try to discover the file type
     if filename[-3:] == '.py':
         filetype = 'python'
@@ -873,12 +869,14 @@ def edit():
 def todolist():
     """ Returns all TODO of the requested app
     """
-    app = request.vars.app or ''
-    app_path = apath('%(app)s' % {'app': app}, r=request)
+    app = get_app(request.vars.app or request.args(0))
     dirs = ['models', 'controllers', 'modules', 'private']
 
     def listfiles(app, dir, regexp=r'.*\.py$'):
-        files = sorted(listdir(apath('%(app)s/%(dir)s/' % {'app': app, 'dir': dir}, r=request), regexp))
+        path = check_app_path(
+            request, app,
+            apath('%(app)s/%(dir)s/' % {'app': app, 'dir': dir}, r=request))
+        files = sorted(listdir(path, regexp))
         files = [x.replace(os.path.sep, '/') for x in files if not x.endswith('.bak')]
         return files
 
@@ -923,9 +921,8 @@ def resolve():
     """
     """
 
-    filename = '/'.join(request.args)
+    app, filename, path = get_app_file_path()
     # ## check if file is not there
-    path = apath(filename, r=request)
     a = safe_read(path).split('\n')
     try:
         b = safe_read(path + '.1').split('\n')
@@ -983,10 +980,9 @@ def resolve():
 
 def edit_language():
     """ Edit language file """
-    app = get_app()
-    filename = '/'.join(request.args)
+    app, filename, path = get_app_file_path()
     response.title = request.args[-1]
-    strings = read_dict(apath(filename, r=request))
+    strings = read_dict(path)
 
     if '__corrupted__' in strings:
         form = SPAN(strings['__corrupted__'], _class='error')
@@ -1034,18 +1030,16 @@ def edit_language():
             if form.vars[name] == chr(127):
                 continue
             strs[key] = form.vars[name]
-        write_dict(apath(filename, r=request), strs)
+        write_dict(path, strs)
         session.flash = T('file saved on %(time)s', dict(time=time.ctime()))
         redirect(URL(r=request, args=request.args))
-    return dict(app=request.args[0], filename=filename, form=form)
+    return dict(app=app, filename=filename, form=form)
 
 
 def edit_plurals():
     """ Edit plurals file """
-    app = get_app()
-    filename = '/'.join(request.args)
-    plurals = read_plural_dict(
-        apath(filename, r=request))  # plural forms dictionary
+    app, filename, path = get_app_file_path()
+    plurals = read_plural_dict(path)  # plural forms dictionary
     nplurals = int(request.vars.nplurals) - 1  # plural forms quantity
     xnplurals = range(nplurals)
 
@@ -1085,11 +1079,11 @@ def edit_plurals():
                 continue
             new_plurals[key] = [form.vars[name + '_' + str(n)]
                                 for n in xnplurals]
-        write_plural_dict(apath(filename, r=request), new_plurals)
+        write_plural_dict(path, new_plurals)
         session.flash = T('file saved on %(time)s', dict(time=time.ctime()))
         redirect(URL(r=request, args=request.args, vars=dict(
             nplurals=request.vars.nplurals)))
-    return dict(app=request.args[0], filename=filename, form=form)
+    return dict(app=app, filename=filename, form=form)
 
 
 def about():
@@ -1234,8 +1228,10 @@ def design():
 
 def delete_plugin():
     """ Object delete handler """
-    app = request.args(0)
+    app = get_app()
     plugin = request.args(1)
+    if not re.compile(r'^\w+$').match(plugin or ''):
+        raise HTTP(403)
     plugin_name = 'plugin_' + plugin
 
     dialog = FORM.confirm(
@@ -1532,10 +1528,11 @@ def create_file():
 
 
 def listfiles(app, dir, regexp=r'.*\.py$'):
-    path = apath('%(app)s/%(dir)s/' % {'app': app, 'dir': dir}, r=request)
-    web2py_apps_root = os.path.abspath(up(request.folder))
-    path_abs = os.path.abspath(path)
-    if not is_within_root(path_abs, web2py_apps_root):
+    try:
+        path = check_app_path(
+            request, app,
+            apath('%(app)s/%(dir)s/' % {'app': app, 'dir': dir}, r=request))
+    except HTTP:
         return []
     files = sorted(
         listdir(path, regexp))
@@ -1550,7 +1547,7 @@ def editfile(path, file, vars={}, app=None):
 
 
 def files_menu():
-    app = request.vars.app or 'welcome'
+    app = get_app(request.vars.app or request.args(0) or 'welcome')
     dirs = [{'name': 'models', 'reg': r'.*\.py$'},
             {'name': 'controllers', 'reg': r'.*\.py$'},
             {'name': 'views', 'reg': r'[\w/\-]+(\.\w+)+$'},
@@ -2004,7 +2001,7 @@ def git_push():
 
 
 def plugins():
-    app = request.args(0)
+    app = get_app()
     from gluon.serializers import loads_json
     if not session.plugins:
         try:
@@ -2015,11 +2012,11 @@ def plugins():
         except:
             response.flash = T('Unable to download the list of plugins')
             session.plugins = []
-    return dict(plugins=session.plugins["results"], app=request.args(0))
+    return dict(plugins=session.plugins["results"], app=app)
 
 
 def install_plugin():
-    app = request.args(0)
+    app = get_app()
     source = request.vars.source
     plugin = request.vars.plugin
     if not (source and app):

--- a/applications/admin/controllers/pythonanywhere.py
+++ b/applications/admin/controllers/pythonanywhere.py
@@ -9,6 +9,32 @@ from urllib.parse import urlencode
 from urllib import request as urllib2
 from xmlrpc.client import ProtocolError
 from gluon.contrib.simplejsonrpc import ServerProxy
+from gluon.admin import apath, check_app_path
+
+
+APPNAME = re.compile(r'^\w+$')
+
+
+def list_authorized_apps():
+    local = sorted(f for f in os.listdir(apath(r=request)) if APPNAME.match(f))
+    if not MULTI_USER_MODE or is_manager():
+        return local
+    owned = db(db.app.owner == auth.user.id).select(db.app.name)
+    owned = set(row.name for row in owned)
+    return [app for app in local if app in owned]
+
+
+def authorized_app_path(app):
+    if not APPNAME.match(app or ''):
+        raise HTTP(403)
+    if (MULTI_USER_MODE and not is_manager() and
+            not db(db.app.name == app)(db.app.owner == auth.user.id).count()):
+        raise HTTP(403)
+    folder = check_app_path(request, app, apath(app, r=request))
+    if not os.path.isdir(folder):
+        raise HTTP(404)
+    return folder
+
 
 def deploy():
     response.title = T('Deploy to pythonanywhere')
@@ -19,7 +45,7 @@ def create_account():
     """ Create a PythonAnywhere account """
     if not request.vars:
         raise HTTP(400)
-    
+
     if request.vars.username and request.vars.web2py_admin_password:
         # Check if web2py is already there otherwise we get an error 500 too.
         client = ServerProxy('https://%(username)s:%(web2py_admin_password)s@%(username)s.pythonanywhere.com/admin/webservices/call/jsonrpc' % request.vars)
@@ -32,7 +58,7 @@ def create_account():
     url = 'https://www.pythonanywhere.com/api/web2py/create_account'
     data = urlencode(request.vars)
     req = urllib2.Request(url, data)
-    
+
     try:
         reply = urllib2.urlopen(req)
     except urllib2.HTTPError as error:
@@ -51,8 +77,7 @@ def list_apps():
     if not request.vars.username or not request.vars.password:
         raise HTTP(400)
     client = ServerProxy('https://%(username)s:%(password)s@%(username)s.pythonanywhere.com/admin/webservices/call/jsonrpc' % request.vars)
-    regex = re.compile('^\w+$')
-    local = [f for f in os.listdir(apath(r=request)) if regex.match(f)]
+    local = list_authorized_apps()
     try:
         pythonanywhere = client.list_apps()
     except ProtocolError as error:
@@ -67,11 +92,11 @@ def bulk_install():
         """
         Given an app's name, return the base64 representation of its packed version.
         """
-        folder = apath(app, r=request)
+        folder = authorized_app_path(app)
         tmpfile = io.StringIO()
         tar = tarfile.TarFile(fileobj=tmpfile, mode='w')
         try:
-            filenames = listdir(folder, '^[\w\.\-]+$', add_dirs=True, 
+            filenames = listdir(folder, r'^[\w\.\-]+$', add_dirs=True,
                                 exclude_content_from=['cache', 'sessions', 'errors'])
             for fname in filenames:
                 tar.add(os.path.join(folder, fname), fname, False)
@@ -99,4 +124,4 @@ def bulk_install():
         except ProtocolError as error:
             raise HTTP(error.errcode)
 
-    return response.json({'status': 'ok'}) 
+    return response.json({'status': 'ok'})

--- a/applications/admin/controllers/wizard.py
+++ b/applications/admin/controllers/wizard.py
@@ -47,7 +47,22 @@ def listify(x):
 
 
 def clean(name):
-    return re.sub('\W+', '_', name.strip().lower())
+    return re.sub(r'\W+', '_', name.strip().lower())
+
+
+def app_can_be_written(app):
+    if not MULTI_USER_MODE or is_manager():
+        return True
+    app_path = os.path.join(request.folder, '..', app)
+    if os.path.isdir(app_path):
+        return db(db.app.name == app)(db.app.owner == auth.user.id).count()
+    return not db(db.app.name == app)(db.app.owner != auth.user.id).count()
+
+
+def ensure_app_can_be_written(app):
+    if not app_can_be_written(app):
+        session.flash = 'App belongs already to other user'
+        redirect(URL('index'))
 
 
 def index():
@@ -59,9 +74,8 @@ def index():
     if form.accepts(request.vars):
         app = form.vars.name
         session.app['name'] = app
-        if MULTI_USER_MODE and db(db.app.name == app)(db.app.owner != auth.user.id).count():
-            session.flash = 'App belongs already to other user'
-        elif app in apps:
+        ensure_app_can_be_written(app)
+        if app in apps:
             meta = os.path.normpath(
                 os.path.join(os.path.normpath(request.folder),
                              '..', app, 'wizard.metadata'))
@@ -483,8 +497,9 @@ def create(options):
         redirect(URL('step6'))
     params = dict(session.app['params'])
     app = session.app['name']
+    ensure_app_can_be_written(app)
     if app_create(app, request, force=True, key=params['security_key']):
-        if MULTI_USER_MODE:
+        if MULTI_USER_MODE and not db(db.app.name == app).count():
             db.app.insert(name=app, owner=auth.user.id)
     else:
         session.flash = 'Failure to create application'

--- a/gluon/tests/test_appadmin.py
+++ b/gluon/tests/test_appadmin.py
@@ -111,6 +111,34 @@ class TestAppAdmin(unittest.TestCase):
             self.assertEqual(normalized, expected_str)
         return res
 
+    def prepare_multi_user_admin_env(self):
+        from gluon.fileutils import read_file
+        from gluon.restricted import compile2, restricted
+
+        env = self.env
+        request = env["request"]
+        request.folder = os.path.abspath("applications/admin")
+        env["MULTI_USER_MODE"] = True
+        env["is_manager"] = lambda: False
+        env["auth"].user = Storage(id=1, is_manager=False)
+        db = DAL(DEFAULT_URI)
+        db.define_table("app", Field("name"), Field("owner", "integer"))
+        env["db"] = db
+        db.app.insert(name="welcome", owner=1)
+        db.app.insert(name="admin", owner=2)
+        db.app.insert(name="ghost", owner=2)
+
+        def load_controller(controller):
+            filename = os.path.join(
+                request.folder, "controllers", "%s.py" % controller)
+            restricted(
+                compile2(read_file(filename), filename),
+                env,
+                layer=filename)
+            return env
+
+        return load_controller
+
     def _test_index(self):
         result = self.run_function()
         self.assertTrue("db" in result["databases"])
@@ -305,7 +333,7 @@ class TestAppAdmin(unittest.TestCase):
 
     def test_admin_file_manager_boundaries(self):
         """Test that admin file manager enforces app boundaries."""
-        from gluon.admin import join_app_path
+        from gluon.admin import apath, check_app_path, is_within_root, join_app_path
         from gluon.globals import Request
         from gluon.http import HTTP
         request = Request(env={})
@@ -321,6 +349,17 @@ class TestAppAdmin(unittest.TestCase):
         static_base = os.path.join(app_root, "static")
         static_res = join_app_path(request, "welcome", static_base, "js/app.js")
         self.assertTrue(static_res.endswith(os.path.join("welcome", "static", "js", "app.js")))
+
+        cross_app_path = apath("welcome/../admin/controllers/default.py", r=request)
+        normalized_cross_app_path = os.path.abspath(os.path.normpath(cross_app_path))
+        self.assertTrue(is_within_root(normalized_cross_app_path, web2py_apps_root))
+        self.assertRaises(
+            HTTP,
+            check_app_path,
+            request,
+            "welcome",
+            cross_app_path
+        )
 
         self.assertRaises(
             HTTP,
@@ -348,6 +387,26 @@ class TestAppAdmin(unittest.TestCase):
             os.path.join(app_root, "static"),
             "/tmp/pwn.py"
         )
+
+    def test_admin_wizard_blocks_cross_user_app_overwrite(self):
+        """Test that the wizard cannot overwrite another user's app."""
+        env = self.prepare_multi_user_admin_env()("wizard")
+        self.assertTrue(env["app_can_be_written"]("welcome"))
+        self.assertFalse(env["app_can_be_written"]("admin"))
+        self.assertFalse(env["app_can_be_written"]("ghost"))
+        self.assertTrue(env["app_can_be_written"]("brand_new"))
+
+    def test_pythonanywhere_blocks_cross_user_app_export(self):
+        """Test that PythonAnywhere deployment only sees owned apps."""
+        env = self.prepare_multi_user_admin_env()("pythonanywhere")
+        apps = env["list_authorized_apps"]()
+        self.assertIn("welcome", apps)
+        self.assertNotIn("admin", apps)
+        self.assertRaises(HTTP, env["authorized_app_path"], "admin")
+        self.assertRaises(HTTP, env["authorized_app_path"], "../admin")
+        self.assertTrue(
+            env["authorized_app_path"]("welcome").endswith(
+                os.path.join("applications", "welcome")))
 
     def test_safe_eval_expression_blocks_function_calls(self):
         """Test that safe_eval_expression blocks arbitrary function calls (RCE)"""


### PR DESCRIPTION
## Summary
- enforce authorized app-root checks before admin file read/write/delete operations
- require app ownership for plugin install/list/delete flows
- restrict PythonAnywhere deployment export to apps owned by the current admin user
- block wizard generation from overwriting another user's app
- add regression coverage for cross-app traversal and multi-user app ownership checks

## Testing
- git diff --check HEAD~1..HEAD
- python3 -m py_compile applications/admin/controllers/default.py applications/admin/controllers/pythonanywhere.py applications/admin/controllers/wizard.py gluon/tests/test_appadmin.py
- python3 -m unittest gluon.tests.test_appadmin