### PR TITLE
keep pdf image fetches on the app origin in _resolve_pdf_image_path

### DIFF
--- a/gluon/contrib/generics.py
+++ b/gluon/contrib/generics.py
@@ -55,6 +55,12 @@ def _resolve_pdf_image_path(path, request):
             return safe_path_join(request.folder, "static", relative_static_path)
         except ValueError:
             raise HTTP(403, "invalid static path")
+    # The image is fetched server-side from the app's own host, so only a
+    # same-origin absolute path is meaningful here. A value that does not
+    # begin with a single "/" would attach to the host and move the fetch to
+    # another server, e.g. "@internal:8080/x" -> "http://host@internal:8080/x".
+    if not path.startswith("/") or path.startswith("//"):
+        raise HTTP(403, "invalid image path")
     return "http%s://%s%s" % (
         request.is_https and "s" or "",
         request.env.http_host,

--- a/gluon/tests/test_contribs.py
+++ b/gluon/tests/test_contribs.py
@@ -127,6 +127,38 @@ class TestContribs(unittest.TestCase):
             _resolve_pdf_image_path("/welcome/static/../../private/secret.txt", request)
         self.assertEqual(ctx.exception.status, 403)
 
+    def test_pdf_image_map_allows_same_origin_path(self):
+        request = Storage(
+            {
+                "application": "welcome",
+                "folder": os.path.join("applications", "welcome"),
+                "is_https": False,
+                "env": Storage({"http_host": "example.com"}),
+            }
+        )
+        result = _resolve_pdf_image_path("/welcome/default/download/logo.png", request)
+        self.assertEqual(result, "http://example.com/welcome/default/download/logo.png")
+
+    def test_pdf_image_map_rejects_cross_host_fetch(self):
+        request = Storage(
+            {
+                "application": "welcome",
+                "folder": os.path.join("applications", "welcome"),
+                "is_https": False,
+                "env": Storage({"http_host": "example.com:8000"}),
+            }
+        )
+        # "@internal:8080/x" would build http://example.com:8000@internal:8080/x,
+        # i.e. the server-side fetch would connect to internal:8080.
+        for path in (
+            "@internal:8080/logo.png",
+            "evil.example/logo.png",
+            "//evil/logo.png",
+        ):
+            with self.assertRaises(HTTP) as ctx:
+                _resolve_pdf_image_path(path, request)
+            self.assertEqual(ctx.exception.status, 403)
+
     def test_autolinks_escapes_url_in_markup(self):
         from gluon.contrib import autolinks
 


### PR DESCRIPTION
The pdf generator maps every image referenced in the html it renders through _resolve_pdf_image_path, and pyfpdf will urlopen whatever comes back as an http url. The static branch here was tightened with safe_path_join, but the fallback simply glues the image path onto the request host as http://<host><path>, and that path comes straight from an img src that the application renders into the pdf. Since the value is not constrained to a same-origin absolute path, one that does not begin with a single slash attaches to the host rather than to the path: a src of @internal:8080/logo.png builds http://<host>@internal:8080/logo.png, so the userinfo portion moves the server-side fetch to internal:8080. In practice that lets a rendered document reach hosts the server can talk to but the client cannot, which is the usual request-forgery shape. I came across it while looking at why only the static branch had been hardened. The change keeps the fallback to genuine same-origin absolute paths and refuses anything else with a 403, in the same way the static branch already rejects bad input.