### PR TITLE
enforce session unique_key check in redis MockQuery.select

### DIFF
--- a/gluon/contrib/redis_session.py
+++ b/gluon/contrib/redis_session.py
@@ -15,6 +15,7 @@ from gluon import current
 from gluon.contrib.redis_utils import (acquire_lock, register_release_lock,
                                        release_lock)
 from gluon.storage import Storage
+from gluon.utils import compare
 
 logger = logging.getLogger("web2py.session.redis")
 
@@ -233,9 +234,10 @@ class MockQuery(object):
                 acquire_lock(self.db.r_server, key + ":lock", self.value, 2)
             rtn = {k.decode(): v for k, v in self.db.r_server.hgetall(key).items()}
             if rtn:
-                if self.unique_key:
+                if self.unique_key is not None:
                     # make sure the id and unique_key are correct
-                    if rtn["unique_key"].decode() == self.unique_key:
+                    stored_key = rtn.get("unique_key", b"").decode()
+                    if compare(stored_key, self.unique_key):
                         rtn["update_record"] = self.update  # update record support
                     else:
                         rtn = None

--- a/gluon/tests/test_redis.py
+++ b/gluon/tests/test_redis.py
@@ -89,6 +89,33 @@ class TestRedis(unittest.TestCase):
         data_from_db = db(table.id == record_id).select()[0]
         self.assertDictEqual(Storage(dd), data_from_db, "get the updated value")
 
+    def test_0_redis_session_unique_key(self):
+        """A session is only returned when the unique_key matches"""
+        db = self.db
+        Field = db.Field
+        db.define_table(
+            self.tname,
+            Field("locked", "boolean", default=False),
+            Field("client_ip", length=64),
+            Field("created_datetime", "datetime", default=datetime.now().isoformat()),
+            Field("modified_datetime", "datetime"),
+            Field("unique_key", length=64),
+            Field("session_data", "blob"),
+        )
+        table = db[self.tname]
+        unique_key = web2py_uuid()
+        record_id = table.insert(
+            locked=0,
+            client_ip="127.0.0.1",
+            modified_datetime=datetime.now().isoformat(),
+            unique_key=unique_key,
+            session_data=pickle.dumps({"secret": 1}, pickle.HIGHEST_PROTOCOL),
+        )
+        self.assertTrue(table(record_id, unique_key=unique_key))
+        self.assertFalse(table(record_id, unique_key=web2py_uuid()))
+        # a cookie of the form "<record_id>:" carries an empty unique_key
+        self.assertFalse(table(record_id, unique_key=""))
+
     def test_1_redis_delete(self):
         """Redis session get and delete sessions"""
         db = self.db


### PR DESCRIPTION
Session.connect splits the session cookie into a record id and a unique_key and calls table(record_id, unique_key=unique_key), but the redis backend only validated the key under `if self.unique_key:`, so a cookie of the form `session_id_<app>=7:` carries an empty (falsy) key and the check is skipped, returning the stored session hash for that id. Record ids come from a redis INCR counter, so anyone can walk small integers and have another user's session_data unpickled into their own session, auth included, without ever knowing the unique_key; check_client is off by default and the SQL backend is not affected because pydal turns the empty key into a real comparison that fails. The check now runs whenever a key was supplied and uses gluon.utils.compare, with the lookup left untouched for the Session.renew call that passes no key and does its own comparison.