### PR TITLE
avoid marshal.loads in XML_unpickle reachable via ticket allowlist

### DIFF
--- a/gluon/html.py
+++ b/gluon/html.py
@@ -15,7 +15,6 @@ import copy
 import copyreg
 import functools
 import itertools
-import marshal
 import os
 import pickle
 import re
@@ -756,11 +755,11 @@ class XML(XmlComponent):
 
 
 def XML_unpickle(data):
-    return XML(marshal.loads(data))
+    return XML(data)
 
 
 def XML_pickle(data):
-    return XML_unpickle, (marshal.dumps(str(data)),)
+    return XML_unpickle, (str(data),)
 
 
 copyreg.pickle(XML, XML_pickle, XML_unpickle)

--- a/gluon/tests/test_html.py
+++ b/gluon/tests/test_html.py
@@ -354,6 +354,17 @@ class TestBareHelpers(unittest.TestCase):
             "data to be pickle",
         )
 
+    def test_XML_pickle_stores_plain_text_not_marshal(self):
+        # XML must pickle its text directly. Marshalling it routed the pickled
+        # bytes into marshal.loads inside XML_unpickle, which
+        # gluon.restricted.TicketStorage whitelists in its SafeUnpickler
+        # allow-list, exposing crafted ticket data to an unsafe deserializer.
+        reducer, args = XML_pickle(XML("<b>hi</b>"))
+        self.assertIs(reducer, XML_unpickle)
+        self.assertIsInstance(args[0], str)
+        self.assertEqual(args, ("<b>hi</b>",))
+        self.assertEqual(str(XML_unpickle(args[0])), "<b>hi</b>")
+
     def test_DIV(self):
         # Empty DIV()
         self.assertEqual(DIV().xml(), "<div></div>")


### PR DESCRIPTION
gluon.restricted.TicketStorage loads error-ticket data through the SafeUnpickler allow-list, which whitelists gluon.html.XML_unpickle so pickled XML snapshots in a ticket survive the round trip. XML_unpickle runs marshal.loads on the pickled bytes, so a crafted ticket in an app errors/ folder or the web2py_ticket table is still handed to an unsafe deserializer (marshal.loads is documented as not secure against maliciously constructed data) when the admin ticket viewer opens it, which is exactly what the restricted unpickler was meant to prevent. XML only wraps text, so pickle the string directly and drop the marshal indirection; valid tickets round-trip unchanged.