### PR TITLE
feat(csp): report-only mode, and turn CSP on in the admin app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,13 @@ Breaking change:
   `auth.settings.host` or an allowlist in `auth.settings.host_names`;
   otherwise an `HTTP 500` is raised.
 
-CSP is now used by the software that ships with web2py. `enable_csp()` accepts
-`report_only=True`, which sends `Content-Security-Policy-Report-Only` so a browser
-reports violations without blocking them, and the bundled `admin` application turns
-that on for every request. Nonces are emitted in report-only mode too, so the reports
-describe what enforcement would do. admin's remaining inline `on*=` handlers and
-`style=` attributes are what stop it enforcing today.
+The bundled `admin` application now uses CSP in report-only mode.
+`enable_csp()` accepts `report_only=True`, which sends
+`Content-Security-Policy-Report-Only` so a browser reports violations without
+blocking them. Other applications must opt in explicitly. Nonces are emitted
+in report-only mode too, so the reports describe what enforcement would do.
+admin's remaining inline `on*=` handlers and `style=` attributes are what stop
+it enforcing today.
 
 Other security fixes in this range:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ Breaking change:
   `auth.settings.host` or an allowlist in `auth.settings.host_names`;
   otherwise an `HTTP 500` is raised.
 
+CSP is now used by the software that ships with web2py. `enable_csp()` accepts
+`report_only=True`, which sends `Content-Security-Policy-Report-Only` so a browser
+reports violations without blocking them, and the bundled `admin` application turns
+that on for every request. Nonces are emitted in report-only mode too, so the reports
+describe what enforcement would do. admin's remaining inline `on*=` handlers and
+`style=` attributes are what stop it enforcing today.
+
 Other security fixes in this range:
 
 - Hardened ticket deserialization with the restricted unpickler

--- a/applications/admin/models/access.py
+++ b/applications/admin/models/access.py
@@ -191,3 +191,32 @@ elif session.authorized and \
 if request.controller == 'appadmin' and DEMO_MODE:
     session.flash = 'Appadmin disabled in demo mode'
     redirect(URL('default', 'sites'))
+
+
+# ###########################################################
+# ## Content-Security-Policy
+# ##
+# ## Report-only, deliberately. admin's views still use inline
+# ## event handler attributes (onclick=, onchange=, ...) and
+# ## inline style= attributes. A nonce covers neither, so
+# ## enforcing today would stop those handlers firing.
+# ## Report-only changes nothing for the user and makes the
+# ## browser list exactly what is left to convert.
+# ##
+# ## Nonces are emitted either way: response.files and the
+# ## SCRIPT()/STYLE() helpers read _csp_enabled, so the reports
+# ## describe what enforcement would really do. Once the inline
+# ## handlers and style attributes are gone, drop report_only.
+# ##
+# ## img-src allows data: because the bundled CodeMirror theme
+# ## (static/css/web2py-codemirror.css) loads data:image/png
+# ## sprites. Two off-origin images are expected to show up in
+# ## the reports and are left to be dealt with separately:
+# ## views/default/plugins.html:10 (web2pyslices.com thumbnails)
+# ## and views/wizard/step.html:88 (placehold.it fallback).
+# ###########################################################
+
+response.enable_csp(
+    report_only=True,
+    img_src=["'self'", "data:"],
+)

--- a/applications/admin/views/appadmin.html
+++ b/applications/admin/views/appadmin.html
@@ -1,5 +1,5 @@
 {{extend 'layout.html'}}
-<script><!--
+<script nonce="{{=response.nonce}}"><!--
     jQuery(document).ready(function(){
     jQuery("table.sortable tbody tr").mouseover( function() {
     jQuery(this).addClass("highlight"); }).mouseout( function() {
@@ -246,7 +246,7 @@
   {{else:}}    
     <div id="vis"></div>
       <link rel="stylesheet" href="{{=URL('admin','static','css/d3_graph.css')}}"/>
-      <script>
+      <script nonce="{{=response.nonce}}">
         // Define the d3 input data
         {{from gluon.serializers import json }}
         var nodes = {{=XML(json(nodes))}};

--- a/applications/admin/views/debug/breakpoints.html
+++ b/applications/admin/views/debug/breakpoints.html
@@ -119,7 +119,7 @@ frm_trs = form.elements('tr')
     </div>
 </div>
   
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{=response.nonce}}">
     jQuery(document).ready(function() {
         jQuery('.sourcecode').hide();
         jQuery("#trck_breakpoints thead tr th:first input[type=checkbox]").click(function() {

--- a/applications/admin/views/debug/index.html
+++ b/applications/admin/views/debug/index.html
@@ -85,7 +85,7 @@
   </ul>
 </div>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{=response.nonce}}">
 var bShellScrolling=0
 jQuery(document).ready(function(){
   jQuery('#statement').focus();

--- a/applications/admin/views/debug/interact.html
+++ b/applications/admin/views/debug/interact.html
@@ -113,7 +113,7 @@
 
     <script src="{{=URL('static', 'js/autoscroll.js')}}"></script>
 
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{=response.nonce}}">
     var bShellScrolling=0
     jQuery(document).ready(function(){
       // jQuery('#statement').focus();  // not usefull most times... 

--- a/applications/admin/views/default.mobile/edit.html
+++ b/applications/admin/views/default.mobile/edit.html
@@ -1,5 +1,5 @@
 {{extend 'default.mobile/layout.html'}}
-<script>
+<script nonce="{{=response.nonce}}">
 var current_theme = "{{=editor_settings['theme']}}";  //Default theme
 var current_editor = "{{=editor_settings['editor']}}";  //Default editor
 {{if editor_settings['closetag'] == 'true':}}

--- a/applications/admin/views/default.mobile/edit_language.html
+++ b/applications/admin/views/default.mobile/edit_language.html
@@ -1,5 +1,5 @@
 {{extend 'default.mobile/layout.html'}}
-<script>
+<script nonce="{{=response.nonce}}">
 function delkey(id) {
   jQuery('#'+id).hide();
   jQuery('#'+id+' INPUT').val(String.fromCharCode(127));

--- a/applications/admin/views/default.mobile/errors.html
+++ b/applications/admin/views/default.mobile/errors.html
@@ -3,7 +3,7 @@
 
 {{block sectionclass}}errors{{end}}
 
-<style>
+<style nonce="{{=response.nonce}}">
 table.sortable {
   border-spacing:0px;
 }
@@ -24,7 +24,7 @@ a.unavailable {
 }
 </style>
 
-<script language="JavaScript">
+<script language="JavaScript" nonce="{{=response.nonce}}">
   function check(){
     for (var i = 0; i < document.myform.elements.length; i++) {
         var e = document.myform.elements[i];

--- a/applications/admin/views/default.mobile/layout.html
+++ b/applications/admin/views/default.mobile/layout.html
@@ -38,7 +38,7 @@
 
     {{include 'web2py_ajax.html'}}
 
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{=response.nonce}}">
     //run this script after jQuery loads, but before jQuery Mobile loads
 
 //customize jQuery Mobile to let IE7+ in (Mobile IE)
@@ -63,7 +63,7 @@ $(document).bind("mobileinit", function(){
 
     <script src="{{=URL('static','plugin_jqmobile/jquery.mobile-1.3.1.min.js')}}"></script>
 
-    <style>
+    <style nonce="{{=response.nonce}}">
       .error { color: red; }
     </style>
   </head>
@@ -111,7 +111,7 @@ $(document).bind("mobileinit", function(){
 
     <!--[if lt IE 7 ]>
     <script src="{{=URL('static','plugin_jqmobile/dd_belatedpng.js')}}"></script>
-    <script> DD_belatedPNG.fix('img, .png_bg'); //fix any <img> or .png_bg background-images </script>
+    <script nonce="{{=response.nonce}}"> DD_belatedPNG.fix('img, .png_bg'); //fix any <img> or .png_bg background-images </script>
     <![endif]-->
 
   </body>

--- a/applications/admin/views/default.mobile/resolve.html
+++ b/applications/admin/views/default.mobile/resolve.html
@@ -4,7 +4,7 @@
 
 <h2>{{=T('Resolve Conflict file')}} "{{=filename}}"</h2>
 
-<script>
+<script nonce="{{=response.nonce}}">
 function plus() {jQuery('.plus').show(); jQuery('.minus').hide(); }
 function minus() {jQuery('.plus').hide(); jQuery('.minus').show(); }
 function all() {jQuery('.plus').show(); jQuery('.minus').show(); }

--- a/applications/admin/views/default.mobile/test.html
+++ b/applications/admin/views/default.mobile/test.html
@@ -9,7 +9,7 @@
   <h3>Testing controller "{{=controller}}"... <blink>please wait!</blink></h3>
 </div>
 
-<script><!--
+<script nonce="{{=response.nonce}}"><!--
 ajax('{{=URL(a=app,c=controller[:-3],f='_TEST')}}',[],'output_{{=controller[:-3]}}');
 //--></script>
 {{pass}}

--- a/applications/admin/views/default.mobile/ticket.html
+++ b/applications/admin/views/default.mobile/ticket.html
@@ -121,7 +121,7 @@
 {{except Exception as e:}}
     <!-- this should not happen, just in case... (cannot output normal hmtl as we don't know current open tags) -->
     {{import traceback;tb=traceback.format_exc().replace("\n","\\n") }}
-    <script language='javascript'>alert("Exception during snapshot rendering: {{=tb}} ");</script>
+    <script language='javascript' nonce="{{=response.nonce}}">alert("Exception during snapshot rendering: {{=tb}} ");</script>
 {{pass}}
 {{pass}}
 

--- a/applications/admin/views/default.mobile/ticket.load
+++ b/applications/admin/views/default.mobile/ticket.load
@@ -120,7 +120,7 @@
 {{except Exception as e:}}
     <!-- this should not happen, just in case... (cannot output normal hmtl as we don't know current open tags) -->
     {{import traceback;tb=traceback.format_exc().replace("\n","\\n") }}
-    <script language='javascript'>alert("Exception during snapshot rendering: {{=tb}} ");</script>
+    <script language='javascript' nonce="{{=response.nonce}}">alert("Exception during snapshot rendering: {{=tb}} ");</script>
 {{pass}}    
 {{pass}}
 

--- a/applications/admin/views/default.mobile/user.html
+++ b/applications/admin/views/default.mobile/user.html
@@ -12,7 +12,7 @@
 {{pass}}
 </div>
 
-<script language="javascript">
+<script language="javascript" nonce="{{=response.nonce}}">
 <!--
  jQuery("#web2py_user_form input:visible:enabled:first").focus();
 //-->

--- a/applications/admin/views/default/about.html
+++ b/applications/admin/views/default/about.html
@@ -18,7 +18,7 @@
 	</div>
 	<div class="span2"> </div>
 </div>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{=response.nonce}}">
 jQuery(document).ready(function() {
 	jQuery.plot(jQuery("#placeholder"), [ {{=progress}} ]);
 })

--- a/applications/admin/views/default/change_password.html
+++ b/applications/admin/views/default/change_password.html
@@ -14,7 +14,7 @@
 	<div class="controls"><button type="submit" class="btn">{{=T('Submit')}}</button></div>
 {{=form.custom.end}}
 </div>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{=response.nonce}}">
 	jQuery(document).ready(function() {
 		jQuery(":input:visible:enabled:first").focus();
 	});

--- a/applications/admin/views/default/design.html
+++ b/applications/admin/views/default/design.html
@@ -467,7 +467,7 @@ for c in controllers: controller_functions+=[c[:-3]+'/%s.html'%x for x in functi
       </div>
 </div>
 
-<script>
+<script nonce="{{=response.nonce}}">
 function filter_files() {
       if(jQuery('#search').val()){
         jQuery.getJSON('{{=URL('search',args=request.args)}}?keywords='+escape(jQuery('#search').val()),null,function(data, textStatus, xhr){

--- a/applications/admin/views/default/edit.html
+++ b/applications/admin/views/default/edit.html
@@ -81,7 +81,7 @@ def file_create_form(location, anchor=None, helptext=""):
 <script src="{{=js_url}}/ajax_editor.js"></script>
 <link rel="stylesheet" href="{{=css_url}}/typeahead.js-bootstrap.css">
 <link rel="stylesheet" href="{{=css_url}}/web2py-codemirror.css">
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{=response.nonce}}">
 var current_font_incr = 0; // Default font-size, 0 means isn't set
 $(document).on('shown click', 'a[data-toggle="tab"]', function (e, lineno) {
     var tab_id = $(this).attr('href');
@@ -239,7 +239,7 @@ $(document).on('click', 'a.font_button', function (e) {
         	  {{=file_create_form('%s/' % app, '')}}
         	</div>          			  			
       	      </div>
-      	      <script>jQuery('#form').slideToggle()</script>
+      	      <script nonce="{{=response.nonce}}">jQuery('#form').slideToggle()</script>
     	    </div>
     	    <br />            
             <div id="files_menu">
@@ -278,7 +278,7 @@ $(document).on('click', 'a.font_button', function (e) {
 </div>
 </div>
 
-<script>
+<script nonce="{{=response.nonce}}">
     $(document).on('click', '#window_todo li a', function (e) {
         $(this).find('i').toggleClass('icon-chevron-right');
         $(this).find('i').toggleClass('icon-chevron-down');
@@ -294,7 +294,7 @@ $(document).on('click', 'a.font_button', function (e) {
     });
 </script>
 {{end}}
-<script>
+<script nonce="{{=response.nonce}}">
 $(document).ready(function() {
     var filesMenu = $('#files');
     var ow = filesMenu.outerWidth();
@@ -310,7 +310,7 @@ $(document).ready(function() {
 <!-- Typeahead scripts here so the page load faster -->
 <script src="{{=URL('static', 'js/typeahead.min.js')}}"></script>
 <script src="{{=URL('static', 'js/hogan-2.0.0.js')}}"></script>
-<script>
+<script nonce="{{=response.nonce}}">
     $('.typeahead-tw').typeahead({
         name: 'files',
         local:{{from gluon.serializers import json}}{{=XML(json(auto_complete_list))}},

--- a/applications/admin/views/default/edit_js.html
+++ b/applications/admin/views/default/edit_js.html
@@ -41,7 +41,7 @@
 </div>
 
     <textarea style=" height:100%; direction:ltr;" id="textarea_{{=id}}" class="input-block-level" name="data" >{{=data}}</textarea>
-    <script>
+    <script nonce="{{=response.nonce}}">
     var editor = CodeMirror.fromTextArea(document.getElementById("textarea_{{=id}}"),{
     {{if filetype=='html':}}
         mode : "text/html",

--- a/applications/admin/views/default/edit_language.html
+++ b/applications/admin/views/default/edit_language.html
@@ -1,5 +1,5 @@
 {{extend 'layout.html'}}
-<script>
+<script nonce="{{=response.nonce}}">
 function delkey(id) {
   jQuery('#'+id).hide();
   jQuery('#'+id+' INPUT').val(String.fromCharCode(127));

--- a/applications/admin/views/default/edit_plurals.html
+++ b/applications/admin/views/default/edit_plurals.html
@@ -1,5 +1,5 @@
 {{extend 'layout.html'}}
-<script>
+<script nonce="{{=response.nonce}}">
 function delkey(id) {
   jQuery('#'+id).hide();
   jQuery('#'+id+' INPUT').val(String.fromCharCode(127));

--- a/applications/admin/views/default/editor_settings.html
+++ b/applications/admin/views/default/editor_settings.html
@@ -45,7 +45,7 @@
 		<div class="controls"><button type="submit" class="disabled btn btn-primary">{{=T('Save')}}</button></div>
 	</div>
 </form>
-<script>
+<script nonce="{{=response.nonce}}">
 $.web2py.trap_form("{{=URL('default', 'edit', args=request.args, vars={'settings':True})}}", "editor_settings");
 $("#editor_settings_form").on('change', 'select, input', function (e) {
 	$("#editor_settings_form button[type=submit]").removeClass('disabled');

--- a/applications/admin/views/default/errors.html
+++ b/applications/admin/views/default/errors.html
@@ -110,7 +110,7 @@ pass}}
         {{ pass }}
     </form><!-- /errorform -->
 </div>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{=response.nonce}}">
     jQuery(document).ready(function() {
         jQuery('.traceback').hide();
         jQuery("#trck_errors thead tr th:first input[type=checkbox]").click(function() {

--- a/applications/admin/views/default/index.html
+++ b/applications/admin/views/default/index.html
@@ -15,7 +15,7 @@
 <p class="help span7 alert alert-block alert-warning">{{=T('ATTENTION: Login requires a secure (HTTPS) connection or running on localhost.')}}</p>
 {{pass}}
 </div>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{=response.nonce}}">
 	jQuery(document).ready(function(){
 		jQuery("#password").focus();
 	});

--- a/applications/admin/views/default/pack_custom.html
+++ b/applications/admin/views/default/pack_custom.html
@@ -30,4 +30,4 @@
 {{tree(base)}}
 </div>
 </form>
-<script>jQuery(function(){jQuery('.collapsible').hide();});</script>
+<script nonce="{{=response.nonce}}">jQuery(function(){jQuery('.collapsible').hide();});</script>

--- a/applications/admin/views/default/resolve.html
+++ b/applications/admin/views/default/resolve.html
@@ -2,7 +2,7 @@
 {{block sectionclass}}resolve{{end}}
 <!-- begin "resolve" block -->
 <h2>{{=T('Resolve Conflict file')}} "{{=filename}}"</h2>
-<script>
+<script nonce="{{=response.nonce}}">
 function plus() {jQuery('.plus').show(); jQuery('.minus').hide(); }
 function minus() {jQuery('.plus').hide(); jQuery('.minus').show(); }
 function all() {jQuery('.plus').show(); jQuery('.minus').show(); }

--- a/applications/admin/views/default/site.html
+++ b/applications/admin/views/default/site.html
@@ -86,7 +86,7 @@
     <p id="check_version" class="row-buttons">
       {{if session.check_version:}}
         {{=T('Checking for upgrades...')}}
-        <script>ajax('{{=URL('check_version')}}',[],'check_version');</script>
+        <script nonce="{{=response.nonce}}">ajax('{{=URL('check_version')}}',[],'check_version');</script>
         {{session.check_version=False}}
       {{else:}}
         {{=button("javascript:ajax('"+URL('check_version')+"',[],'check_version')", T('Check for upgrades'))}}

--- a/applications/admin/views/default/test.html
+++ b/applications/admin/views/default/test.html
@@ -9,7 +9,7 @@
   <h3>Testing controller "{{=controller}}"... <blink>please wait!</blink></h3>
 </div>
 
-<script><!--
+<script nonce="{{=response.nonce}}"><!--
 ajax('{{=URL(a=app,c=controller[:-3],f='_TEST')}}',[],'output_{{=controller[:-3]}}');
 //--></script>
 {{pass}}

--- a/applications/admin/views/default/ticket.html
+++ b/applications/admin/views/default/ticket.html
@@ -125,7 +125,7 @@
 {{except Exception as e:}}
 <!-- this should not happen, just in case... (cannot output normal hmtl as we don't know current open tags) -->
 {{import traceback;tb=traceback.format_exc().replace("\n","\\n") }}
-<script language='javascript'>alert("Exception during snapshot rendering: {{=tb}} ");</script>
+<script language='javascript' nonce="{{=response.nonce}}">alert("Exception during snapshot rendering: {{=tb}} ");</script>
 {{pass}}
 {{pass}}
 

--- a/applications/admin/views/default/ticket.load
+++ b/applications/admin/views/default/ticket.load
@@ -120,7 +120,7 @@
 {{except Exception as e:}}
     <!-- this should not happen, just in case... (cannot output normal hmtl as we don't know current open tags) -->
     {{import traceback;tb=traceback.format_exc().replace("\n","\\n") }}
-    <script language='javascript'>alert("Exception during snapshot rendering: {{=tb}} ");</script>
+    <script language='javascript' nonce="{{=response.nonce}}">alert("Exception during snapshot rendering: {{=tb}} ");</script>
 {{pass}}    
 {{pass}}
 

--- a/applications/admin/views/default/user.html
+++ b/applications/admin/views/default/user.html
@@ -59,7 +59,7 @@ pass
 {{=form}}
 {{pass}}
 </div>
-<script language="javascript">
+<script language="javascript" nonce="{{=response.nonce}}">
 //<!--
  jQuery("#web2py_user_form input:visible:enabled:first").focus();
 //-->

--- a/applications/admin/views/gae/deploy.html
+++ b/applications/admin/views/gae/deploy.html
@@ -1,8 +1,8 @@
 {{extend 'layout.html'}}
-<script>$=jQuery</script>
+<script nonce="{{=response.nonce}}">$=jQuery</script>
 <link rel="stylesheet" type="text/css" href="{{=URL(r=request,c='static',f='css/jqueryMultiSelect.css')}}" />
 <script src="{{=URL(r=request,c='static',f='js/jqueryMultiSelect.js')}}"></script>
-<script>
+<script nonce="{{=response.nonce}}">
 function callback() {
   $.get('{{=URL(r=request,f='callback')}}','',function(data,status){ if(data!='<done/>') { $('#target').html($('#target').html()+data); callback(); } });
 }

--- a/applications/admin/views/layout.html
+++ b/applications/admin/views/layout.html
@@ -74,13 +74,13 @@
         <!-- BS JAVASCRIPT
         ====================== -->
         <script src="{{=URL('static','js/bootstrap.min.js')}}"></script>
-        <script type="text/javascript">
+        <script type="text/javascript" nonce="{{=response.nonce}}">
             jQuery(document).ready(function(){
                 jQuery("[rel=tooltip]").tooltip();
                 jQuery(":input").attr("autocomplete","off");
             });
         </script>
-        <script>
+        <script nonce="{{=response.nonce}}">
             // ====================
             // upload input mask
             // ====================

--- a/applications/admin/views/openshift/deploy.html
+++ b/applications/admin/views/openshift/deploy.html
@@ -1,8 +1,8 @@
 {{extend 'layout.html'}}
-<script>$=jQuery</script>
+<script nonce="{{=response.nonce}}">$=jQuery</script>
 <link rel="stylesheet" type="text/css" href="{{=URL(r=request,c='static',f='css/jqueryMultiSelect.css')}}" />
 <script src="{{=URL(r=request,c='static',f='js/jqueryMultiSelect.js')}}"></script>
-<script>
+<script nonce="{{=response.nonce}}">
 function callback() {
   $.get('{{=URL(r=request,f='callback')}}','',function(data,status){ if(data!='<done/>') { $('#target').html($('#target').html()+data); callback(); } });
 }

--- a/applications/admin/views/plugin_jqmobile/about.html
+++ b/applications/admin/views/plugin_jqmobile/about.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>jQuery Mobile Plugin for web2py</title>
-    <style>
+    <style nonce="{{=response.nonce}}">
       * {
       border: 0; margin:0; padding: 0;
       font-family: helvetica;

--- a/applications/admin/views/plugin_jqmobile/layout.html
+++ b/applications/admin/views/plugin_jqmobile/layout.html
@@ -38,7 +38,7 @@
 
     {{include 'web2py_ajax.html'}}
 
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{=response.nonce}}">
     //run this script after jQuery loads, but before jQuery Mobile loads
 
 //customize jQuery Mobile to let IE7+ in (Mobile IE)
@@ -63,7 +63,7 @@ $(document).bind("mobileinit", function(){
 
     <script src="{{=URL('static','plugin_jqmobile/jquery.mobile-1.3.1.min.js')}}"></script>
 
-    <style>
+    <style nonce="{{=response.nonce}}">
       .error { color: red; }
     </style>
   </head>
@@ -111,7 +111,7 @@ $(document).bind("mobileinit", function(){
 
     <!--[if lt IE 7 ]>
     <script src="{{=URL('static','plugin_jqmobile/dd_belatedpng.js')}}"></script>
-    <script> DD_belatedPNG.fix('img, .png_bg'); //fix any <img> or .png_bg background-images </script>
+    <script nonce="{{=response.nonce}}"> DD_belatedPNG.fix('img, .png_bg'); //fix any <img> or .png_bg background-images </script>
     <![endif]-->
 
   </body>

--- a/applications/admin/views/pythonanywhere/deploy.html
+++ b/applications/admin/views/pythonanywhere/deploy.html
@@ -79,7 +79,7 @@
     </div>
 </div>
 
-<script>
+<script nonce="{{=response.nonce}}">
 
 $(document).ready(function() {
 

--- a/applications/admin/views/web2py_ajax.html
+++ b/applications/admin/views/web2py_ajax.html
@@ -1,4 +1,4 @@
-<script type="text/javascript"><!--
+<script type="text/javascript" nonce="{{=response.nonce}}"><!--
     // These variables are used by the web2py_ajax_init function in web2py_ajax.js (which is loaded below).
     {{=ASSIGNJS(
     w2p_ajax_confirm_message = T('Are you sure you want to delete this object?'),

--- a/applications/admin/views/wizard/step.html
+++ b/applications/admin/views/wizard/step.html
@@ -78,7 +78,7 @@
 				<div class="controls"><button type="submit" class="btn">{{=T('Submit')}}</button></div>
 			{{=form.custom.end}}
 		</div>
-		<script>
+		<script nonce="{{=response.nonce}}">
 			jQuery(function(){
 				var t=jQuery('#no_table_layout_theme');
 				t.change(function(){
@@ -175,7 +175,7 @@
 		</div>
 	</div> <!-- /wizard form -->
 </div>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{=response.nonce}}">
 	//jQuery(document).ready(function() {
 		//jQuery(":input:visible:enabled:first").focus();
 	//});

--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -669,9 +669,21 @@ class Response(Storage):
             self["nonce"] = web2py_uuid()
         return self["nonce"]
 
-    def enable_csp(self, **policies):
+    def enable_csp(self, report_only=False, **policies):
+        """Emit a per-request nonce-based Content-Security-Policy header.
+
+        With report_only=True the policy goes out as
+        Content-Security-Policy-Report-Only, so violations are reported by the
+        browser without being blocked. Nonces are still emitted, otherwise the
+        report would not describe what enforcement is going to do.
+        """
         self._csp_enabled = True
-        existing = self.headers.get("Content-Security-Policy")
+        header = (
+            "Content-Security-Policy-Report-Only"
+            if report_only
+            else "Content-Security-Policy"
+        )
+        existing = self.headers.get(header)
         p = {}
         if existing:
             for policy in _split_serialized_csp_list(existing):
@@ -701,7 +713,7 @@ class Response(Storage):
         for k, v in policies.items():
             merge(k.replace("_", "-"), v)
 
-        self.headers["Content-Security-Policy"] = "; ".join(
+        self.headers[header] = "; ".join(
             "%s %s" % (k, " ".join(v)) for k, v in p.items()
         )
 

--- a/gluon/tests/test_globals.py
+++ b/gluon/tests/test_globals.py
@@ -16,8 +16,8 @@ from io import BytesIO
 
 from pydal import DAL
 
-from gluon.html import XML, URL
-from gluon.globals import Request, Response, Session
+from gluon.html import XML, URL, SCRIPT
+from gluon.globals import current, Request, Response, Session
 from gluon.settings import global_settings
 from gluon.http import HTTP
 from gluon.rewrite import regex_url_in
@@ -381,6 +381,44 @@ class testResponse(unittest.TestCase):
         self.assertIn("report-to csp-endpoint", csp)
         self.assertIn("sandbox allow-scripts allow-same-origin", csp)
         self.assertIn("upgrade-insecure-requests", csp)
+
+    def test_enable_csp_report_only_uses_the_report_only_header(self):
+        response = Response()
+        response.enable_csp(report_only=True)
+        self.assertIn("Content-Security-Policy-Report-Only", response.headers)
+        self.assertNotIn("Content-Security-Policy", response.headers)
+        csp = response.headers["Content-Security-Policy-Report-Only"]
+        self.assertIn("default-src 'self'", csp)
+        self.assertIn("'nonce-%s'" % response.nonce, csp)
+
+    def test_enable_csp_report_only_still_emits_nonces(self):
+        # report-only is only useful if the page renders the same nonces it
+        # would render under enforcement, otherwise the report describes a
+        # policy nobody intends to ship.
+        response = Response()
+        current.response = response
+        response.enable_csp(report_only=True)
+        rendered = SCRIPT("var x = 1;").xml()
+        self.assertIn('nonce="%s"' % response.nonce, rendered)
+        self.assertIn(
+            "'nonce-%s'" % response.nonce,
+            response.headers["Content-Security-Policy-Report-Only"],
+        )
+
+    def test_enable_csp_report_only_reads_its_own_existing_header(self):
+        response = Response()
+        response.headers["Content-Security-Policy-Report-Only"] = "img-src 'self'"
+        response.enable_csp(report_only=True)
+        csp = response.headers["Content-Security-Policy-Report-Only"]
+        self.assertIn("img-src 'self'", csp)
+        self.assertIn("script-src", csp)
+        self.assertNotIn("Content-Security-Policy", response.headers)
+
+    def test_enable_csp_enforcing_is_unchanged_by_default(self):
+        response = Response()
+        response.enable_csp()
+        self.assertIn("Content-Security-Policy", response.headers)
+        self.assertNotIn("Content-Security-Policy-Report-Only", response.headers)
 
     def test_enable_csp_accepts_existing_policy_lists(self):
         response = Response()


### PR DESCRIPTION
web2py has shipped nonce-based CSP since #2576 and nothing in the tree uses it. `response.enable_csp()` has no call site outside `gluon/` and its test suite, so the `admin` application, which has filesystem, database and source-execution access, serves no `Content-Security-Policy` header at all.

Enforcing one today would break admin. A nonce covers an inline `<script>` block but can't cover an inline event handler attribute, and admin's views carry 77 such handlers across 19 files, with inline `style=` in 15 more. Turning enforcement on would silently stop those handlers firing.

So this adds the step that comes first in a real CSP rollout.

### `report_only=True`

`enable_csp(report_only=True)` sends `Content-Security-Policy-Report-Only`, which asks the browser to report violations and block nothing. The header name is the only difference. The policy is built identically, and `_csp_enabled` is still set, so `response.files` and the `SCRIPT()` / `STYLE()` helpers keep emitting nonces.

That last part is the point. A report generated without nonces would describe a policy nobody intends to ship, and every nonced tag would show up as a violation you were never going to have.

### admin turns it on

From `models/access.py`, next to the existing HTTPS-or-localhost gate, and the hand-written inline `<script>` / `<style>` blocks in admin's views now carry `nonce="{{=response.nonce}}"`. `<script src=...>` tags are left alone since `script-src 'self'` already covers them.

`img-src` allows `data:` because the bundled CodeMirror theme loads `data:image/png` sprites. Two off-origin images are left deliberately and will appear in reports: `views/default/plugins.html:10` (web2pyslices.com thumbnails) and `views/wizard/step.html:88` (a placehold.it fallback).

After this the only violations admin can report are the inline handlers and style attributes, which is a clean boundary for the follow-up that converts them and drops `report_only`.

### Verified on a running server, not only in tests

```
$ curl -si http://127.0.0.1:8123/admin/default/index | grep -i content-security
Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self'
  'nonce-cb806697-78bb-4bc1-ae6d-1b614fd6f5cb'; style-src 'self'
  'nonce-cb806697-78bb-4bc1-ae6d-1b614fd6f5cb'; img-src 'self' data:
```

The nonce in that header is the same value carried by every inline `<script>` in the body, and the body contains exactly one distinct nonce. `/welcome/` sends no CSP header, so the change is scoped to admin. No enforcing `Content-Security-Policy` header is sent anywhere. All 74 admin templates parse, and the page renders with no ticket.

The nonce pass initially rewrote a `<script>` inside a JavaScript string literal at `views/default/edit.html:160`, where `$("<script>")` builds an element to load a keymap. That's reverted, and it needs no nonce anyway since the script it loads is same-origin and covered by `'self'`.

### Tests

Four in `gluon/tests/test_globals.py`: the report-only header is used, nonces are still emitted under report-only, an existing report-only header is read back rather than duplicated, and enforcing mode is unchanged by default.

The nonce test asserts on rendered `SCRIPT(...).xml()` output rather than on the private `_csp_enabled` flag, and it's mutation-checked: changing `self._csp_enabled = True` to `not report_only` fails that test and only that test.

`test_globals.py` 42/42, `test_html.py` 80/80, `test_tools.py` 110/110, `test_appadmin.py` 36/36.
