### PR TITLE
validate _next before redirect in openid_auth login handler

### DIFF
--- a/gluon/contrib/login_methods/openid_auth.py
+++ b/gluon/contrib/login_methods/openid_auth.py
@@ -36,6 +36,7 @@ from datetime import datetime, timedelta
 
 from gluon import *
 from gluon.storage import Messages, Storage
+from gluon.tools import prevent_open_redirect
 
 try:
     import openid.consumer.consumer
@@ -209,7 +210,10 @@ class OpenIDAuth(object):
                             del current.session.w2popenid
                         current.session.flash = self.messages.flash_openid_associated
                         if nextvar in request.vars:
-                            redirect(request.vars[nextvar])
+                            redirect(
+                                prevent_open_redirect(request.vars[nextvar])
+                                or self.auth.settings.login_next
+                            )
                         redirect(self.auth.settings.login_next)
 
                     if nextvar not in request.vars:


### PR DESCRIPTION
OpenIDAuth.get_user redirects to request.vars._next verbatim when it associates a freshly authenticated OpenID for an already logged-in user, so a crafted _next sends the visitor to any external site. Core Auth and Crud already route _next through prevent_open_redirect; do the same here and fall back to login_next when the value is rejected.