### PR TITLE
Enforce appadmin ownership in multi-user mode

### DIFF
--- a/gluon/fileutils.py
+++ b/gluon/fileutils.py
@@ -465,6 +465,48 @@ def set_session(request, session, other_application="admin"):
     storage.save_storage(session, session_filename)
 
 
+def _session_auth_user(session):
+    auth = session.get("auth")
+    if not auth:
+        return None
+    return auth.get("user")
+
+
+def _check_admin_app_ownership(request, session):
+    """Checks multi-user admin ownership before authorizing appadmin."""
+    if request.application == "admin":
+        return True
+
+    user = _session_auth_user(session)
+    if not user:
+        return True
+
+    user_id = user.get("id")
+    if user_id == 1 or user.get("is_manager"):
+        return True
+
+    db = None
+    try:
+        from gluon.dal import DAL
+
+        admin_db_folder = safe_path_join(up(request.folder), "admin", "databases")
+        db = DAL(
+            "sqlite://storage.sqlite",
+            folder=admin_db_folder,
+            auto_import=True,
+            migrate=False,
+        )
+        if "app" not in db.tables:
+            return False
+        query = (db.app.name == request.application) & (db.app.owner == user_id)
+        return bool(db(query).count())
+    except Exception:
+        return False
+    finally:
+        if db is not None:
+            db.close()
+
+
 def check_credentials(
     request, other_application="admin", expiration=60 * 60, gae_login=True
 ):
@@ -487,6 +529,8 @@ def check_credentials(
         dt = t0 - expiration
         s = get_session(request, other_application)
         r = s.authorized and s.last_time and s.last_time > dt
+        if r and other_application == "admin":
+            r = _check_admin_app_ownership(request, s)
         if r:
             s.last_time = t0
             set_session(request, s, other_application)

--- a/gluon/tests/test_appadmin.py
+++ b/gluon/tests/test_appadmin.py
@@ -139,6 +139,46 @@ class TestAppAdmin(unittest.TestCase):
 
         return load_controller
 
+    def make_multi_user_appadmin_request(self, application, user_id=2, is_manager=False):
+        import shutil
+        import tempfile
+        import time
+
+        from gluon.dal import DAL
+        from gluon.globals import Request
+        from gluon.storage import save_storage
+
+        root = tempfile.mkdtemp(prefix="web2py-appadmin-")
+        self.addCleanup(shutil.rmtree, root)
+        apps = os.path.join(root, "applications")
+        admin_sessions = os.path.join(apps, "admin", "sessions")
+        admin_databases = os.path.join(apps, "admin", "databases")
+        os.makedirs(admin_sessions)
+        os.makedirs(admin_databases)
+        os.makedirs(os.path.join(apps, "owned"))
+        os.makedirs(os.path.join(apps, "victim"))
+
+        db = DAL("sqlite://storage.sqlite", folder=admin_databases)
+        db.define_table("app", Field("name"), Field("owner", "integer"))
+        db.app.insert(name="owned", owner=2)
+        db.app.insert(name="victim", owner=3)
+        db.commit()
+        db.close()
+
+        session_id = "session"
+        admin_session = Storage(authorized=True, last_time=time.time())
+        if user_id is not None:
+            admin_session.auth = Storage(user=Storage(id=user_id, is_manager=is_manager))
+        save_storage(admin_session, os.path.join(admin_sessions, session_id))
+
+        request = Request(env={})
+        request.application = application
+        request.folder = os.path.join(apps, application)
+        request.cookies["session_id_admin"] = session_id
+        request.env.web2py_runtime_gae = False
+
+        return request
+
     def _test_index(self):
         result = self.run_function()
         self.assertTrue("db" in result["databases"])
@@ -387,6 +427,26 @@ class TestAppAdmin(unittest.TestCase):
             os.path.join(app_root, "static"),
             "/tmp/pwn.py"
         )
+
+    def test_appadmin_rejects_unowned_app_in_multi_user_mode(self):
+        """Test appadmin enforces app ownership for multi-user admin sessions."""
+        request = self.make_multi_user_appadmin_request("victim")
+        self.assertFalse(self.original_check_credentials(request))
+
+    def test_appadmin_allows_owned_app_in_multi_user_mode(self):
+        """Test appadmin still works for the current admin user's apps."""
+        request = self.make_multi_user_appadmin_request("owned")
+        self.assertTrue(self.original_check_credentials(request))
+
+    def test_appadmin_allows_manager_in_multi_user_mode(self):
+        """Test managers can still use appadmin across apps."""
+        request = self.make_multi_user_appadmin_request("victim", is_manager=True)
+        self.assertTrue(self.original_check_credentials(request))
+
+    def test_appadmin_allows_global_admin_session_without_multi_user_auth(self):
+        """Test global admin-password sessions still work outside multi-user auth."""
+        request = self.make_multi_user_appadmin_request("victim", user_id=None)
+        self.assertTrue(self.original_check_credentials(request))
 
     def test_admin_wizard_blocks_cross_user_app_overwrite(self):
         """Test that the wizard cannot overwrite another user's app."""


### PR DESCRIPTION
## Summary

In `MULTI_USER_MODE`, app ownership is tracked by the admin app's `db.app` table, but application `appadmin` controllers authorize through the shared admin session via `gluon.fileutils.check_credentials(request)`. A non-manager admin user with a valid admin session could therefore reach another application's `/appadmin` controller because the credential check only verified that the admin session was fresh.

This patch makes the shared credential check enforce the multi-user app boundary before authorizing appadmin access:

- global admin-password sessions without multi-user `auth.user` data keep the existing behavior
- manager users, including user id 1, keep cross-app access
- non-manager multi-user admin sessions are accepted only when `db.app` records show they own `request.application`
- missing ownership metadata fails closed for multi-user admin sessions

## Security impact

`appadmin` can read, insert, update, delete, import, export, and inspect an application's database tables. In a shared `MULTI_USER_MODE` deployment, allowing one non-manager admin user to access another user's appadmin crosses the intended app ownership boundary and can expose or modify another application's data.

## Tests

- `python3 -m unittest gluon.tests.test_appadmin`
- `python3 -m py_compile gluon/fileutils.py gluon/tests/test_appadmin.py`
- `git diff --check origin/master..HEAD`