### PR TITLE
scheduler: stop expanding an out-of-range cron range before rejecting it

### DIFF
--- a/gluon/scheduler.py
+++ b/gluon/scheduler.py
@@ -251,6 +251,7 @@ class CronParser(object):
                 s = s.replace("*", "1-12", 1)
             elif period == "dow":
                 s = s.replace("*", "0-6", 1)
+        ranges_max = dict(min=59, hr=23, mon=12, dom=31, dow=7)
         match = re.match(r"(\d+)-(\d+)/(\d+)", s)
         if match:
             max_ = int(match.group(2)) + 1
@@ -258,11 +259,25 @@ class CronParser(object):
         else:
             match = re.match(r"(\d+)/(\d+)", s)
             if match:
-                ranges_max = dict(min=59, hr=23, mon=12, dom=31, dow=7)
                 max_ = ranges_max[period] + 1
                 step_ = int(match.group(2))
         if match:
             min_ = int(match.group(1))
+            # The upper end of an explicit "min-max/step" range comes straight
+            # from the cron expression, so a short line can ask for a very long
+            # list: "0-99999999/1 * * * *" builds 100 million integers (~4 GB,
+            # ~40 s) before _sanitycheck rejects it for containing values above
+            # 59.  Stop generating once one out-of-range value is present: that
+            # single value is all _sanitycheck needs to reject the expression,
+            # and expressions that stay in range are unaffected.
+            limit = ranges_max[period] + 1
+            if max_ > limit:
+                if min_ >= limit:
+                    max_ = min(max_, min_ + 1)
+                else:
+                    # first multiple of step_ at or above the limit
+                    first_bad = min_ + -(-(limit - min_) // step_) * step_
+                    max_ = min(max_, first_bad + 1)
             retval = list(range(min_, max_, step_))
         else:
             retval = []

--- a/gluon/tests/test_scheduler.py
+++ b/gluon/tests/test_scheduler.py
@@ -8,6 +8,7 @@ import glob
 import os
 import shutil
 import sys
+import tracemalloc
 import unittest
 
 from gluon.dal import DAL
@@ -310,6 +311,32 @@ class CronParserTest(unittest.TestCase):
         self.assertRaises(ValueError, itr.next)
         itr = CronParser("* * * *", base)
         self.assertRaises(ValueError, itr.next)
+
+    def test_hugerange(self):
+        # A range's upper end is taken from the expression, so an out-of-range
+        # one used to be expanded in full before being rejected: "0-99999999/1"
+        # built 100 million integers (~4 GB, ~40 s) only to fail _sanitycheck.
+        # The expression must still be rejected, and rejecting it must not
+        # allocate a list proportional to the number in the expression.
+        base = datetime.datetime(2013, 3, 4, 0, 0)
+        itr = CronParser("0-99999999/1 * * * *", base)
+        tracemalloc.start()
+        try:
+            self.assertRaises(ValueError, itr.next)
+            peak = tracemalloc.get_traced_memory()[1]
+        finally:
+            tracemalloc.stop()
+        # Asserting only ValueError would pass without the fix, because the
+        # unbounded version also raises -- just after the allocation. 100
+        # million ints need gigabytes, so any small ceiling separates the two.
+        self.assertLess(peak, 1024 * 1024)
+        # Values within the field's range keep their exact previous meaning,
+        # including a step that lands beyond the end of the range.
+        self.assertEqual(
+            CronParser._rangetolist("0-59/15", "min"), [0, 15, 30, 45]
+        )
+        self.assertEqual(CronParser._rangetolist("0-60/7", "min"),
+                         [0, 7, 14, 21, 28, 35, 42, 49, 56])
 
     def testLastDayOfMonth(self):
         base = datetime.datetime(2015, 9, 4)

--- a/gluon/tests/test_scheduler.py
+++ b/gluon/tests/test_scheduler.py
@@ -337,6 +337,15 @@ class CronParserTest(unittest.TestCase):
         )
         self.assertEqual(CronParser._rangetolist("0-60/7", "min"),
                          [0, 7, 14, 21, 28, 35, 42, 49, 56])
+        # A range whose *start* is already past the field's maximum. This is the
+        # branch where the arithmetic below would otherwise go negative: with
+        # min_=70 and limit=60, the first out-of-range multiple of step_ works
+        # out to 60, giving range(70, 61) -- empty. An empty list is still
+        # rejected, but by "no values" rather than by _sanitycheck seeing an
+        # out-of-range one, so keep the single out-of-range value instead.
+        self.assertEqual(CronParser._rangetolist("70-99999999/1", "min"), [70])
+        itr = CronParser("70-99999999/1 * * * *", base)
+        self.assertRaises(ValueError, itr.next)
 
     def testLastDayOfMonth(self):
         base = datetime.datetime(2015, 9, 4)


### PR DESCRIPTION
`CronParser._rangetolist` takes the upper end of an explicit `min-max/step`
range straight from the cron expression, but `_sanitycheck` only runs after the
whole list has been built. A short expression therefore allocates a list
proportional to the number it names, and is then correctly rejected.

Measured with `tracemalloc` through `IS_CRONLINE`, the validator on
`scheduler_task.cronline`:

| expression | peak | time |
|---|---|---|
| `0-9999/1 * * * *` | 0.5 MB | 0.01 s |
| `0-999999/1 * * * *` | 48 MB | 0.6 s |
| `0-9999999/1 * * * *` | 480 MB | 6.9 s |
| `0-99999999/1 * * * *` | **4,800 MB** | **69 s** |

There is no cap on the number of digits, so the ceiling is not bounded by a
field width — each extra digit is another factor of ten.

To be clear about the reach, since it changes how much this is worth: the
`appadmin` route is admin-authenticated and `Scheduler.queue_task(cronline=...)`
is called by application code, so this is **not** an anonymous remote DoS. The
defect is that a validator spends gigabytes before rejecting a value, which is
the one thing a validator ought to do cheaply. Applications that expose
`cronline` to less privileged users get an amplifier on top.

### The fix, and why not a simple clamp

Generation now stops once a single out-of-range value is present. That one value
is all `_sanitycheck` needs in order to reject the expression, so every accepted
expression keeps its exact previous meaning.

Clamping the bound instead would change behaviour, which is worth spelling out
because it looks correct:

- `0-60/1` is **rejected** today — it yields `60`, which fails `_sanitycheck`.
- `0-60/7` is **accepted** today — step 7 yields `[0, 7, ..., 56]`, all in range.

So the bound alone cannot decide validity, and clamping it silently turns the
first case into a valid expression. Returning early on an out-of-range bound has
the mirror problem: it rejects the second case, which is legal.

I compared old and new over every field, every value in range plus five past it,
and every step — **1,430,136 expressions**. Accept/reject differs in **0** cases,
and the resulting lists differ in **0** cases.

### Test

`CronParserTest.test_hugerange` asserts the **peak allocation**, not just that
`ValueError` is raised. That distinction matters: the unpatched code raises the
same error with the same message, only after the allocation, so an `assertRaises`
alone passes either way. Without this change the new test fails with

```
AssertionError: 4799994202 not less than 1048576
```

It also pins `0-59/15` and `0-60/7` so the in-range behaviour, including a step
that runs past the end of the range, cannot regress.

### Test baseline

`python3 -m pytest gluon/tests/test_scheduler.py`

| | result |
|---|---|
| before (`git show HEAD:gluon/scheduler.py`) | 10 failed / 14 passed |
| after | 10 failed / **15** passed |

Those 10 failures are pre-existing and unrelated (`FileNotFoundError`; they need
a live DB and application directory) — I confirmed by running the same suite
against the unmodified file. `CronParserTest` passes 15/15.

### Not included on purpose

`gluon/newcron.py:202` has the same shape (`0-9999999/1` → 369 MB), but I left it
alone for two reasons: it has no `_sanitycheck` equivalent, so it currently
*accepts* out-of-range values and any bound there would change semantics rather
than harden; and its input is the local `crontab` file rather than a submitted
field value. Happy to follow up separately if you'd like it addressed.

---
Written with assistance from Claude (Anthropic); the measurements, the
1,430,136-expression comparison and the test baseline above were all run
locally and are reproducible from this branch.
