### PR TITLE
fix(csp): set the directives that do not fall back to default-src

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ Security hardening since 3.0.x. Two opt-in features are worth calling out:
   one-colon `secure_loads` payloads now honor the same flag.
 - Opt-in Content-Security-Policy: `response.enable_csp(**directives)` emits a
   per-request nonce-based CSP header (`default-src 'self'`, nonce'd
-  `script-src`/`style-src`), with directive/token validation. Use
-  `response.nonce` on inline `<script>`/`<style>` tags.
+  `script-src`/`style-src`), plus `base-uri 'self'`, `form-action 'self'` and
+  `object-src 'none'`, with directive/token validation. Use `response.nonce`
+  on inline `<script>`/`<style>` tags. `base-uri` and `form-action` do not
+  fall back to `default-src`, so they are set explicitly; pass either as a
+  keyword to override, e.g. `enable_csp(form_action="https://pay.example")`
+  for a site that posts forms off-origin.
 
 Breaking change:
 

--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -128,6 +128,15 @@ template_mapping_csp = {
 
 CSP_DIRECTIVE = re.compile(r"^[A-Za-z0-9-]+$")
 CSP_DIRECTIVE_TOKEN = re.compile(r"^[\x21-\x2B\x2D-\x3A\x3C-\x7E]+$")
+# Applied by Response.enable_csp() unless the caller or an already-set header
+# provides the directive. base-uri and form-action are a document and a
+# navigation directive, so neither falls back to default-src; object-src does
+# fall back, but only as far as default-src's 'self'.
+CSP_SECURE_DEFAULTS = (
+    ("base-uri", ("'self'",)),
+    ("form-action", ("'self'",)),
+    ("object-src", ("'none'",)),
+)
 CSP_STANDARD_DIRECTIVES = frozenset(
     (
         "base-uri",
@@ -698,6 +707,10 @@ class Response(Storage):
         n = self.nonce
         merge("script-src", ["'self'", "'nonce-%s'" % n])
         merge("style-src", ["'self'", "'nonce-%s'" % n])
+        supplied = set(k.replace("_", "-") for k in policies)
+        for directive, sources in CSP_SECURE_DEFAULTS:
+            if directive not in p and directive not in supplied:
+                merge(directive, sources)
         for k, v in policies.items():
             merge(k.replace("_", "-"), v)
 

--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -204,7 +204,11 @@ def _split_serialized_csp_list(serialized):
     start = 0
     for match in re.finditer(r",([\t\n\f\r ]*)([A-Za-z0-9-]+)", serialized):
         directive = match.group(2)
-        if match.group(1) or directive in CSP_STANDARD_DIRECTIVES or "-" in directive:
+        if (
+            match.group(1)
+            or directive.lower() in CSP_STANDARD_DIRECTIVES
+            or "-" in directive
+        ):
             policies.append(serialized[start : match.start()].strip())
             start = match.end(1)
     policies.append(serialized[start:].strip())
@@ -690,10 +694,12 @@ class Response(Storage):
                         continue
                     bits = directive.split()
                     if bits:
-                        _validate_csp_directive(bits[0])
-                        p[bits[0]] = _normalize_csp_tokens(bits[1:])
+                        directive = bits[0].lower()
+                        _validate_csp_directive(directive)
+                        p[directive] = _normalize_csp_tokens(bits[1:])
 
         def merge(directive, sources):
+            directive = directive.replace("_", "-").lower()
             _validate_csp_directive(directive)
             sources = _normalize_csp_tokens(sources)
             if directive not in p:
@@ -707,12 +713,12 @@ class Response(Storage):
         n = self.nonce
         merge("script-src", ["'self'", "'nonce-%s'" % n])
         merge("style-src", ["'self'", "'nonce-%s'" % n])
-        supplied = set(k.replace("_", "-") for k in policies)
+        supplied = set(k.replace("_", "-").lower() for k in policies)
         for directive, sources in CSP_SECURE_DEFAULTS:
             if directive not in p and directive not in supplied:
                 merge(directive, sources)
         for k, v in policies.items():
-            merge(k.replace("_", "-"), v)
+            merge(k, v)
 
         self.headers["Content-Security-Policy"] = "; ".join(
             "%s %s" % (k, " ".join(v)) for k, v in p.items()

--- a/gluon/tests/test_globals.py
+++ b/gluon/tests/test_globals.py
@@ -429,6 +429,44 @@ class testResponse(unittest.TestCase):
         )
         self.assertEqual("'self'", self._csp_directive(csp, "form-action"))
 
+    def test_enable_csp_directives_are_case_insensitive(self):
+        response = Response()
+        response.enable_csp(
+            **{
+                "BASE_URI": "https://cdn.example",
+                "Form_Action": "https://pay.example",
+                "OBJECT_SRC": "'self'",
+            }
+        )
+        csp = response.headers["Content-Security-Policy"]
+        self.assertEqual(
+            "https://cdn.example", self._csp_directive(csp, "base-uri")
+        )
+        self.assertEqual(
+            "https://pay.example", self._csp_directive(csp, "form-action")
+        )
+        self.assertEqual("'self'", self._csp_directive(csp, "object-src"))
+
+        response = Response()
+        response.headers["Content-Security-Policy"] = (
+            "BASE-URI https://cdn.example; Form-Action https://pay.example; "
+            "OBJECT-SRC 'self'"
+        )
+        response.enable_csp()
+        csp = response.headers["Content-Security-Policy"]
+        self.assertEqual(
+            "https://cdn.example", self._csp_directive(csp, "base-uri")
+        )
+        self.assertEqual(
+            "https://pay.example", self._csp_directive(csp, "form-action")
+        )
+        self.assertEqual("'self'", self._csp_directive(csp, "object-src"))
+
+        response = Response()
+        response.headers["Content-Security-Policy"] = "BASE_URI https://cdn.example"
+        with self.assertRaises(ValueError):
+            response.enable_csp()
+
     def test_enable_csp_accepts_existing_policy_lists(self):
         response = Response()
         response.headers["Content-Security-Policy"] = (

--- a/gluon/tests/test_globals.py
+++ b/gluon/tests/test_globals.py
@@ -382,6 +382,53 @@ class testResponse(unittest.TestCase):
         self.assertIn("sandbox allow-scripts allow-same-origin", csp)
         self.assertIn("upgrade-insecure-requests", csp)
 
+    @staticmethod
+    def _csp_directive(csp, name):
+        for directive in csp.split(";"):
+            bits = directive.split()
+            if bits and bits[0] == name:
+                return " ".join(bits[1:])
+        return None
+
+    def test_enable_csp_sets_directives_without_default_src_fallback(self):
+        # base-uri and form-action do not fall back to default-src, so a nonce
+        # policy that omits them still permits an injected <base> to retarget
+        # every relative URL, including FORM's default action="#".
+        response = Response()
+        response.enable_csp()
+        csp = response.headers["Content-Security-Policy"]
+        self.assertEqual("'self'", self._csp_directive(csp, "base-uri"))
+        self.assertEqual("'self'", self._csp_directive(csp, "form-action"))
+        self.assertEqual("'none'", self._csp_directive(csp, "object-src"))
+        self.assertEqual("'self'", self._csp_directive(csp, "default-src"))
+        self.assertEqual(
+            "'self' 'nonce-%s'" % response.nonce,
+            self._csp_directive(csp, "script-src"),
+        )
+
+    def test_enable_csp_defaults_do_not_override_caller(self):
+        response = Response()
+        response.enable_csp(base_uri="'none'", form_action="https://pay.example")
+        csp = response.headers["Content-Security-Policy"]
+        self.assertEqual("'none'", self._csp_directive(csp, "base-uri"))
+        self.assertEqual(
+            "https://pay.example", self._csp_directive(csp, "form-action")
+        )
+        # a directive the caller did not mention still gets its default
+        self.assertEqual("'none'", self._csp_directive(csp, "object-src"))
+
+    def test_enable_csp_defaults_do_not_override_existing_header(self):
+        response = Response()
+        response.headers["Content-Security-Policy"] = "base-uri https://cdn.example"
+        response.enable_csp()
+        csp = response.headers["Content-Security-Policy"]
+        # merge() appends, so a missing guard shows up as the default tacked on
+        # the end of the caller's value, not in front of it.
+        self.assertEqual(
+            "https://cdn.example", self._csp_directive(csp, "base-uri")
+        )
+        self.assertEqual("'self'", self._csp_directive(csp, "form-action"))
+
     def test_enable_csp_accepts_existing_policy_lists(self):
         response = Response()
         response.headers["Content-Security-Policy"] = (


### PR DESCRIPTION
`enable_csp()` currently emits `default-src`, `script-src` and `style-src` only. `default-src` is the fallback for fetch directives, so `object-src` inherits `'self'`. But `base-uri` is a document directive ([CSP3 §6.3](https://www.w3.org/TR/CSP3/#directive-base-uri)) and `form-action` is a navigation directive ([§6.4](https://www.w3.org/TR/CSP3/#directive-form-action)), and neither has any fallback. Both are unrestricted in every policy the helper produces.

### Why that matters here

The gap is reachable through the exact injection a nonce policy is deployed to contain.

`FORM` sets `action="#"` when the caller doesn't supply one (`gluon/html.py:2251`), so the default form action is a fragment-only reference, resolved against the document base URL:

```python
>>> from urllib.parse import urljoin
>>> urljoin("https://victim.example/app/default/user/login", "#")
'https://victim.example/app/default/user/login#'
>>> urljoin("https://attacker.example/", "#")     # after <base href="https://attacker.example/">
'https://attacker.example/#'
```

So an injected `<base href="https://attacker.example/">` retargets every form on the page. The nonce still stops the injected script from running, which is what makes this easy to miss, but the login and password forms now submit to the attacker along with their CSRF token, and `form-action` isn't set to stop them.

### Change

Set `base-uri 'self'`, `form-action 'self'` and `object-src 'none'` by default. `object-src 'none'` is included because inheriting `'self'` still permits an `<object>` or `<embed>` pointed at same-origin content the attacker controls, such as an uploaded file served back by the app.

Each default applies only when neither the caller nor an already-set `Content-Security-Policy` header provides that directive:

```python
response.enable_csp()
# default-src 'self'; script-src 'self' 'nonce-…'; style-src 'self' 'nonce-…';
# base-uri 'self'; form-action 'self'; object-src 'none'

response.enable_csp(form_action="https://pay.example")
# … form-action https://pay.example
```

That override handling is load-bearing: `merge()` appends, so applying a default unconditionally would emit `base-uri 'self' 'none'`.

### Compatibility

This changes the emitted header for existing `enable_csp()` callers, so both risky directives stay overridable by keyword, as above.

I grepped the shipped applications to size the risk: zero off-origin form actions, so `form-action 'self'` should not affect anything in-tree; two `<object>`/`<embed>` tags, which is why `object_src=` is overridable; and no real `<base>` tag anywhere (the single grep hit is a string inside `codemirror/emmet.min.js`), so `base-uri 'self'` looks free. An application outside the tree that posts to a payment endpoint or embeds a PDF viewer will need the keyword.

`frame-ancestors` is deliberately left alone. It also has no fallback, but restricting it changes embedding behaviour for a different threat model, and it seems better as its own opt-in than as a side effect of enabling CSP.

### Tests

Three tests in `gluon/tests/test_globals.py` cover the defaults, caller override, and existing-header precedence. They compare directive values exactly, so an unexpected extra token can't slip past a substring match.

The guard has two halves and each is pinned by mutation:

| mutation | result |
|---|---|
| drop `directive not in p` | fails only `..._do_not_override_existing_header` |
| drop `directive not in supplied` | fails only `..._do_not_override_caller` |
| `gluon/globals.py` reverted, tests kept | all three fail |

With the change: `test_globals.py` 41/41, `test_html.py` 80/80. `test_web.py` has two failures (`testRegisterAndLogin`, `testStaticCache`) both before and after, so they're pre-existing here and unrelated.
