### PR TITLE
Use the timing-safe compare() helper for the CSRF formkey check

### DIFF
--- a/gluon/html.py
+++ b/gluon/html.py
@@ -2199,7 +2199,7 @@ class FORM(DIV):
             keyname = "_formkey[%s]" % formname
             formkeys = list(session.get(keyname, []))
             # check if user tampering with form and void CSRF
-            if not (formkey and formkeys and formkey in formkeys):
+            if not (formkey and formkeys and any(compare(formkey, k) for k in formkeys)):
                 status = False
             else:
                 session[keyname].remove(formkey)


### PR DESCRIPTION
## Summary

`FORM.accepts()` validates the anti-CSRF form key with a plain list-membership test:

```python
if not (formkey and formkeys and formkey in formkeys):
```

`formkey in formkeys` compares the attacker-supplied `_formkey` against each stored key using CPython's `==`, which short-circuits on the first differing character and is not constant-time.

web2py already ships a timing-safe comparison helper for exactly this, `gluon.utils.compare` (documented "Compares two strings and not vulnerable to timing attacks", backed by `hmac.compare_digest`), and already uses it for the analogous signature check in the same file:

```python
# gluon/html.py:581
return compare(original_sig, sig)
```

This applies that same helper to the formkey check, so the anti-CSRF token comparison is timing-safe and consistent with the rest of the module:

```python
if not (formkey and formkeys and any(compare(formkey, k) for k in formkeys)):
```

`compare` is already imported at the top of the file, so no new import is needed. Behavior is unchanged: a valid formkey is still accepted and an invalid one is still rejected; only the per-key comparison is now constant-time.

## Testing

`gluon/tests/test_html.py` and `gluon/tests/test_form.py` pass unchanged (86 passed). I also verified directly that a valid formkey is accepted and a wrong formkey is rejected after the change.

This is the same hardening class as #1321 ("fixed timing attack in gluon.utils.compare"), applied to the formkey comparison site.
