### PR TITLE
Fix admin password generation and use a CSPRNG for it

### DIFF
--- a/gluon/main.py
+++ b/gluon/main.py
@@ -13,8 +13,8 @@ import datetime
 import gc
 import http
 import os
-import random
 import re
+import secrets
 import signal
 import socket
 import string
@@ -608,8 +608,8 @@ def save_password(password, port):
     password_file = abspath("parameters_%i.py" % port)
     if password == "<random>":
         # make up a new password
-        chars = string.letters + string.digits
-        password = "".join([random.choice(chars) for _ in range(8)])
+        chars = string.ascii_letters + string.digits
+        password = "".join([secrets.choice(chars) for _ in range(8)])
         cpassword = CRYPT()(password)[0]
         print("******************* IMPORTANT!!! ************************")
         print('your admin password is "%s"' % password)

--- a/gluon/tests/test_main.py
+++ b/gluon/tests/test_main.py
@@ -1,0 +1,34 @@
+import contextlib
+import io
+import os
+import re
+import tempfile
+import unittest
+from unittest import mock
+
+from gluon import main
+
+
+class TestMain(unittest.TestCase):
+    def test_save_password_random(self):
+        port = 19879
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            password_file = os.path.join(temporary_directory, "parameters_%i.py" % port)
+            output = io.StringIO()
+            with mock.patch.object(main, "abspath", return_value=password_file):
+                with contextlib.redirect_stdout(output):
+                    main.save_password("<random>", port)
+
+            password_match = re.search(
+                r'admin password is "([A-Za-z0-9]{8})"', output.getvalue()
+            )
+            self.assertIsNotNone(password_match)
+            with open(password_file, encoding="utf-8") as parameter_file:
+                stored_password = re.fullmatch(
+                    r'password="([^"]+)"\n', parameter_file.read()
+                ).group(1)
+            self.assertNotEqual(stored_password, password_match.group(1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The `<random>` admin password option is broken on Python 3 and cannot generate a password at all.

`save_password()` builds the character set from `string.letters`, which only exists on Python 2:

```python
chars = string.letters + string.digits
password = "".join([random.choice(chars) for _ in range(8)])
```

Starting web2py with `-a "<random>"` therefore raises `AttributeError: module 'string' has no attribute 'letters'` instead of producing a password. web2py has been Python 3 only since 2024, so this path has no working configuration.

Fixing the attribute alone would leave the generated admin password coming from `random.choice()`. That is worth avoiding here, because `gluon/utils.py` seeds the global `random` module at import time with `uuid.getnode() + int(time.time() * 1e6)`, replacing the OS entropy CPython would otherwise use with a MAC address and a startup timestamp. `web2py_uuid()` compensates by XORing its `random` output with `os.urandom`, but `save_password()` has no equivalent mitigation, and this credential unlocks an interface that can edit and run application code.

This uses `string.ascii_letters` and `secrets.choice`, matching the `secrets` usage already present in `gluon/tools.py`. The `random` import in `gluon/main.py` is now unused and is dropped.

To verify: run `python3 web2py.py -a "<random>"` before the change and it aborts with the AttributeError; after it prints a generated password and writes `parameters_<port>.py` as intended.

I left the length at 8 characters deliberately, to keep this to the fix rather than change behaviour operators may depend on. Happy to raise it in a separate PR if you would prefer.