### PR TITLE
reject two factor code when no code was issued

### DIFF
--- a/gluon/tests/test_tools.py
+++ b/gluon/tests/test_tools.py
@@ -1748,6 +1748,121 @@ class TestAuthHostHeaderPoisoning(unittest.TestCase):
         self.assertNotIn("attacker.example", str(link))
 
 
+class TestAuthTwoFactor(unittest.TestCase):
+    """
+    Regression tests for the second challenge in Auth.login().
+
+    A two_factor_methods / two_factor_onvalidation callback that returns
+    None leaves session.auth_two_factor unset, and the code check used to
+    compare the submitted value against str(None). Submitting the literal
+    string "None" then passed the second factor (CWE-287).
+    """
+
+    def _set_post(self, request, **kw):
+        request._get_vars = Storage()
+        request._post_vars = Storage(kw)
+        request._vars = Storage(kw)
+
+    def _make_auth(self):
+        request = Request(env={})
+        request.application = "a"
+        request.controller = "c"
+        request.function = "f"
+        request.folder = "applications/admin"
+        request.env.request_method = "POST"
+        response = Response()
+        session = Session()
+        session.connect(request, response)
+        current.request = request
+        current.response = response
+        current.session = session
+        current.T = TranslatorFactory("", "en")
+        db = DAL(DEFAULT_URI, check_reserved=["all"])
+        auth = Auth(db)
+        auth.define_tables(username=True, signature=False)
+        auth.settings.registration_requires_verification = False
+        auth.settings.registration_requires_approval = False
+        auth.register_bare(
+            first_name="Bart",
+            last_name="Simpson",
+            username="bart",
+            email="bart@simpson.com",
+            password="bart_password",
+        )
+        auth.csrf_prevention = False
+        auth.settings.auth_two_factor_enabled = True
+        self._db = db
+        return auth, request, session
+
+    def _first_factor(self, auth, request):
+        self._set_post(
+            request,
+            username="bart",
+            password="bart_password",
+            _formname="login",
+        )
+        auth.login(next="/")
+
+    def _second_factor(self, auth, request, code):
+        self._set_post(request, authentication_code=code, _formname="login")
+        try:
+            auth.login(next="/")
+        except HTTP:
+            pass  # redirect to next on success
+        return auth.is_logged_in()
+
+    def tearDown(self):
+        try:
+            db = getattr(self, "_db", None)
+            if db is not None:
+                for t in (
+                    "auth_cas",
+                    "auth_event",
+                    "auth_membership",
+                    "auth_permission",
+                    "auth_group",
+                    "auth_user",
+                ):
+                    if t in db:
+                        db[t].drop()
+        except Exception:
+            pass
+
+    def test_two_factor_method_returning_none_rejects_none_literal(self):
+        # An external OTP client owns the code, so two_factor_methods
+        # returns None -- no code is issued for this session.
+        auth, request, session = self._make_auth()
+        auth.settings.two_factor_methods = [lambda user, code: None]
+        self._first_factor(auth, request)
+        self.assertIsNotNone(session.auth_two_factor_user)
+        self.assertIsNone(session.auth_two_factor)
+        self.assertFalse(self._second_factor(auth, request, "None"))
+
+    def test_onvalidation_returning_none_rejects_none_literal(self):
+        # The framework issued a real code, but the onvalidation callback
+        # overwrites it with its None return value on a failed check.
+        auth, request, session = self._make_auth()
+        auth.settings.mailer = Storage(send=lambda **kw: True)
+        auth.settings.two_factor_onvalidation = [lambda user, otp: None]
+        self._first_factor(auth, request)
+        self.assertIsNotNone(session.auth_two_factor_user)
+        self.assertFalse(self._second_factor(auth, request, "None"))
+
+    def test_valid_code_still_accepted(self):
+        auth, request, session = self._make_auth()
+        auth.settings.two_factor_methods = [lambda user, code: "123456"]
+        self._first_factor(auth, request)
+        self.assertEqual(session.auth_two_factor, "123456")
+        self.assertTrue(self._second_factor(auth, request, "123456"))
+        self.assertEqual(auth.user.username, "bart")
+
+    def test_wrong_code_still_rejected(self):
+        auth, request, session = self._make_auth()
+        auth.settings.two_factor_methods = [lambda user, code: "123456"]
+        self._first_factor(auth, request)
+        self.assertFalse(self._second_factor(auth, request, "654321"))
+
+
 # TODO: class TestCrud(unittest.TestCase):
 # It deprecated so far from a priority
 

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -3343,7 +3343,15 @@ class Auth(AuthAPI):
                         else:
                             break
 
-                if form.vars["authentication_code"] == str(session.auth_two_factor):
+                # A None expected code means no code was ever issued for this
+                # session, or a two_factor_methods/two_factor_onvalidation
+                # callback signalled failure by returning None. str(None) is
+                # the guessable literal "None", so never accept a submitted
+                # code against it.
+                expected_code = session.auth_two_factor
+                if expected_code is not None and form.vars[
+                    "authentication_code"
+                ] == str(expected_code):
                     # Handle the case when the two-factor form has been successfully validated
                     # and the user was previously stored (the current user should be None because
                     # in this case, the previous username/password login form should not be displayed.


### PR DESCRIPTION
The second challenge in Auth.login compares the submitted code against str(session.auth_two_factor), but that session value is whatever the configured two_factor_methods / two_factor_onvalidation callback returned, and the recipe documented in login's own docstring returns None (two_factor_methods returns None when an external OTP client owns the code, and the verify_otp onvalidation example falls through to None on a failed check). str(None) is the literal "None", so anyone holding the victim's password submits authentication_code=None and clears the second factor. It applies even when a real random code was generated and emailed, since the onvalidation return value overwrites it before the comparison. Binding the expected code to a local and refusing the comparison when it is None keeps a session with no issued code from ever satisfying the challenge; valid and wrong codes are unaffected.