### PR TITLE
restrict hypermedia query and orderby to policy fields

### DIFF
--- a/gluon/contrib/hypermedia.py
+++ b/gluon/contrib/hypermedia.py
@@ -162,10 +162,15 @@ class Collection(object):
         if len(self.request.args) > 1:
             vars.id = self.request.args[1]
 
-        fieldnames = table.fields
+        # only fields the policy exposes may be filtered/ordered on. These are
+        # the same fields table2queries() advertises as searchable; the request
+        # must not reach beyond them to non-exposed columns (e.g. password),
+        # otherwise the items_found count and _orderby leak those values.
+        fieldnames = self.table_policy.get("fields", table.fields)
         queries = [table]
         limitby = [0, self.MAXITEMS + 1]
         orderby = "id"
+        orderby_from_vars = False
         for key, value in vars.items():
             if key == "_offset":
                 limitby[0] = int(value)  # MAY FAIL
@@ -173,6 +178,7 @@ class Collection(object):
                 limitby[1] = int(value) + 1  # MAY FAIL
             elif key == "_orderby":
                 orderby = value
+                orderby_from_vars = True
             elif key in fieldnames:
                 queries.append(table[key] == value)
             elif (
@@ -201,8 +207,13 @@ class Collection(object):
         query = (
             reduce(lambda a, b: a & b, queries[1:]) if len(queries) > 1 else queries[0]
         )
+        orderby_names = orderby.split(",")
+        if orderby_from_vars:
+            for f in orderby_names:
+                if (f[1:] if f[:1] == "~" else f) not in fieldnames:
+                    raise ValueError("Invalid Query")
         orderby = [
-            table[f] if f[0] != "~" else ~table[f[1:]] for f in orderby.split(",")
+            table[f] if f[0] != "~" else ~table[f[1:]] for f in orderby_names
         ]
         return (query, limitby, orderby)
 

--- a/gluon/tests/test_contribs.py
+++ b/gluon/tests/test_contribs.py
@@ -114,3 +114,45 @@ class TestContribs(unittest.TestCase):
             'href="http://good.com/page"',
             autolinks.expand_one("http://good.com/page", {"http://good.com/page": {}}),
         )
+
+    def test_hypermedia_query_respects_policy_fields(self):
+        from gluon.dal import DAL, Field
+        from gluon.contrib.hypermedia import Collection
+
+        class Args(list):
+            def __call__(self, i, default=None):
+                try:
+                    return self[i]
+                except IndexError:
+                    return default
+
+        db = DAL("sqlite:memory")
+        try:
+            db.define_table("thing", Field("name"), Field("secret"))
+            db.thing.insert(name="alice", secret="TOPSECRET")
+            db.commit()
+
+            col = Collection(db)
+            col.request = Storage(args=Args(["thing"]))
+            # policy exposes id and name only; secret must stay hidden
+            col.table_policy = {"query": None, "fields": ["id", "name"]}
+
+            # a filter on the non-exposed column leaks it through items_found
+            for op in ("secret", "secret.startswith", "secret.contains"):
+                with self.assertRaises(ValueError):
+                    col.request2query(db.thing, Storage({op: "TOP"}))
+            # ordering by a non-exposed column is also refused
+            with self.assertRaises(ValueError):
+                col.request2query(db.thing, Storage({"_orderby": "secret"}))
+
+            # exposed fields keep working
+            query, _, _ = col.request2query(db.thing, Storage({"name": "alice"}))
+            self.assertEqual(db(query).count(), 1)
+            col.request2query(db.thing, Storage({"_orderby": "name"}))
+
+            # a policy that declares no field list is unchanged (all columns)
+            col.table_policy = {"query": None}
+            query, _, _ = col.request2query(db.thing, Storage({"secret": "TOPSECRET"}))
+            self.assertEqual(db(query).count(), 1)
+        finally:
+            db.close()


### PR DESCRIPTION
1. request2query builds its filters and _orderby from table.fields rather than the per-table policy's exposed field list, so a query on a column the policy does not expose (e.g. `?password.startswith=x`) still runs and leaks that column through the items_found count, one character at a time.
2. table2queries already advertises only the policy fields as searchable, so accepting queries beyond them was a gap between what is offered and what is honored.

Restricted the queryable set to `self.table_policy.get('fields', table.fields)` (so a policy that declares no field list keeps all columns, e.g. DELETE) and validate a caller-supplied _orderby against that same set, returning 400 otherwise. Regression test added in gluon/tests/test_contribs.py.