### PR TITLE
reject login when the account has no stored password

### DIFF
--- a/gluon/authapi.py
+++ b/gluon/authapi.py
@@ -1042,9 +1042,23 @@ class AuthAPI(object):
 
         # Finally verify the password
         passfield = settings.password_field
+        stored_password = user[passfield]
+        # Accounts created without a local password (register_bare with no
+        # password, or a user provisioned by an alternate login method, which
+        # stores None in this field) have nothing to compare against. The
+        # validator below returns its input unchanged when it errors, so an
+        # empty or null candidate would come back as None/'' and compare equal
+        # to the stored value. Auth.login_bare refuses such accounts for the
+        # same reason.
+        if not stored_password:
+            return {
+                "errors": {passfield: self.messages.invalid_password},
+                "message": self.messages.invalid_login,
+                "user": None,
+            }
         password = table_user[passfield].validate(kwargs.get(passfield, ""), None)[0]
 
-        if password == user[passfield]:
+        if password == stored_password:
             self.login_user(user)
             session.auth.expiration = (
                 kwargs.get("remember_me", False)

--- a/gluon/tests/test_authapi.py
+++ b/gluon/tests/test_authapi.py
@@ -57,6 +57,29 @@ class TestAuthAPI(unittest.TestCase):
         result = self.auth.login(**{"username": "BarT", "password": "bart_password"})
         self.assertTrue(self.auth.is_logged_in())
 
+    def test_login_without_stored_password(self):
+        # users provisioned by an alternate login method (or by register_bare
+        # with no password) have no local password and must not be reachable
+        for stored in (None, ""):
+            uid = self.auth.table_user().insert(
+                first_name="Maggie",
+                last_name="Simpson",
+                username="maggie%s" % (stored is None),
+                email="maggie%s@simpson.com" % (stored is None),
+                password=stored,
+                registration_key="",
+            )
+            self.db.commit()
+            for candidate in (None, ""):
+                result = self.auth.login(
+                    **{
+                        "username": self.auth.table_user()[uid].username,
+                        "password": candidate,
+                    }
+                )
+                self.assertTrue(result["errors"] is not None)
+                self.assertFalse(self.auth.is_logged_in())
+
     def test_logout(self):
         self.auth.login(**{"username": "bart", "password": "bart_password"})
         self.assertTrue(self.auth.is_logged_in())


### PR DESCRIPTION
AuthAPI.login keeps only element [0] of table_user[passfield].validate(...), so when CRYPT rejects the candidate it silently returns the input unchanged: None stays None, "" stays "". Accounts provisioned without a local password store None in that column (register_bare with no password, and the alternate-login-method branch of Auth.login which sets form.vars[passfield] = None before get_or_create_user), so posting {"username": "victim", "password": null} to an AuthAPI-backed endpoint reaches None == None and logs the caller in with no credential. Auth.login_bare already refuses those accounts via user.get(settings.passfield, False); this adds the same guard before the comparison in AuthAPI.login, plus a regression test that fails without it.