### PR TITLE
Fix PAM account authorization check

### DIFF
--- a/gluon/contrib/pam.py
+++ b/gluon/contrib/pam.py
@@ -88,6 +88,10 @@ PAM_AUTHENTICATE = LIBPAM.pam_authenticate
 PAM_AUTHENTICATE.restype = c_int
 PAM_AUTHENTICATE.argtypes = [PamHandle, c_int]
 
+PAM_ACCT_MGMT = LIBPAM.pam_acct_mgmt
+PAM_ACCT_MGMT.restype = c_int
+PAM_ACCT_MGMT.argtypes = [PamHandle, c_int]
+
 
 def authenticate(username, password, service="login"):
     """Returns True if the given username and password authenticate for the
@@ -124,6 +128,8 @@ def authenticate(username, password, service="login"):
         return False
 
     retval = PAM_AUTHENTICATE(handle, 0)
+    if retval == 0:
+        retval = PAM_ACCT_MGMT(handle, 0)
     return retval == 0
 
 

--- a/gluon/tests/test_contribs.py
+++ b/gluon/tests/test_contribs.py
@@ -8,6 +8,7 @@ import hmac
 import os
 import shutil
 import unittest
+from unittest.mock import patch
 from urllib.parse import urlencode
 
 from gluon import HTTP
@@ -43,6 +44,20 @@ def tearDownModule():
 
 class TestContribs(unittest.TestCase):
     """Tests the contrib package"""
+
+    def test_pam_authentication_requires_account_approval(self):
+        from gluon.contrib import pam
+
+        with patch.object(pam, "PAM_START", return_value=0), patch.object(
+            pam, "PAM_AUTHENTICATE", return_value=0
+        ), patch.object(pam, "PAM_ACCT_MGMT", return_value=7) as account_check:
+            self.assertFalse(pam.authenticate(b"expired-user", b"password"))
+            account_check.assert_called_once()
+
+        with patch.object(pam, "PAM_START", return_value=0), patch.object(
+            pam, "PAM_AUTHENTICATE", return_value=0
+        ), patch.object(pam, "PAM_ACCT_MGMT", return_value=0):
+            self.assertTrue(pam.authenticate(b"active-user", b"password"))
 
     def test_fpdf(self):
         """Basic PDF test and sanity checks"""


### PR DESCRIPTION
## Summary

- call `pam_acct_mgmt` after successful credential authentication
- reject expired, disabled, or otherwise unauthorized PAM accounts instead of accepting them on password validity alone
- add a regression covering denied and approved account-policy results

Fixes #2449.

## Testing

- `python3 -m unittest gluon.tests.test_contribs` (15 tests passed, 5 optional skips)
- `W2P_SKIP_SCHEDULER_TESTS=1 python3 -m unittest gluon.tests` (435 tests passed, 9 optional skips)
- `python3 -m py_compile gluon/contrib/pam.py gluon/tests/test_contribs.py`
- deterministic stock-versus-patched PAM-function proof: successful password plus denied account changed from accepted to rejected

## AI Disclosure

This change was written with the assistance of Codex. I reviewed the diff and tests and take responsibility for the code.