### PR TITLE
verify the mail server certificate in Mail.send

### DIFF
--- a/gluon/tests/test_tools.py
+++ b/gluon/tests/test_tools.py
@@ -10,6 +10,7 @@ import json
 import os
 import shutil
 import smtplib
+import ssl
 import sys
 import tempfile
 import unittest
@@ -61,11 +62,16 @@ class TestMail(unittest.TestCase):
         inbox = []
         users = {}
 
+        last = None
+
         def __init__(self, address, port, **kwargs):
             self.address = address
             self.port = port
             self.has_quit = False
             self.tls = False
+            self.tls_context = None
+            self.init_kwargs = kwargs
+            TestMail.DummySMTP.last = self
 
         def login(self, username, password):
             if username not in self.users or self.users[username] != password:
@@ -82,8 +88,14 @@ class TestMail(unittest.TestCase):
         def ehlo(self, hostname=None):
             pass
 
-        def starttls(self):
+        def starttls(self, *args, **kwargs):
             self.tls = True
+            # Mail.send now hands a context in. Record it instead of dropping
+            # it: without the parameter this raised a TypeError, which
+            # Mail.send swallows, so every test here would have gone silently
+            # false rather than failing.
+            self.tls_context = kwargs.get("context")
+            TestMail.DummySMTP.last = self
 
     def setUp(self):
         self.original_SMTP = smtplib.SMTP
@@ -198,6 +210,59 @@ class TestMail(unittest.TestCase):
             )
         )
         TestMail.DummySMTP.inbox.pop()
+
+    # Mail.send talks to the relay the operator configured and authenticates to
+    # it with settings.login. It called starttls() and SMTP_SSL() without a
+    # context, so the TLS layer used ssl._create_stdlib_context()
+    # (check_hostname=False, verify_mode=CERT_NONE) and never checked the server
+    # certificate: an on-path attacker presenting a forged one read the
+    # credentials and everything the framework mails, password reset links
+    # included.
+
+    def _send_one(self, mail):
+        return mail.send(
+            to=["somebody@example.com"],
+            subject="hello",
+            reply_to="us@example.com",
+            message="world",
+        )
+
+    def test_starttls_uses_verifying_context(self):
+        mail = Mail()
+        mail.settings.server = "smtp.example.com:25"
+        mail.settings.sender = "you@example.com"
+        mail.settings.tls = True
+        self.assertTrue(self._send_one(mail))
+        TestMail.DummySMTP.inbox.pop()
+        ctx = TestMail.DummySMTP.last.tls_context
+        self.assertIsInstance(ctx, ssl.SSLContext)
+        self.assertTrue(ctx.check_hostname)
+        self.assertEqual(ctx.verify_mode, ssl.CERT_REQUIRED)
+
+    def test_ssl_uses_verifying_context(self):
+        mail = Mail()
+        mail.settings.server = "smtp.example.com:25"
+        mail.settings.sender = "you@example.com"
+        mail.settings.ssl = True
+        self.assertTrue(self._send_one(mail))
+        TestMail.DummySMTP.inbox.pop()
+        ctx = TestMail.DummySMTP.last.init_kwargs.get("context")
+        self.assertIsInstance(ctx, ssl.SSLContext)
+        self.assertTrue(ctx.check_hostname)
+        self.assertEqual(ctx.verify_mode, ssl.CERT_REQUIRED)
+
+    def test_self_signed_certificate_opts_out(self):
+        # The escape hatch for a relay with a self-signed certificate, same
+        # opt-in as ldap_auth and freeipa_auth. It has to keep working, and it
+        # has to be the only way to get the old behaviour back.
+        mail = Mail()
+        mail.settings.server = "smtp.example.com:25"
+        mail.settings.sender = "you@example.com"
+        mail.settings.tls = True
+        mail.settings.self_signed_certificate = True
+        self.assertTrue(self._send_one(mail))
+        TestMail.DummySMTP.inbox.pop()
+        self.assertIsNone(TestMail.DummySMTP.last.tls_context)
 
     def test_tls(self):
         mail = Mail()

--- a/gluon/tools.py
+++ b/gluon/tools.py
@@ -27,6 +27,7 @@ import random
 import re
 import secrets
 import smtplib
+import ssl
 import sys
 import time
 import traceback
@@ -255,6 +256,10 @@ class Mail(object):
                               the messages with can be a file name /
                               string or a list of file names /
                               strings (PEM format)
+        self_signed_certificate: skip verification of the mail server
+                              certificate, for a relay that presents a
+                              self-signed one. Same opt-in as ldap_auth
+                              and freeipa_auth. Defaults to False
 
     Examples:
         Create Mail object with authentication data for remote server::
@@ -354,6 +359,9 @@ class Mail(object):
         settings.x509_nocerts = False
         settings.x509_crypt_certfiles = None
         settings.debug = False
+        # Skip verification of the mail server certificate, for a relay that
+        # presents a self-signed one. Same opt-in as ldap_auth and freeipa_auth.
+        settings.self_signed_certificate = False
         settings.lock_keys = True
         self.result = {}
         self.error = None
@@ -936,13 +944,25 @@ class Mail(object):
             else:
                 smtp_args = self.settings.server.split(":")
                 kwargs = dict(timeout=self.settings.timeout)
+                # Without a context, smtplib falls back to
+                # ssl._create_stdlib_context(), which sets check_hostname=False
+                # and verify_mode=CERT_NONE. Both the implicit TLS branch below
+                # and starttls() were unverified, so the login credentials and
+                # the message went to whatever certificate the peer presented.
+                context = (
+                    None
+                    if self.settings.self_signed_certificate
+                    else ssl.create_default_context()
+                )
                 func = smtplib.SMTP_SSL if self.settings.ssl else smtplib.SMTP
+                if self.settings.ssl:
+                    kwargs["context"] = context
                 server = remote_server or func(*smtp_args, **kwargs)
                 try:
                     if not remote_server:
                         if self.settings.tls and not self.settings.ssl:
                             server.ehlo(self.settings.hostname)
-                            server.starttls()
+                            server.starttls(context=context)
                             server.ehlo(self.settings.hostname)
                         if self.settings.login:
                             server.login(*self.settings.login.split(":", 1))


### PR DESCRIPTION
`Mail.send()` called `smtplib.SMTP.starttls()` and `smtplib.SMTP_SSL()` without a
context, so the TLS layer fell back to `ssl._create_stdlib_context()`:
`check_hostname=False`, `verify_mode=CERT_NONE`. Neither branch checked the
certificate of the relay it authenticates to with `settings.login`, so an on-path
attacker presenting any certificate read the credentials and everything the
framework mails, password reset and verification links included. Same class as
#2674 and #2652, in the function the rest of the framework mails through.

Both branches now get a verifying context. `mail.settings.self_signed_certificate`
opts back out, which is the opt-in `ldap_auth` and `freeipa_auth` already use
under that name.

This came up in #2434 in 2022. You asked there whether verifying might break mail
in other cases, and said it would need a setting first. That setting is what this
adds, and it defaults to verifying, the same way #2652 did it.

Measured against a local SMTP server, driving the real `Mail.send()`:

| certificate | branch | before | after |
| --- | --- | --- | --- |
| self-signed | `tls=True` | delivered | refused |
| self-signed | `ssl=True` | delivered | refused |
| trusted CA | `tls=True` | delivered | delivered |
| trusted CA | `ssl=True` | delivered | delivered |
| self-signed, opt-out set | either | n/a | delivered |

The trusted CA rows are the control: the change refuses an unverifiable peer, not
every peer.

Suite: 460 tests before, 463 with the three added here, the same two pre-existing
errors on both sides. `TestMail` is green on Python 3.9 in a pinned container and
on the other three versions of the matrix.

`DummySMTP.starttls()` took no arguments and now records the context. Without
that it raises `TypeError`, and since `Mail.send()` catches everything and
returns False, `test_tls` and `test_ssl` would have gone quietly false instead of
failing.
