### PR TITLE
reject dangerous url schemes in autolinks expand_one

### DIFF
--- a/gluon/contrib/autolinks.py
+++ b/gluon/contrib/autolinks.py
@@ -50,6 +50,8 @@ import uuid
 from json import loads
 from urllib.parse import quote as urllib_quote
 
+from gluon.contrib.markmin.markmin2html import is_unsafe
+
 try:
     from BeautifulSoup import BeautifulSoup, Comment
 
@@ -178,6 +180,12 @@ def extension(url):
 
 
 def expand_one(url, cdict):
+    # markmin's regex_auto matches any "scheme://..." token, so javascript:,
+    # vbscript: and data: urls reach here when Wiki installs this as the
+    # autolinks callback. Refuse them the way autolinks_simple does, before
+    # any branch below drops the url into an href or src.
+    if is_unsafe(url):
+        return '<span class="markmin_unsafe">%s</span>' % html.escape(url, quote=True)
     # try ombed but first check in cache
     if "@" in url and not "://" in url:
         esc = html.escape(url, quote=True)

--- a/gluon/tests/test_contribs.py
+++ b/gluon/tests/test_contribs.py
@@ -115,6 +115,30 @@ class TestContribs(unittest.TestCase):
             autolinks.expand_one("http://good.com/page", {"http://good.com/page": {}}),
         )
 
+    def test_autolinks_rejects_unsafe_url_schemes(self):
+        from gluon.contrib import autolinks
+        from gluon.contrib.markmin.markmin2html import render
+
+        # markmin's regex_auto matches any "scheme://..." token, so a wiki page
+        # body can reach expand_one with a script-bearing scheme
+        payload = "javascript://x%0alocation=name"
+        self.assertIn("markmin_unsafe", autolinks.expand_one(payload, {}))
+        self.assertNotIn("href=", autolinks.expand_one(payload, {}))
+        self.assertIn("markmin_unsafe", autolinks.expand_one("vbscript://x", {}))
+
+        # same result whether markmin autolinks itself or Wiki delegates to
+        # expand_one
+        rendered = render(
+            payload, autolinks=lambda link: autolinks.expand_one(link, {})
+        )
+        self.assertNotIn("href=", rendered)
+
+        # http(s) urls still get linked
+        self.assertIn(
+            'href="http://good.com/page"',
+            autolinks.expand_one("http://good.com/page", {"http://good.com/page": {}}),
+        )
+
     def test_hypermedia_query_respects_policy_fields(self):
         from gluon.dal import DAL, Field
         from gluon.contrib.hypermedia import Collection


### PR DESCRIPTION
1. markmin blocks script-bearing schemes in its own autolinkers: `autolinks_simple`, `protolinks_simple` and the link-target branch of `render()` all call `is_unsafe()` and emit a `markmin_unsafe` span for `javascript:` / `vbscript:` / `data:`. `expand_one` has no scheme check, and `Wiki.markmin_base` / `Wiki.html_render` install it as the autolinks callback, so the wiki loses that protection.
2. `regex_auto` matches any `\w+://` token, so a page body containing `javascript://x%0alocation=name` renders as `<a href="javascript://x%0alocation=name">` for every reader; a wiki author can script anyone who opens the page.

Put the check at the top of `expand_one` so the anchor, image/audio/video, googledoc and component branches are all covered at one point, and reused markmin's `is_unsafe` rather than a second scheme list. http(s) urls render as before.

Repro against the unpatched tree:

    from gluon.contrib.autolinks import expand_one
    from gluon.contrib.markmin.markmin2html import render
    render("javascript://x%0alocation=name", autolinks=lambda l: expand_one(l, {}))
    # <p><a href="javascript://x%0alocation=name">...</a></p>
    render("javascript://x%0alocation=name")
    # <p><span class="markmin_unsafe">...</span></p>   <- markmin default, already safe

Regression test in `gluon/tests/test_contribs.py`; it fails before the change. Full `--run_system_tests` run is unchanged apart from the new test.