### PR TITLE
reject script schemes in redirect client-side location

### DIFF
--- a/gluon/http.py
+++ b/gluon/http.py
@@ -72,6 +72,23 @@ defined_status = {
 regex_status = re.compile(r"^\d{3} [0-9A-Z ]+$")
 regex_header_newlines = re.compile(r"[\r\n]")
 
+# URL schemes that run script when the value is assigned to window.location
+# (the client_side branch of redirect() emits web2py-redirect-location, which
+# web2py.js assigns to window.location) or opened from a Location header on
+# legacy browsers. They are never valid redirect targets.
+_UNSAFE_REDIRECT_SCHEMES = frozenset(("javascript", "vbscript", "data"))
+
+
+def _is_unsafe_redirect(location):
+    # Strip ASCII control characters and spaces the way browsers do before
+    # resolving a URL, so values like "java\tscript:..." cannot slip a
+    # dangerous scheme past the check.
+    cleaned = "".join(
+        c for c in location if ord(c) > 0x20 and ord(c) != 0x7F
+    ).lower()
+    scheme, has_scheme, _ = cleaned.partition(":")
+    return bool(has_scheme) and scheme in _UNSAFE_REDIRECT_SCHEMES
+
 
 class HTTP(Exception):
     """Raises an HTTP response
@@ -186,6 +203,10 @@ def redirect(location="", how=303, client_side=False, headers=None):
     if location:
         from gluon.globals import current
 
+        if _is_unsafe_redirect(location):
+            # Refuse a script-executing scheme instead of handing it to
+            # window.location; fall back to the root path.
+            location = "/"
         loc = location.replace("\r", "%0D").replace("\n", "%0A")
         if client_side and current.request.ajax:
             headers["web2py-redirect-location"] = loc

--- a/gluon/tests/test_http.py
+++ b/gluon/tests/test_http.py
@@ -5,7 +5,9 @@
 
 import unittest
 
+from gluon.globals import current
 from gluon.http import HTTP, content_disposition_header, defined_status, redirect
+from gluon.storage import Storage
 
 
 class TestHTTP(unittest.TestCase):
@@ -94,3 +96,34 @@ class TestRedirect(unittest.TestCase):
         e = self._redirect_http("/app/default/index")
         self.assertEqual(e.headers["Location"], "/app/default/index")
         self.assertIn('<a href="/app/default/index">here</a>', e.body)
+
+    def _redirect_client_side(self, location):
+        current.request = Storage(ajax=True)
+        try:
+            redirect(location, client_side=True)
+        except HTTP as e:
+            return e
+        finally:
+            current.request = None
+        self.fail("redirect did not raise HTTP")
+
+    def test_redirect_client_side_rejects_script_schemes(self):
+        # web2py.js assigns web2py-redirect-location to window.location, so a
+        # javascript:/vbscript:/data: value there is client-side code execution.
+        for payload in (
+            "javascript:alert(document.cookie)",
+            "vbscript:msgbox(1)",
+            "data:text/html,<script>alert(1)</script>",
+            "java\tscript:alert(1)",
+        ):
+            e = self._redirect_client_side(payload)
+            self.assertEqual(e.headers["web2py-redirect-location"], "/")
+
+    def test_redirect_client_side_preserves_benign_location(self):
+        e = self._redirect_client_side("/app/default/index")
+        self.assertEqual(e.headers["web2py-redirect-location"], "/app/default/index")
+
+    def test_redirect_rejects_script_scheme_in_location_header(self):
+        e = self._redirect_http("javascript:alert(1)")
+        self.assertEqual(e.headers["Location"], "/")
+        self.assertNotIn("javascript:", e.body)


### PR DESCRIPTION
redirect(location, client_side=True) writes the target into the web2py-redirect-location header, which web2py.js assigns to window.location, and the value was only CRLF-neutralized, so a javascript:, vbscript: or data: target runs as script when the browser navigates to it. The SQLFORM.grid client_side_delete branch reaches this callee from the Web2py-Component-Location request header, and redirect() is a public helper apps call with externally-influenced locations. Reject those schemes (after stripping control and space characters so java\tscript: cannot slip through) and fall back to /; http, https, protocol-relative and relative targets are unchanged.