### PR TITLE
contain admin webservices file paths to the applications tree

### DIFF
--- a/applications/admin/controllers/default.py
+++ b/applications/admin/controllers/default.py
@@ -15,7 +15,7 @@ import io
 import importlib
 
 from gluon.admin import *
-from gluon.admin import check_app_path, is_within_root, join_app_path
+from gluon.admin import check_app_path, is_within_root, join_app_path, safe_path
 from gluon.fileutils import abspath, read_file, write_file
 from gluon.http import content_disposition_header
 from gluon.restricted import safe_load, safe_loads, TicketStorage
@@ -92,14 +92,7 @@ def safe_open(a, b):
                 pass
         return tmp()
 
-    a_for_check = os.path.abspath(os.path.normpath(a))
-
-    web2py_apps_root = os.path.abspath(up(request.folder))
-    web2py_deposit_root = os.path.join(up(web2py_apps_root), 'deposit')
-
-    allowed_roots = [web2py_apps_root, web2py_deposit_root]
-    if not any(is_within_root(a_for_check, root) for root in allowed_roots):
-        raise HTTP(403)
+    a = safe_path(request, a)
 
     if 'b' in b:
         return open(a, b)

--- a/applications/admin/controllers/webservices.py
+++ b/applications/admin/controllers/webservices.py
@@ -11,6 +11,25 @@ import io
 
 service = Service(globals())
 
+
+def _safe_apath(path):
+    """Resolve ``path`` inside the web2py tree and refuse anything escaping it.
+
+    read_file/write_file/hash_file/list_files take the path straight from the
+    JSON-RPC caller. apath() rejects neither an absolute path nor a chain of
+    ../ segments that climbs past the tree, so the following open()/listdir()
+    would reach arbitrary host files. Contain to the applications and deposit
+    roots, the same guard default.py's safe_open() applies.
+    """
+    resolved = os.path.abspath(os.path.normpath(apath(path, r=request)))
+    apps_root = os.path.abspath(up(request.folder))
+    deposit_root = os.path.join(up(apps_root), 'deposit')
+    if not any(is_within_root(resolved, root)
+               for root in (apps_root, deposit_root)):
+        raise HTTP(403)
+    return resolved
+
+
 @service.jsonrpc
 def login():
     "dummy function to test credentials"
@@ -27,14 +46,14 @@ def list_apps():
 
 @service.jsonrpc
 def list_files(app, pattern='.*\.py$'):
-    files = listdir(apath('%s/' % app, r=request), pattern)
+    files = listdir(_safe_apath('%s/' % app), pattern)
     return [x.replace('\\', '/') for x in files]
 
 
 @service.jsonrpc
 def read_file(filename, b64=False):
     """ Visualize object code """
-    f = open(apath(filename, r=request), "rb")
+    f = open(_safe_apath(filename), "rb")
     try:
         data = f.read()
         if not b64:
@@ -48,7 +67,7 @@ def read_file(filename, b64=False):
 
 @service.jsonrpc
 def write_file(filename, data, b64=False):
-    f = open(apath(filename, r=request), "wb")
+    f = open(_safe_apath(filename), "wb")
     try:
         if not b64:
             data = data.replace('\r\n', '\n').strip() + '\n'
@@ -63,7 +82,7 @@ def write_file(filename, data, b64=False):
 def hash_file(filename):
     data = read_file(filename)
     file_hash = md5_hash(data)
-    path = apath(filename, r=request)
+    path = _safe_apath(filename)
     saved_on = os.stat(path)[stat.ST_MTIME]
     size = os.path.getsize(path)
     return dict(saved_on=saved_on, file_hash=file_hash, size=size)

--- a/applications/admin/controllers/webservices.py
+++ b/applications/admin/controllers/webservices.py
@@ -11,25 +11,6 @@ import io
 
 service = Service(globals())
 
-
-def _safe_apath(path):
-    """Resolve ``path`` inside the web2py tree and refuse anything escaping it.
-
-    read_file/write_file/hash_file/list_files take the path straight from the
-    JSON-RPC caller. apath() rejects neither an absolute path nor a chain of
-    ../ segments that climbs past the tree, so the following open()/listdir()
-    would reach arbitrary host files. Contain to the applications and deposit
-    roots, the same guard default.py's safe_open() applies.
-    """
-    resolved = os.path.abspath(os.path.normpath(apath(path, r=request)))
-    apps_root = os.path.abspath(up(request.folder))
-    deposit_root = os.path.join(up(apps_root), 'deposit')
-    if not any(is_within_root(resolved, root)
-               for root in (apps_root, deposit_root)):
-        raise HTTP(403)
-    return resolved
-
-
 @service.jsonrpc
 def login():
     "dummy function to test credentials"
@@ -46,14 +27,14 @@ def list_apps():
 
 @service.jsonrpc
 def list_files(app, pattern='.*\.py$'):
-    files = listdir(_safe_apath('%s/' % app), pattern)
+    files = listdir(safe_apath('%s/' % app, r=request), pattern)
     return [x.replace('\\', '/') for x in files]
 
 
 @service.jsonrpc
 def read_file(filename, b64=False):
     """ Visualize object code """
-    f = open(_safe_apath(filename), "rb")
+    f = open(safe_apath(filename, r=request), "rb")
     try:
         data = f.read()
         if not b64:
@@ -67,7 +48,7 @@ def read_file(filename, b64=False):
 
 @service.jsonrpc
 def write_file(filename, data, b64=False):
-    f = open(_safe_apath(filename), "wb")
+    f = open(safe_apath(filename, r=request), "wb")
     try:
         if not b64:
             data = data.replace('\r\n', '\n').strip() + '\n'
@@ -82,7 +63,7 @@ def write_file(filename, data, b64=False):
 def hash_file(filename):
     data = read_file(filename)
     file_hash = md5_hash(data)
-    path = _safe_apath(filename)
+    path = safe_apath(filename, r=request)
     saved_on = os.stat(path)[stat.ST_MTIME]
     size = os.path.getsize(path)
     return dict(saved_on=saved_on, file_hash=file_hash, size=size)

--- a/gluon/admin.py
+++ b/gluon/admin.py
@@ -81,6 +81,19 @@ def apath(path="", r=None):
     return os.path.join(opath, path).replace("\\", "/")
 
 
+def safe_path(request, path):
+    resolved = os.path.abspath(os.path.normpath(path))
+    apps_root = os.path.abspath(up(request.folder))
+    deposit_root = os.path.join(up(apps_root), "deposit")
+    if not any(is_within_root(resolved, root) for root in (apps_root, deposit_root)):
+        raise HTTP(403)
+    return resolved
+
+
+def safe_apath(path="", r=None):
+    return safe_path(r, apath(path, r))
+
+
 def is_within_root(path, root):
     return path == root or path.startswith(root + os.sep)
 

--- a/gluon/tests/__init__.py
+++ b/gluon/tests/__init__.py
@@ -25,3 +25,4 @@ from .test_storage import *
 from .test_tools import *
 from .test_utils import *
 from .test_web import *
+from .test_webservices import *

--- a/gluon/tests/test_webservices.py
+++ b/gluon/tests/test_webservices.py
@@ -1,0 +1,78 @@
+#!/bin/python
+# -*- coding: utf-8 -*-
+
+"""
+    Unit tests for the admin webservices controller path containment
+"""
+
+import base64
+import os
+import unittest
+
+from gluon.fileutils import read_file as _read_source
+from gluon.http import HTTP
+from gluon.restricted import compile2, restricted
+
+
+class TestWebservicesPathContainment(unittest.TestCase):
+    def setUp(self):
+        from gluon.globals import Request, Response, Session, current
+
+        request = Request(env={})
+        request.application = "admin"
+        request.controller = "webservices"
+        request.function = "read_file"
+        request.folder = os.path.abspath(os.path.join("applications", "admin"))
+        request.env.http_host = "127.0.0.1:8000"
+        request.env.remote_addr = "127.0.0.1"
+        request.client = request.env.remote_addr
+        request.is_local = True
+        response = Response()
+        session = Session()
+        session.connect(request, response)
+        current.request = request
+        current.response = response
+        current.session = session
+
+        from gluon.fileutils import listdir
+
+        self.apps_root = os.path.abspath(os.path.dirname(request.folder))
+        self.env = locals()
+        filename = os.path.join(request.folder, "controllers", "webservices.py")
+        restricted(compile2(_read_source(filename), filename), self.env,
+                   layer=filename)
+
+    def test_read_file_rejects_escape(self):
+        read_file = self.env["read_file"]
+        with self.assertRaises(HTTP):
+            read_file("../../../../../../etc/passwd", b64=True)
+        with self.assertRaises(HTTP):
+            read_file("/etc/hosts", b64=True)
+
+    def test_read_file_allows_in_tree(self):
+        read_file = self.env["read_file"]
+        data = base64.b64decode(read_file("admin/controllers/webservices.py",
+                                          b64=True))
+        self.assertIn(b"jsonrpc", data)
+
+    def test_list_files_rejects_escape(self):
+        list_files = self.env["list_files"]
+        with self.assertRaises(HTTP):
+            list_files("../..")
+
+    def test_write_file_rejects_escape(self):
+        write_file = self.env["write_file"]
+        escaped = os.path.join(self.apps_root, os.pardir, "_ws_escape_test.tmp")
+        escaped = os.path.abspath(escaped)
+        try:
+            with self.assertRaises(HTTP):
+                write_file("../_ws_escape_test.tmp",
+                           base64.b64encode(b"owned").decode(), b64=True)
+            self.assertFalse(os.path.exists(escaped))
+        finally:
+            if os.path.exists(escaped):
+                os.unlink(escaped)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gluon/tests/test_webservices.py
+++ b/gluon/tests/test_webservices.py
@@ -73,6 +73,5 @@ class TestWebservicesPathContainment(unittest.TestCase):
             if os.path.exists(escaped):
                 os.unlink(escaped)
 
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The admin webservices JSON-RPC endpoints read_file, write_file, hash_file and list_files pass the caller-supplied filename straight into apath(), which rejects neither an absolute path nor a run of ../ segments, so read_file("/etc/passwd") or write_file("../../../../root/.ssh/authorized_keys", ...) escapes the applications tree to read or overwrite arbitrary files on the host. default.py already confines the same admin to the applications and deposit roots through safe_open(), so these four endpoints are just the ones that never got that guard. This adds a _safe_apath() helper that resolves the path and refuses anything outside those roots, routes the four sites through it, and covers the escape and in-tree cases with tests in gluon/tests/test_webservices.py.