### PR TITLE
verify tls certificates in pysimplesoap transports

### DIFF
--- a/gluon/contrib/pysimplesoap/transport.py
+++ b/gluon/contrib/pysimplesoap/transport.py
@@ -125,7 +125,10 @@ else:
             if httplib2.__version__ >= "0.3.0":
                 kwargs["timeout"] = timeout
             if httplib2.__version__ >= "0.7.0":
-                kwargs["disable_ssl_certificate_validation"] = cacert is None
+                # cacert selects an additional CA bundle; when it is not given
+                # httplib2 falls back to its own trust store, so verification
+                # stays on either way.
+                kwargs["disable_ssl_certificate_validation"] = False
                 kwargs["ca_certs"] = cacert
             httplib2.Http.__init__(self, **kwargs)
 
@@ -151,17 +154,16 @@ class urllib2Transport(TransportBase):
             raise RuntimeError("timeout is not supported with urllib2 transport")
         if proxy:
             raise RuntimeError("proxy is not supported with urllib2 transport")
-        if cacert:
-            raise RuntimeError("cacert is not support with urllib2 transport")
 
         handlers = []
 
         if (sys.version_info[0] == 2 and sys.version_info >= (2, 7, 9)) or (
             sys.version_info[0] == 3 and sys.version_info >= (3, 2, 0)
         ):
-            context = ssl.create_default_context()
-            context.check_hostname = False
-            context.verify_mode = ssl.CERT_NONE
+            # cacert, when given, is an extra CA bundle to trust; the default
+            # context already verifies the chain and the hostname against the
+            # system trust store.
+            context = ssl.create_default_context(cafile=cacert)
             handlers.append(urllib2.HTTPSHandler(context=context))
 
         if sessions:
@@ -184,6 +186,7 @@ class urllib2Transport(TransportBase):
 
 _http_connectors["urllib2"] = urllib2Transport
 _http_facilities.setdefault("sessions", []).append("urllib2")
+_http_facilities.setdefault("cacert", []).append("urllib2")
 
 if sys.version_info >= (2, 6):
     _http_facilities.setdefault("timeout", []).append("urllib2")
@@ -226,8 +229,8 @@ else:
             # c.setopt(pycurl.HEADERFUNCTION, self.header)
             if self.cacert:
                 c.setopt(c.CAINFO, self.cacert)
-            c.setopt(pycurl.SSL_VERIFYPEER, self.cacert and 1 or 0)
-            c.setopt(pycurl.SSL_VERIFYHOST, self.cacert and 2 or 0)
+            c.setopt(pycurl.SSL_VERIFYPEER, 1)
+            c.setopt(pycurl.SSL_VERIFYHOST, 2)
             c.setopt(pycurl.CONNECTTIMEOUT, self.timeout)
             c.setopt(pycurl.TIMEOUT, self.timeout)
             if method == "POST":

--- a/gluon/tests/test_contribs.py
+++ b/gluon/tests/test_contribs.py
@@ -4,6 +4,7 @@
 """ Unit tests for contribs """
 
 import os
+import shutil
 import unittest
 
 from gluon import HTTP
@@ -156,3 +157,84 @@ class TestContribs(unittest.TestCase):
             self.assertEqual(db(query).count(), 1)
         finally:
             db.close()
+
+
+class TestPySimpleSoapTransport(unittest.TestCase):
+    """Tests the TLS handling of the pysimplesoap transports"""
+
+    def _serve_https(self, common_name):
+        """Serve one HTTPS request with a throwaway self-signed certificate."""
+        import http.server
+        import ssl
+        import subprocess
+        import tempfile
+        import threading
+
+        tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmpdir, True)
+        cert = os.path.join(tmpdir, "cert.pem")
+        key = os.path.join(tmpdir, "key.pem")
+        try:
+            subprocess.check_call(
+                [
+                    "openssl",
+                    "req",
+                    "-x509",
+                    "-newkey",
+                    "rsa:2048",
+                    "-keyout",
+                    key,
+                    "-out",
+                    cert,
+                    "-days",
+                    "1",
+                    "-nodes",
+                    "-subj",
+                    "/CN=%s" % common_name,
+                    "-addext",
+                    "subjectAltName=DNS:%s,IP:127.0.0.1" % common_name,
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except (OSError, subprocess.CalledProcessError):
+            self.skipTest("openssl is not available")
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(200)
+                self.send_header("Content-Length", "2")
+                self.end_headers()
+                self.wfile.write(b"ok")
+
+            def log_message(self, *args):
+                pass
+
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(cert, key)
+        server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+        server.socket = context.wrap_socket(server.socket, server_side=True)
+        self.addCleanup(server.server_close)
+        self.addCleanup(server.shutdown)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        return cert, server.server_address[1]
+
+    def test_untrusted_certificate_is_refused(self):
+        """An unknown self-signed certificate must not be accepted"""
+        from gluon.contrib.pysimplesoap.transport import get_Http
+
+        _, port = self._serve_https("localhost")
+        http_transport = get_Http()(timeout=5)
+        with self.assertRaises(Exception):
+            http_transport.request("https://localhost:%d/" % port, "GET", None, {})
+
+    def test_certificate_trusted_through_cacert_is_accepted(self):
+        """A certificate signed by the supplied cacert bundle still works"""
+        from gluon.contrib.pysimplesoap.transport import get_Http
+
+        cert, port = self._serve_https("localhost")
+        http_transport = get_Http()(timeout=5, cacert=cert)
+        _, content = http_transport.request(
+            "https://localhost:%d/" % port, "GET", None, {}
+        )
+        self.assertEqual(content, b"ok")


### PR DESCRIPTION
**TLS certificate verification is off by default in the SOAP transports**

All three transports in `gluon/contrib/pysimplesoap/transport.py` treat a caller-supplied `cacert` as the switch that turns verification on, so without one the chain and the hostname are both ignored and any https SOAP call is open to an active man-in-the-middle. The urllib2 transport is the worst of the three: it sets `CERT_NONE` unconditionally and raises on `cacert`, so there was no way to get a verified connection at all, and it is the transport selected on a stock install where neither httplib2 nor pycurl is present. My reading is that `cacert` was only ever meant to add a private CA rather than to enable verification, so I have made it behave that way and left the system trust store as the default.

I checked this against a local server presenting a self-signed certificate with a mismatched name: `urllib.request.urlopen` refuses it while the transport returned the body happily. The two tests in `test_contribs.py` cover both directions, since the second one would catch it if this turned out to be too strict for a private CA setup.