### PR TITLE
Importer: Add import error passthrough if caused by subdependency

### DIFF
--- a/gluon/custom_import.py
+++ b/gluon/custom_import.py
@@ -64,7 +64,7 @@ def custom_importer(name, globals={}, locals=None, fromlist=(), level=_DEFAULT_L
         try:
             return NATIVE_IMPORTER(name, globals, locals, fromlist, level)
         except ImportError as e:
-            if e.name != name:
+            if e.name != name.split('.')[0]:
                 raise e
             pass
         except KeyError:

--- a/gluon/custom_import.py
+++ b/gluon/custom_import.py
@@ -63,7 +63,11 @@ def custom_importer(name, globals={}, locals=None, fromlist=(), level=_DEFAULT_L
         # absolute import from application code
         try:
             return NATIVE_IMPORTER(name, globals, locals, fromlist, level)
-        except (ImportError, KeyError):
+        except ImportError as e:
+            if e.name != name:
+                raise e
+            pass
+        except KeyError:
             pass
         if current.request._custom_import_track_changes:
             base_importer = TRACK_IMPORTER


### PR DESCRIPTION
This refines the error handling in the custom import function to better handle import errors caused by subdependencies.  This fixes an issue where the error will say that package A is missing, when in reality, package A depends on package B, and package B is what's missing.

## User Story

After switching to a virtual environment, I never installed a few subdependencies that were required by parts of one of my packages (but annoyingly, they aren't listed as package dependencies).  Additionally, one package depended on a built-in library that was removed in Python 3.13.  When importing both of these packages, however, web2py would report that it could not find the package, even though I could import other parts of the first package that didn't require other dependencies.  It wasn't until trying to import the second package in a Python shell that I realized what was going on: it wasn't that the package couldn't be found, but there was an import error within the package.

## Solution

To save on troubleshooting headache in the future, this adds a clause to check the import error raised when importing a module, and cross-references the name of the failed import against the module we're trying to import.  If it doesn't match, then it raises that error.

Before:
<img width="677" height="370" alt="Screenshot 2026-07-23 at 23 13 09" src="https://github.com/user-attachments/assets/f4c33334-f31e-4565-a84c-84d271e02ae0" />

After:
<img width="933" height="727" alt="Screenshot 2026-07-23 at 23 13 29" src="https://github.com/user-attachments/assets/53f3d9db-8ef2-43fa-936e-0088168cfeb1" />
