### PR TITLE
validate service in cas logout to prevent open redirect

### DIFF
--- a/gluon/tests/test_tools.py
+++ b/gluon/tests/test_tools.py
@@ -876,6 +876,26 @@ class TestAuth(unittest.TestCase):
         self.current.request.vars._next = "next_test"
         self.assertEqual(self.auth.get_vars_next(), "next_test")
 
+    def test_cas_logout_open_redirect(self):
+        from gluon.storage import List
+
+        # the CAS provider redirects to `service` after logout; a service on a
+        # host outside the allowlist must not be usable as a redirect target
+        self.current.request.args = List(["cas", "logout"])
+        self.current.request.vars.service = "https://evil.example/"
+        self.myassertRaisesRegex(HTTP, "403*", self.auth)
+
+        # a service on an allowed host (cas_domains) still redirects there
+        self.current.session.auth = None
+        host = self.auth.settings.cas_domains[0]
+        allowed = "https://%s/a/default/user/login" % host
+        self.current.request.args = List(["cas", "logout"])
+        self.current.request.vars.service = allowed
+        with self.assertRaises(HTTP) as cm:
+            self.auth()
+        self.assertEqual(cm.exception.status, 303)
+        self.assertEqual(cm.exception.headers["Location"], allowed)
+
     # TODO: def test_navbar(self):
     # TODO: def test___get_migrate(self):
 

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -2117,7 +2117,12 @@ class Auth(AuthAPI):
             ):
                 return self.cas_validate(version=3, proxy=True)
             elif args(1) == self.settings.cas_actions["logout"]:
-                return self.logout(next=request.vars.service or DEFAULT)
+                incoming_service = request.vars.service
+                if incoming_service is not None and not self._is_allowed_cas_service(
+                    incoming_service
+                ):
+                    raise HTTP(403, "service not allowed")
+                return self.logout(next=incoming_service or DEFAULT)
         else:
             raise HTTP(404)
 


### PR DESCRIPTION
The built-in CAS provider validates the `service` request variable on login through `_is_allowed_cas_service`, but the logout branch in `Auth.__call__` passes `request.vars.service` straight to `logout(next=...)`, which skips the usual `_next` validation and reaches `redirect()`. A request to `/app/default/user/cas/logout?service=https://evil.example` therefore sends the visitor to an arbitrary external site. Apply the same allowlist check `cas_login` already uses before redirecting, returning 403 for a service that is not permitted.