### PR TITLE
Reject unsupported LDAP authentication modes

### DIFF
--- a/gluon/contrib/login_methods/ldap_auth.py
+++ b/gluon/contrib/login_methods/ldap_auth.py
@@ -211,6 +211,17 @@ def ldap_auth(
         group_mapping=group_mapping,
         db=db,
     ):
+        if ldap_mode not in (
+            "ad",
+            "domino",
+            "cn",
+            "uid",
+            "company",
+            "uid_r",
+            "custom",
+        ):
+            logger.error("unsupported LDAP authentication mode: %s", ldap_mode)
+            return False
         if password == "":  # http://tools.ietf.org/html/rfc4513#section-5.1.2
             logger.warning("blank password not allowed")
             return False

--- a/gluon/tests/test_login_methods.py
+++ b/gluon/tests/test_login_methods.py
@@ -80,7 +80,9 @@ def _make_fake_ldap(captured):
         def start_tls_s(self):
             pass
 
-    ldap_mod.initialize = lambda uri: FakeCon()
+    ldap_mod.initialize = lambda uri: (
+        captured.setdefault("initialized", []).append(uri) or FakeCon()
+    )
 
     filter_mod = types.ModuleType("ldap.filter")
     filter_mod.escape_filter_chars = _rfc4515_escape
@@ -92,7 +94,7 @@ def _make_fake_ldap(captured):
     return ldap_mod, filter_mod, dn_mod
 
 
-class TestLdapAuthFilterInjection(unittest.TestCase):
+class TestLdapAuthSecurity(unittest.TestCase):
     # gluon.contrib.login_methods.ldap_auth builds LDAP search filters from the
     # attacker-supplied login name. In "uid" mode (with a service bind_dn) the
     # username was interpolated into "(uid=%s)" without escaping, allowing LDAP
@@ -161,6 +163,17 @@ class TestLdapAuthFilterInjection(unittest.TestCase):
         self.assertEqual(bind_dn, "cn=%s,dc=x" % self.escape_dn(malicious))
         # ... so the injected RDN cannot appear unescaped
         self.assertNotIn("cn=evil,ou=Admins", bind_dn)
+
+    def test_invalid_mode_fails_closed(self):
+        auth = self.mod.ldap_auth(
+            mode="invalid",
+            server="ldap.example",
+            base_dn="dc=x",
+            manage_user=False,
+        )
+
+        self.assertFalse(auth("alice", "pw"))
+        self.assertNotIn("initialized", self.captured)
 
 
 class TestOutboundURLTokenEncoding(unittest.TestCase):


### PR DESCRIPTION
Fixes #1955.

Unsupported `mode` values currently skip every authentication branch and reach the successful return path. This makes a configuration typo fail open and accept arbitrary credentials.

This change validates the configured mode before initializing LDAP and fails closed for any unsupported value. The regression test also verifies that an invalid mode does not open an LDAP connection.

Validation:
- `python3 -m unittest gluon.tests.test_login_methods` (8 tests)
- `docker run --rm -v "$PWD:/src" -w /src python:3.12-slim python -m unittest gluon.tests.test_login_methods` (8 tests)
- `python3 -m compileall -q gluon/contrib/login_methods/ldap_auth.py gluon/tests/test_login_methods.py`
- `git diff --check`