### PR TITLE
reject reserved registration_key states in verify_key

### DIFF
--- a/gluon/authapi.py
+++ b/gluon/authapi.py
@@ -1336,8 +1336,21 @@ class AuthAPI(object):
             key (string) - User's registration key
         """
         table_user = self.table_user()
+        # registration_key also holds the reserved states "", "pending",
+        # "disabled" and "blocked", which login() uses to refuse a login.
+        # Only the random key issued at registration is a real verification
+        # key, so refuse the reserved values here; otherwise verify_key(key=
+        # "disabled"/"blocked") would match such an account and clear its key,
+        # re-activating an account an administrator disabled, and key="pending"
+        # would clear one still awaiting approval. Auth.verify_email applies
+        # the same guard.
+        if not key or key in ("pending", "disabled", "blocked"):
+            return {
+                "errors": {"key": self.messages.invalid_key},
+                "message": self.messages.invalid_key,
+            }
         user = table_user(registration_key=key)
-        if (user is None) or (key is None):
+        if user is None:
             return {
                 "errors": {"key": self.messages.invalid_key},
                 "message": self.messages.invalid_key,

--- a/gluon/tests/test_authapi.py
+++ b/gluon/tests/test_authapi.py
@@ -220,3 +220,23 @@ class TestAuthAPI(unittest.TestCase):
         lisa_id = result["user"]["id"]
         result = self.auth.verify_key(key=result["user"]["key"])
         self.assertEqual(self.auth.table_user()[lisa_id].registration_key, "pending")
+
+    def test_verify_key_rejects_reserved_states(self):
+        # registration_key doubles as a status column: "disabled"/"blocked"
+        # accounts and accounts still "pending" approval are refused by login().
+        # verify_key must not treat these reserved values as a verification key,
+        # otherwise passing key="disabled" matches such an account and clears
+        # the key, silently re-activating it.
+        for state in ("disabled", "blocked", "pending"):
+            uid = self.auth.table_user().insert(
+                first_name="Moe",
+                last_name="Szyslak",
+                username="moe_%s" % state,
+                email="moe_%s@simpson.com" % state,
+                password="moe_password",
+                registration_key=state,
+            )
+            self.db.commit()
+            result = self.auth.verify_key(key=state)
+            self.assertTrue(result["errors"] is not None)
+            self.assertEqual(self.auth.table_user()[uid].registration_key, state)


### PR DESCRIPTION
1. AuthAPI.verify_key looks up the account with table_user(registration_key=key) and its only guard is key is None, but registration_key doubles as a status column holding "", "pending", "disabled" and "blocked".
2. login() refuses those states, yet verify_key still matches such a row and clears the key to "", so a request with key="disabled"/"blocked" re-activates an account an administrator disabled and key="pending" clears one still awaiting approval.

Refuse an empty or reserved key before the lookup, the same guard Auth.verify_email already uses. Random registration keys are unaffected. Test added in test_authapi.py fails on the current code.