### PR TITLE
enforce can_read on wiki template body prefill

### DIFF
--- a/gluon/tests/test_tools.py
+++ b/gluon/tests/test_tools.py
@@ -536,6 +536,41 @@ class TestWikiFirstParagraph(unittest.TestCase):
         self.assertEqual(wiki.first_paragraph(page), "teaser paragraph")
 
 
+class TestWikiTemplateBody(unittest.TestCase):
+    # _edit is reachable as /wiki/_edit/<newslug>/<id> with a raw page id, so
+    # the template pre-fill must honour can_read; otherwise a wiki_author could
+    # read the body of any restricted page by using it as a "template".
+    def _wiki(self, groups=None, user=None, pages=None):
+        wiki = Wiki.__new__(Wiki)
+        wiki.settings = Storage(manage_permissions=True, groups=groups or [])
+        pages = pages or {}
+        db = Storage(wiki_page=lambda id: pages.get(id))
+        wiki.auth = Storage(user=user, db=db)
+        return wiki
+
+    def _page(self, can_read):
+        return Storage(body="secret body", can_read=can_read, can_edit=[], created_by=0)
+
+    def test_unreadable_template_body_not_leaked(self):
+        page = self._page(can_read=["admins"])
+        wiki = self._wiki(pages={7: page})
+        self.assertFalse(wiki.can_read(page))
+        self.assertEqual(wiki._template_body(7, "Slug"), "## Slug\n\npage content")
+
+    def test_readable_template_body_is_used(self):
+        page = self._page(can_read=["everybody"])
+        wiki = self._wiki(pages={7: page})
+        self.assertEqual(wiki._template_body(7, "Slug"), "secret body")
+
+    def test_no_template_returns_default(self):
+        wiki = self._wiki()
+        self.assertEqual(wiki._template_body(0, "Slug"), "## Slug\n\npage content")
+
+    def test_missing_template_returns_default(self):
+        wiki = self._wiki(pages={})
+        self.assertEqual(wiki._template_body(99, "Slug"), "## Slug\n\npage content")
+
+
 class TestWikiSearchSerialization(unittest.TestCase):
     # the rendered (html/load) search path withholds restricted page bodies
     # via first_paragraph, but the serialized path (any other extension, e.g.

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -7095,6 +7095,24 @@ class Wiki(object):
     def fix_hostname(self, body):
         return (body or "").replace("://HOSTNAME", "://%s" % self.host)
 
+    def _template_body(self, from_template, title_guess):
+        # Body used to pre-fill the editor when creating a new page. A template
+        # id is only honoured when the requester is allowed to read that page,
+        # otherwise the edit form would hand back the body of an arbitrary
+        # (possibly access-restricted) page. create() constrains from_template
+        # to settings.templates, but _edit is reachable with a raw id in args.
+        default = "## %s\n\npage content" % title_guess
+        try:
+            template_id = int(from_template)
+        except (TypeError, ValueError):
+            return default
+        if template_id <= 0:
+            return default
+        template_page = self.auth.db.wiki_page(id=template_id)
+        if template_page and self.can_read(template_page):
+            return template_page.body
+        return default
+
     def read(self, slug, force_render=False):
         if slug in "_cloud":
             return self.cloud()
@@ -7159,12 +7177,8 @@ class Wiki(object):
                     "- Menu Item > @////index\n- - Submenu > http://web2py.com"
                 )
             else:
-                db.wiki_page.body.default = (
-                    db(db.wiki_page.id == from_template)
-                    .select(db.wiki_page.body)[0]
-                    .body
-                    if int(from_template) > 0
-                    else "## %s\n\npage content" % title_guess
+                db.wiki_page.body.default = self._template_body(
+                    from_template, title_guess
                 )
         vars = current.request.post_vars
         if vars.body:


### PR DESCRIPTION
Wiki.edit prefills a new page's body from the from_template id taken straight out of request.args (/wiki/_edit/<slug>/<id>), selecting that page's body with no can_read check. create() constrains from_template to settings.templates via IS_IN_DB, but _edit is reachable directly with a raw id, so a wiki_author can read the body of any access-restricted page by requesting it as a template. Route the prefill through a helper that only returns the page body when the requester can_read it, which also drops the latent IndexError/ValueError on a missing or non-numeric id.