### PR TITLE
enforce hmac check before broadcasting in websocket_messaging

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
           cache: pip
 
       - name: Install dependencies
-        run: pip install coverage codecov redis
+        run: pip install coverage codecov redis tornado
 
       - name: Create MySQL database
         run: mysql -h 127.0.0.1 -u root -e 'CREATE DATABASE pydal;'

--- a/gluon/contrib/websocket_messaging.py
+++ b/gluon/contrib/websocket_messaging.py
@@ -123,7 +123,7 @@ class PostHandler(tornado.web.RequestHandler):
 
     def post(self):
         if hmac_key and not "signature" in self.request.arguments:
-            self.send_error(401)
+            return self.send_error(401)
         if "message" in self.request.arguments:
             message = self.request.arguments["message"][0].decode(encoding="UTF-8")
             group = self.request.arguments.get("group", ["default"])[0].decode(
@@ -131,12 +131,14 @@ class PostHandler(tornado.web.RequestHandler):
             )
             print("%s:MESSAGE to %s:%s" % (time.time(), group, message))
             if hmac_key:
-                signature = self.request.arguments["signature"][0]
+                signature = self.request.arguments["signature"][0].decode(
+                    encoding="UTF-8"
+                )
                 actual_signature = hmac.new(
                     hmac_key.encode(), message.encode(), hashlib.md5
                 ).hexdigest()
                 if not gluon.utils.compare(signature, actual_signature):
-                    self.send_error(401)
+                    return self.send_error(401)
             for client in listeners.get(group, []):
                 client.write_message(message)
 
@@ -149,17 +151,19 @@ class TokenHandler(tornado.web.RequestHandler):
     """
 
     def post(self):
-        if hmac_key and not "message" in self.request.arguments:
-            self.send_error(401)
+        if hmac_key and not "signature" in self.request.arguments:
+            return self.send_error(401)
         if "message" in self.request.arguments:
-            message = self.request.arguments["message"][0]
+            message = self.request.arguments["message"][0].decode(encoding="UTF-8")
             if hmac_key:
-                signature = self.request.arguments["signature"][0]
+                signature = self.request.arguments["signature"][0].decode(
+                    encoding="UTF-8"
+                )
                 actual_signature = hmac.new(
                     hmac_key.encode(), message.encode(), hashlib.md5
                 ).hexdigest()
                 if not gluon.utils.compare(signature, actual_signature):
-                    self.send_error(401)
+                    return self.send_error(401)
             tokens[message] = None
 
 
@@ -174,8 +178,9 @@ class DistributeHandler(tornado.websocket.WebSocketHandler):
         self.name = name or "anonymous"
         # only authorized parties can join
         if DistributeHandler.tokens:
-            if not self.token in tokens or not token[self.token] is None:
+            if not self.token in tokens or not tokens[self.token] is None:
                 self.close()
+                return
             else:
                 tokens[self.token] = self
         if not self.group in listeners:

--- a/gluon/tests/test_contribs.py
+++ b/gluon/tests/test_contribs.py
@@ -3,8 +3,11 @@
 
 """ Unit tests for contribs """
 
+import hashlib
+import hmac
 import os
 import unittest
+from urllib.parse import urlencode
 
 from gluon import HTTP
 from gluon.contrib.generics import _resolve_pdf_image_path
@@ -12,6 +15,20 @@ from gluon.contrib import fpdf as fpdf
 from gluon.contrib import pyfpdf as pyfpdf
 from gluon.contrib.appconfig import AppConfig
 from gluon.storage import Storage
+
+try:
+    import tornado.testing
+    import tornado.web
+
+    from gluon.contrib import websocket_messaging
+
+    HAVE_TORNADO = True
+    _AsyncHTTPTestCase = tornado.testing.AsyncHTTPTestCase
+except ImportError:
+    # websocket_messaging needs tornado; skip its tests instead of
+    # breaking the suite when the optional dependency is missing.
+    HAVE_TORNADO = False
+    _AsyncHTTPTestCase = unittest.TestCase
 
 
 def setUpModule():
@@ -156,3 +173,60 @@ class TestContribs(unittest.TestCase):
             self.assertEqual(db(query).count(), 1)
         finally:
             db.close()
+
+
+@unittest.skipUnless(HAVE_TORNADO, "tornado is not installed")
+class TestWebsocketMessaging(_AsyncHTTPTestCase):
+    """Tests the hmac gate of the websocket_messaging broadcast server"""
+
+    hmac_key = "topsecret"
+
+    def get_app(self):
+        self.received = []
+        websocket_messaging.hmac_key = self.hmac_key
+        websocket_messaging.listeners.clear()
+        websocket_messaging.tokens.clear()
+        # stand in for a subscribed websocket client
+        websocket_messaging.listeners["default"] = [self]
+        return tornado.web.Application(
+            [
+                (r"/", websocket_messaging.PostHandler),
+                (r"/token", websocket_messaging.TokenHandler),
+            ]
+        )
+
+    def write_message(self, message):
+        self.received.append(message)
+
+    def post(self, path, **kwargs):
+        kwargs.setdefault("group", "default")
+        return self.fetch(path, method="POST", body=urlencode(kwargs)).code
+
+    def sign(self, message):
+        return hmac.new(
+            self.hmac_key.encode(), message.encode(), hashlib.md5
+        ).hexdigest()
+
+    def test_post_rejects_wrong_signature(self):
+        self.assertEqual(self.post("/", message="spoofed", signature="wrong"), 401)
+        self.assertEqual(self.received, [])
+
+    def test_post_rejects_missing_signature(self):
+        self.assertEqual(self.post("/", message="spoofed"), 401)
+        self.assertEqual(self.received, [])
+
+    def test_post_accepts_valid_signature(self):
+        self.assertEqual(
+            self.post("/", message="hello", signature=self.sign("hello")), 200
+        )
+        self.assertEqual(self.received, ["hello"])
+
+    def test_token_rejects_wrong_signature(self):
+        self.assertEqual(self.post("/token", message="mine", signature="wrong"), 401)
+        self.assertEqual(dict(websocket_messaging.tokens), {})
+
+    def test_token_accepts_valid_signature(self):
+        self.assertEqual(
+            self.post("/token", message="mine", signature=self.sign("mine")), 200
+        )
+        self.assertEqual(dict(websocket_messaging.tokens), {"mine": None})


### PR DESCRIPTION
PostHandler.post and TokenHandler.post call self.send_error(401) when the signature is missing or does not verify, but tornado's send_error() only writes the response and calls finish() — it does not raise or return. Execution falls straight through, so a POST carrying any bogus signature is still handed to client.write_message() for every subscriber, and still records tokens[message] = None. Running with -k, an attacker who does not know the key gets their message broadcast to the whole group while the server answers 401. DistributeHandler.open has the same shape: self.close() is not followed by a return, so an unauthorized connection is still appended to listeners[group] and keeps receiving traffic.

Returning on those three decisions is the fix. Two things had to come with it or the gate stays inert: signature arrives from request.arguments as bytes while actual_signature is a str, so gluon.utils.compare() was returning False for legitimate senders too (they were only "working" because of the fall-through), and the token branch read token[self.token] — the local string — instead of tokens[self.token], so the reuse check never ran. Tests are in test_contribs.py behind a tornado import guard, matching how test_redis.py handles its optional dependency; four of the five fail on master. Adding tornado to the CI install step so they actually execute there.