### PR TITLE
enforce can_read on serialized wiki search results

### DIFF
--- a/gluon/tests/test_tools.py
+++ b/gluon/tests/test_tools.py
@@ -536,6 +536,57 @@ class TestWikiFirstParagraph(unittest.TestCase):
         self.assertEqual(wiki.first_paragraph(page), "teaser paragraph")
 
 
+class TestWikiSearchSerialization(unittest.TestCase):
+    # the rendered (html/load) search path withholds restricted page bodies
+    # via first_paragraph, but the serialized path (any other extension, e.g.
+    # .json) returned as_dict() for every matched page. as_dict() carries the
+    # full body, so an unauthorised searcher could read restricted pages.
+    def setUp(self):
+        self.request = Request(env={})
+        self.request.application = "a"
+        self.request.controller = "c"
+        self.request.function = "f"
+        self.request.folder = "applications/admin"
+        self.response = Response()
+        self.session = Session()
+        self.T = TranslatorFactory("", "en")
+        self.session.connect(self.request, self.response)
+        current.request = self.request
+        current.response = self.response
+        current.session = self.session
+        current.T = self.T
+        self.db = DAL(DEFAULT_URI, check_reserved=["all"])
+        self.auth = Auth(self.db)
+        self.auth.define_tables(username=True, signature=False)
+        self.wiki = Wiki(self.auth, manage_permissions=True)
+
+    def _add_page(self, slug, body, can_read):
+        pid = self.db.wiki_page.insert(
+            slug=slug,
+            title="secret topic %s" % slug,
+            body=body,
+            can_read=can_read,
+            can_edit=["admins"],
+            tags=["shared"],
+        )
+        self.db.wiki_tag.insert(name="shared", wiki_page=pid)
+        return pid
+
+    def test_restricted_body_not_leaked_on_json_path(self):
+        # anonymous searcher, manage_permissions on, restrict_search off
+        self._add_page("public", "PUBLIC BODY", ["everybody"])
+        self._add_page("restricted", "RESTRICTED SECRET BODY", ["admins"])
+        self.db.commit()
+        self.request.extension = "json"
+        result = self.wiki.search(
+            query=self.db.wiki_page.title.contains("secret topic"),
+            cloud=False,
+        )
+        bodies = [row.get("body") for row in result["content"]]
+        self.assertIn("PUBLIC BODY", bodies)
+        self.assertNotIn("RESTRICTED SECRET BODY", bodies)
+
+
 @unittest.skipIf(IS_IMAP, "TODO: Imap raises 'Connection refused'")
 # class TestAuth(unittest.TestCase):
 #

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -7558,7 +7558,11 @@ class Wiki(object):
                 content.append(DIV(_class="w2p_wiki_pages", *items))
             else:
                 cloud = False
-                content = [p.wiki_page.as_dict() for p in pages]
+                content = [
+                    p.wiki_page.as_dict()
+                    for p in pages
+                    if self.can_read(p.wiki_page)
+                ]
         elif cloud:
             content.append(self.cloud()["content"])
         if request.extension == "load":


### PR DESCRIPTION
**Restricted page bodies leaked on the serialised wiki search path**

With manage_permissions enabled the rendered search view withholds pages the searcher cannot read, but a request for any other extension (say _search.json) drops into a branch that returns as_dict() for every match, and as_dict() carries the full body, so a restricted page ends up disclosed to anyone able to search. The serialised branch now skips pages the requester cannot read, matching the check the rendered path already makes.