### PR TITLE
require edit permission for wiki _preview

### DIFF
--- a/gluon/tests/test_tools.py
+++ b/gluon/tests/test_tools.py
@@ -621,6 +621,43 @@ class TestWikiTemplateBody(unittest.TestCase):
         self.assertEqual(wiki._template_body(99, "Slug"), "## Slug\n\npage content")
 
 
+class TestWikiPreview(unittest.TestCase):
+    # /wiki/_preview renders whatever is posted, and with more than one render
+    # engine configured the engine is taken from the same post vars, so asking
+    # for the html one echoes the posted body back as markup. It needs the same
+    # authoring permission as the edit and create forms it belongs to.
+    def _wiki(self, groups=None, user=None):
+        wiki = Wiki.__new__(Wiki)
+        wiki.settings = Storage(
+            manage_permissions=True,
+            groups=groups or [],
+            render={"rst": lambda page: page.body},
+            extra={},
+        )
+        wiki.auth = Storage(user=user, settings=Storage(login_url="/a/c/login"))
+        wiki.env = {}
+        return wiki
+
+    def _post(self, body, render):
+        request = Request(env={})
+        request.application = "a"
+        request.controller = "c"
+        request.function = "f"
+        request.folder = "applications/welcome"
+        request.post_vars.update(body=body, render=render, tags=None)
+        current.request = request
+
+    def test_anonymous_preview_is_refused(self):
+        wiki = self._wiki()
+        self._post("<script>alert(1)</script>", "html")
+        self.assertRaises(HTTP, wiki.preview, wiki.get_renderer())
+
+    def test_author_preview_still_renders(self):
+        wiki = self._wiki(groups=["wiki_author"], user=Storage(id=1))
+        self._post("<b>hello</b>", "html")
+        self.assertIn("<b>hello</b>", wiki.preview(wiki.get_renderer()))
+
+
 class TestWikiSearchSerialization(unittest.TestCase):
     # the rendered (html/load) search path withholds restricted page bodies
     # via first_paragraph, but the serialized path (any other extension, e.g.

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -7625,6 +7625,11 @@ class Wiki(object):
         return dict(content=DIV(_class="w2p_cloud", *items))
 
     def preview(self, render):
+        # previewing renders whatever is posted (body, tags and, with more than
+        # one engine configured, the engine itself), so it needs the same
+        # authoring permission as the edit and create forms it belongs to
+        if not self.can_edit():
+            return self.not_authorized()
         request = current.request
         # FIXME: This is an ugly hack to ensure a default render
         # engine if not specified (with multiple render engines)


### PR DESCRIPTION
**Wiki preview is reachable without any permission**

`_preview` is the one authoring endpoint in the wiki dispatch that never asks whether the caller may author anything, so on any app that exposes `auth.wiki()` (the welcome scaffolding does) an anonymous visitor can POST a body and get it rendered and reflected back. It matters most when the app configures more than one render engine, because then the engine is read from the same post vars too, and asking for the html one returns the posted body verbatim as markup rather than escaping it through markmin. I have gated it on can_edit and returned not_authorized, which is the same guard create() already uses.